### PR TITLE
Use a pipe for the signal_handler.

### DIFF
--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -738,7 +738,7 @@ static void init_configfile(void)
 
 	if (pipe(signal_wakeup_pipe)) {
 		g_warning("Failed to create signal wakeup pipe - SIGTERM not attached");
-		signal_wakeup_pipe[0] = 0;
+		signal_wakeup_pipe[0] = -1;
 		return;
 	}
 	if (set_nonblock_flag(signal_wakeup_pipe[0]) || set_nonblock_flag(signal_wakeup_pipe[1])) {
@@ -772,7 +772,7 @@ static void deinit_configfile(void)
 		g_io_channel_unref(signal_wakeup_read_channel);
 	}
 
-	if (signal_wakeup_pipe[0]) {
+	if (signal_wakeup_pipe[0] != -1) {
 		close(signal_wakeup_pipe[0]);
 		close(signal_wakeup_pipe[1]);
 	}


### PR DESCRIPTION
Makes irssi close cleanly at box shutdown or if pkill'ed.

I've been using this patch for years, I assume it's off
the ML but I can't find the post now.
