### PR TITLE
add print_text_after_time to specify time stamp for lines

### DIFF
--- a/docs/signals.txt
+++ b/docs/signals.txt
@@ -334,6 +334,9 @@ gui-readline.c:
 gui-printtext.c:
  "beep"
 
+textbuffer-view.c
+ "gui textbuffer line removed", TEXTBUFFER_VIEW_REC *view, LINE_REC *line, LINE_REC *prev_line
+
 Perl
 ----
 

--- a/src/fe-text/gui-printtext.c
+++ b/src/fe-text/gui-printtext.c
@@ -102,7 +102,7 @@ void gui_printtext(int xpos, int ypos, const char *str)
 	next_xpos = next_ypos = -1;
 }
 
-void gui_printtext_after(TEXT_DEST_REC *dest, LINE_REC *prev, const char *str)
+void gui_printtext_after_time(TEXT_DEST_REC *dest, LINE_REC *prev, const char *str, time_t time)
 {
 	GUI_WINDOW_REC *gui;
 
@@ -110,8 +110,14 @@ void gui_printtext_after(TEXT_DEST_REC *dest, LINE_REC *prev, const char *str)
 
 	gui->use_insert_after = TRUE;
 	gui->insert_after = prev;
+	gui->insert_after_time = time;
 	format_send_to_gui(dest, str);
 	gui->use_insert_after = FALSE;
+}
+
+void gui_printtext_after(TEXT_DEST_REC *dest, LINE_REC *prev, const char *str)
+{
+	gui_printtext_after_time(dest, prev, str, 0);
 }
 
 static void remove_old_lines(TEXT_BUFFER_VIEW_REC *view)
@@ -199,9 +205,10 @@ static void sig_gui_print_text(WINDOW_REC *window, void *fgcolor,
 	}
 
 	lineinfo.level = dest == NULL ? 0 : dest->level;
-        lineinfo.time = time(NULL);
-
         gui = WINDOW_GUI(window);
+        lineinfo.time = (gui->use_insert_after && gui->insert_after_time) ?
+		gui->insert_after_time : time(NULL);
+
 	view = gui->view;
 	insert_after = gui->use_insert_after ?
 		gui->insert_after : view->buffer->cur_line;

--- a/src/fe-text/gui-printtext.h
+++ b/src/fe-text/gui-printtext.h
@@ -18,5 +18,6 @@ INDENT_FUNC get_default_indent_func(void);
 
 void gui_printtext(int xpos, int ypos, const char *str);
 void gui_printtext_after(TEXT_DEST_REC *dest, LINE_REC *prev, const char *str);
+void gui_printtext_after_time(TEXT_DEST_REC *dest, LINE_REC *prev, const char *str, time_t time);
 
 #endif

--- a/src/fe-text/gui-windows.h
+++ b/src/fe-text/gui-windows.h
@@ -20,6 +20,7 @@ typedef struct {
 	unsigned int sticky:1;
 	unsigned int use_insert_after:1;
         LINE_REC *insert_after;
+	time_t insert_after_time;
 } GUI_WINDOW_REC;
 
 void gui_windows_init(void);

--- a/src/fe-text/textbuffer-view.c
+++ b/src/fe-text/textbuffer-view.c
@@ -1141,6 +1141,8 @@ void textbuffer_view_remove_line(TEXT_BUFFER_VIEW_REC *view, LINE_REC *line)
 	g_return_if_fail(view != NULL);
 	g_return_if_fail(line != NULL);
 
+	signal_emit("gui textbuffer line removed", 3, view, line, line->prev);
+
         linecount = view_get_linecount(view, line);
         update_counter = view->cache->update_counter+1;
 

--- a/src/perl/get-signals.pl
+++ b/src/perl/get-signals.pl
@@ -57,6 +57,10 @@ while (<STDIN>) {
 		WINDOW_REC    => 'Irssi::UI::Window',
 		WI_ITEM_REC   => 'iobject',
 
+		# fe-text
+		TEXTBUFFER_VIEW_REC => 'Irssi::TextUI::TextBufferView',
+		LINE_REC	    => 'Irssi::TextUI::Line',
+
 		# perl
 		PERL_SCRIPT_REC => 'Irssi::Script',
 	);

--- a/src/perl/textui/TextUI.xs
+++ b/src/perl/textui/TextUI.xs
@@ -139,11 +139,12 @@ CODE:
 MODULE = Irssi::TextUI PACKAGE = Irssi::UI::Window
 
 void
-print_after(window, prev, level, str)
+print_after(window, prev, level, str, time = 0)
 	Irssi::UI::Window window
 	Irssi::TextUI::Line prev
 	int level
 	char *str
+	time_t time
 PREINIT:
 	TEXT_DEST_REC dest;
 	char *text;
@@ -152,21 +153,22 @@ CODE:
 	format_create_dest(&dest, NULL, NULL, level, window);
 	text = format_string_expand(str, NULL);
 	text2 = g_strconcat(text, "\n", NULL);
-	gui_printtext_after(&dest, prev, text2);
+	gui_printtext_after_time(&dest, prev, text2, time);
 	g_free(text);
 	g_free(text2);
 
 void
-gui_printtext_after(window, prev, level, str)
+gui_printtext_after(window, prev, level, str, time = 0)
 	Irssi::UI::Window window
 	Irssi::TextUI::Line prev
 	int level
 	char *str
+	time_t time
 PREINIT:
 	TEXT_DEST_REC dest;
 CODE:
 	format_create_dest(&dest, NULL, NULL, level, window);
-	gui_printtext_after(&dest, prev, str);
+	gui_printtext_after_time(&dest, prev, str, time);
 
 Irssi::TextUI::Line
 last_line_insert(window)
@@ -179,17 +181,18 @@ OUTPUT:
 MODULE = Irssi::TextUI PACKAGE = Irssi::Server
 
 void
-gui_printtext_after(server, target, prev, level, str)
+gui_printtext_after(server, target, prev, level, str, time = 0)
 	Irssi::Server server
 	char *target
 	Irssi::TextUI::Line prev
 	int level
 	char *str
+	time_t time
 PREINIT:
 	TEXT_DEST_REC dest;
 CODE:
 	format_create_dest(&dest, server, target, level, NULL);
-	gui_printtext_after(&dest, prev, str);
+	gui_printtext_after_time(&dest, prev, str, time);
 
 BOOT:
 	irssi_boot(TextUI__Statusbar);


### PR DESCRIPTION
The proposed API change and amendment to Perl script API would allow
printing lines in the middle of the TextBuffer with an attached
time-stamp. This can be used in the hideshow or dim_nicks script to
dynamically rewrite lines in the visible TextBuffer history. Old
scripts are unaffected and unlikely to have used the API as it used to
break scrollback (see #10).

Note, there might be better ways to alter lines than removing and
reinserting them, but that might be a larger reorganisation of the
fe-text.
