### PR TITLE
Do not break strict-aliasing rules.

### DIFF
--- a/src/irc/dcc/dcc-send.c
+++ b/src/irc/dcc/dcc-send.c
@@ -293,7 +293,8 @@ static void dcc_send_read_size(SEND_DCC_REC *dcc)
 	if (dcc->count_pos != 4)
 		return;
 
-	bytes = ntohl(*((guint32 *) dcc->count_buf));
+	memcpy(&bytes, dcc->count_buf, sizeof(bytes));
+	bytes = ntohl(bytes);
 	dcc->count_pos = 0;
 
 	if (dcc->waitforend && bytes == (dcc->transfd & 0xffffffff)) {


### PR DESCRIPTION
dcc-send.c:296:2: warning: dereferencing type-punned pointer
will break strict-aliasing rules
