### PR TITLE
Replace deprecated g_io_channel_close with g_io_channel_shutdown.

### DIFF
--- a/src/core/net-nonblock.c
+++ b/src/core/net-nonblock.c
@@ -214,7 +214,7 @@ static void simple_init(SIMPLE_THREAD_REC *rec, GIOChannel *handle)
 
 	if (net_geterror(handle) != 0) {
 		/* failed */
-		g_io_channel_close(handle);
+		g_io_channel_shutdown(handle, TRUE, NULL);
                 g_io_channel_unref(handle);
 		handle = NULL;
 	}
@@ -236,9 +236,9 @@ static void simple_readpipe(SIMPLE_THREAD_REC *rec, GIOChannel *pipe)
 	net_gethostbyname_return(pipe, &iprec);
 	g_free_not_null(iprec.errorstr);
 
-	g_io_channel_close(rec->pipes[0]);
+	g_io_channel_shutdown(rec->pipes[0], TRUE, NULL);
 	g_io_channel_unref(rec->pipes[0]);
-	g_io_channel_close(rec->pipes[1]);
+	g_io_channel_shutdown(rec->pipes[1], TRUE, NULL);
 	g_io_channel_unref(rec->pipes[1]);
 
 	ip = iprec.ip4.family != 0 ? &iprec.ip4 : &iprec.ip6;

--- a/src/core/network.c
+++ b/src/core/network.c
@@ -260,7 +260,7 @@ void net_disconnect(GIOChannel *handle)
 {
 	g_return_if_fail(handle != NULL);
 
-	g_io_channel_close(handle);
+	g_io_channel_shutdown(handle, TRUE, NULL);
 	g_io_channel_unref(handle);
 }
 

--- a/src/core/servers.c
+++ b/src/core/servers.c
@@ -56,9 +56,9 @@ void server_connect_failed(SERVER_REC *server, const char *msg)
 	}
 
 	if (server->connect_pipe[0] != NULL) {
-		g_io_channel_close(server->connect_pipe[0]);
+		g_io_channel_shutdown(server->connect_pipe[0], TRUE, NULL);
 		g_io_channel_unref(server->connect_pipe[0]);
-		g_io_channel_close(server->connect_pipe[1]);
+		g_io_channel_shutdown(server->connect_pipe[1], TRUE, NULL);
 		g_io_channel_unref(server->connect_pipe[1]);
 		server->connect_pipe[0] = NULL;
 		server->connect_pipe[1] = NULL;
@@ -274,9 +274,9 @@ static void server_connect_callback_readpipe(SERVER_REC *server)
 
 	net_gethostbyname_return(server->connect_pipe[0], &iprec);
 
-	g_io_channel_close(server->connect_pipe[0]);
+	g_io_channel_shutdown(server->connect_pipe[0], TRUE, NULL);
 	g_io_channel_unref(server->connect_pipe[0]);
-	g_io_channel_close(server->connect_pipe[1]);
+	g_io_channel_shutdown(server->connect_pipe[1], TRUE, NULL);
 	g_io_channel_unref(server->connect_pipe[1]);
 
 	server->connect_pipe[0] = NULL;

--- a/src/fe-common/core/fe-exec.c
+++ b/src/fe-common/core/fe-exec.c
@@ -185,7 +185,7 @@ static void process_destroy(PROCESS_REC *rec, int status)
                 exec_wi_destroy(rec->target_item);
 
 	line_split_free(rec->databuf);
-        g_io_channel_close(rec->in);
+        g_io_channel_shutdown(rec->in, TRUE, NULL);
         g_io_channel_unref(rec->in);
         net_sendbuffer_destroy(rec->out, TRUE);
 


### PR DESCRIPTION
g_io_channel_close flushes the buffer and does not return errors.
g_io_channel_shutdown(handle, TRUE, NULL) keeps that behavior.
