### PR TITLE
Correct use of perl stack macros

### DIFF
--- a/src/perl/common/Expando.xs
+++ b/src/perl/common/Expando.xs
@@ -73,6 +73,10 @@ static char *perl_expando_event(PerlExpando *rec, SERVER_REC *server,
 
 	ret = NULL;
 	if (SvTRUE(ERRSV)) {
+		(void) POPs;
+		/* call putback before emitting script error signal as that
+		 * could manipulate the perl stack. */
+		PUTBACK;
 		/* make sure we don't get back here */
 		if (rec->script != NULL)
 			script_unregister_expandos(rec->script);
@@ -81,9 +85,9 @@ static char *perl_expando_event(PerlExpando *rec, SERVER_REC *server,
 	} else if (retcount > 0) {
 		ret = g_strdup(POPp);
 		*free_ret = TRUE;
+		PUTBACK;
 	}
 
-	PUTBACK;
 	FREETMPS;
 	LEAVE;
 

--- a/src/perl/perl-common.c
+++ b/src/perl/perl-common.c
@@ -248,9 +248,9 @@ void irssi_callXS(void (*subaddr)(pTHX_ CV* cv), CV *cv, SV **mark)
 	dSP;
 
 	PUSHMARK(mark);
-	(*subaddr)(aTHX_ cv);
-
 	PUTBACK;
+
+	(*subaddr)(aTHX_ cv);
 }
 
 void perl_chatnet_fill_hash(HV *hv, CHATNET_REC *chatnet)

--- a/src/perl/perl-core.c
+++ b/src/perl/perl-core.c
@@ -58,9 +58,6 @@ static void perl_script_destroy_package(PERL_SCRIPT_REC *script)
 
 	perl_call_pv("Irssi::Core::destroy", G_VOID|G_EVAL|G_DISCARD);
 
-	SPAGAIN;
-
-	PUTBACK;
 	FREETMPS;
 	LEAVE;
 }

--- a/src/perl/perl-signals.c
+++ b/src/perl/perl-signals.c
@@ -345,7 +345,6 @@ static void perl_call_signal(PERL_SCRIPT_REC *script, SV *func,
 		}
 	}
 
-	PUTBACK;
 	FREETMPS;
 	LEAVE;
 }

--- a/src/perl/perl-sources.c
+++ b/src/perl/perl-sources.c
@@ -68,7 +68,6 @@ static void perl_source_destroy(PERL_SOURCE_REC *rec)
 static int perl_source_event(PERL_SOURCE_REC *rec)
 {
 	dSP;
-	int retcount;
 
 	ENTER;
 	SAVETMPS;
@@ -78,8 +77,7 @@ static int perl_source_event(PERL_SOURCE_REC *rec)
 	PUTBACK;
 
         perl_source_ref(rec);
-	retcount = perl_call_sv(rec->func, G_EVAL|G_SCALAR);
-	SPAGAIN;
+	perl_call_sv(rec->func, G_EVAL|G_DISCARD);
 
 	if (SvTRUE(ERRSV)) {
                 char *error = g_strdup(SvPV(ERRSV, PL_na));
@@ -90,7 +88,6 @@ static int perl_source_event(PERL_SOURCE_REC *rec)
 	if (perl_source_unref(rec) && rec->once)
 		perl_source_destroy(rec);
 
-	PUTBACK;
 	FREETMPS;
 	LEAVE;
 

--- a/src/perl/textui/Statusbar.xs
+++ b/src/perl/textui/Statusbar.xs
@@ -89,7 +89,6 @@ static void perl_statusbar_event(char *function, SBAR_ITEM_REC *item,
 		}
 	}
 
-	PUTBACK;
 	FREETMPS;
 	LEAVE;
 }


### PR DESCRIPTION
Further to pull #49 this is the result of an audit of the use of perl
stack macros. There were several cases where PUTBACK was being called
where the stack pointer could be out-of-date.

Also some misc. cleanup where the macros were used needlessly.
