### PR TITLE
support local perl

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -76,7 +76,7 @@ AC_ARG_WITH(modules,
 
 if test "x$prefix" != "xNONE"; then
 	prefix=`eval echo $prefix`
-	PERL_MM_PARAMS="INSTALLDIRS=perl PREFIX=$prefix"
+	PERL_MM_PARAMS="INSTALLDIRS=perl INSTALL_BASE=$prefix"
 	perl_library_dir="PERL_USE_LIB"
 	perl_set_use_lib=yes
 


### PR DESCRIPTION
the irssi build will fail because of conflicting PREFIX spec to EU::MM _if_ your perl was built with INSTALL_BASE, like most modern local perl installs (e.g. perlbrew)
