### PR TITLE
Revert "add d,q,f and J to CHANMODES default, to work a bit better with ...

### DIFF
--- a/src/irc/core/irc-servers.c
+++ b/src/irc/core/irc-servers.c
@@ -167,7 +167,7 @@ static void server_init(IRC_SERVER_REC *server)
 					    (GCompareFunc) g_istr_equal);
 
 	/* set the standards */
-	g_hash_table_insert(server->isupport, g_strdup("CHANMODES"), g_strdup("beIqd,k,lfJ,imnpst"));
+	g_hash_table_insert(server->isupport, g_strdup("CHANMODES"), g_strdup("beI,k,l,imnpst"));
 	g_hash_table_insert(server->isupport, g_strdup("PREFIX"), g_strdup("(ohv)@%+"));
 
 	server->cmdcount = 0;


### PR DESCRIPTION
...dancer and possibly others"

This is no longer relevant and most ircds now send a correct isupport
message.

This reverts commit b832f1f7b2c4a692786d5d52904a2bdf4d14354f.
