### PR TITLE
Correct the packages of the scripting API

### DIFF
--- a/src/perl/textui/TextUI.xs
+++ b/src/perl/textui/TextUI.xs
@@ -175,7 +175,7 @@ CODE:
 OUTPUT:
 	RETVAL
 
-MODULE = Irssi::TextUI PACKAGE = Irssi::UI::Server
+MODULE = Irssi::TextUI PACKAGE = Irssi::Server
 
 void
 gui_printtext_after(server, target, prev, level, str)


### PR DESCRIPTION
This will break the scripting API for two incorrectly packaged
functions, term_refresh_freeze/thaw and gui_printtext_after and
correct them out of the Irssi::Server package where they don't belong.
