### PR TITLE
Fix compiler warning.

### DIFF
--- a/src/core/network.c
+++ b/src/core/network.c
@@ -60,7 +60,7 @@ GIOChannel *g_io_channel_new(int handle)
 
 IPADDR ip4_any = {
 	AF_INET,
-	{ INADDR_ANY }
+	{ { { INADDR_ANY } } }
 };
 
 int net_ip_compare(IPADDR *ip1, IPADDR *ip2)


### PR DESCRIPTION
network.c:63:2: warning: missing braces around initializer [-Wmissing-braces]
network.c:63:2: warning: (near initialization for 'ip4_any.ip.__u6_addr') [-Wmissing-braces]
