### PR TITLE
Move PUTBACK to within the scope which uses the stack

### DIFF
--- a/src/perl/perl-core.c
+++ b/src/perl/perl-core.c
@@ -217,8 +217,6 @@ static int perl_script_eval(PERL_SCRIPT_REC *script)
 {
 	dSP;
 	char *error;
-	int retcount;
-	SV *ret;
 
 	ENTER;
 	SAVETMPS;
@@ -229,10 +227,10 @@ static int perl_script_eval(PERL_SCRIPT_REC *script)
 	XPUSHs(sv_2mortal(new_pv(script->name)));
 	PUTBACK;
 
-	retcount = perl_call_pv(script->path != NULL ?
-				"Irssi::Core::eval_file" :
-				"Irssi::Core::eval_data",
-				G_EVAL|G_SCALAR);
+	perl_call_pv(script->path != NULL ?
+                              "Irssi::Core::eval_file" :
+                              "Irssi::Core::eval_data",
+                              G_EVAL|G_DISCARD);
 	SPAGAIN;
 
         error = NULL;
@@ -244,11 +242,8 @@ static int perl_script_eval(PERL_SCRIPT_REC *script)
 			signal_emit("script error", 2, script, error);
 			g_free(error);
 		}
-	} else if (retcount > 0) {
-		ret = POPs;
 	}
 
-	PUTBACK;
 	FREETMPS;
 	LEAVE;
 


### PR DESCRIPTION
PUTBACK was being called even for the error case. Because the side
effect of emitting the "script error" signal can involve running Perl
code (Irssi:core::destroy) the stack can be reallocated. This results in
the perl stack being corrupted (although as it's use of freed memory the
crash is not always instant).

Reproducing this is pretty hard. Something like two scripts in ~/.irssi/scripts/autorun:

first.pl

```
use IO::Socket;
use This::doesn't::exist;
```

second.pl

```
1;
```

And then running Irssi under valgrind may show errors or crash before this fix.
