### PR TITLE
Define PERL_NO_GET_CONTEXT in all perl source files

### DIFF
--- a/src/perl/common/Channel.xs
+++ b/src/perl/common/Channel.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 MODULE = Irssi::Channel  PACKAGE = Irssi

--- a/src/perl/common/Core.xs
+++ b/src/perl/common/Core.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 #include "irssi-version.h"
 #include "core.h"

--- a/src/perl/common/Expando.xs
+++ b/src/perl/common/Expando.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 #include "expandos.h"
 

--- a/src/perl/common/Ignore.xs
+++ b/src/perl/common/Ignore.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 MODULE = Irssi::Ignore  PACKAGE = Irssi

--- a/src/perl/common/Irssi.xs
+++ b/src/perl/common/Irssi.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 static int initialized = FALSE;

--- a/src/perl/common/Log.xs
+++ b/src/perl/common/Log.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 MODULE = Irssi::Log  PACKAGE = Irssi

--- a/src/perl/common/Masks.xs
+++ b/src/perl/common/Masks.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 MODULE = Irssi::Masks  PACKAGE = Irssi

--- a/src/perl/common/Query.xs
+++ b/src/perl/common/Query.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 MODULE = Irssi::Query  PACKAGE = Irssi

--- a/src/perl/common/Rawlog.xs
+++ b/src/perl/common/Rawlog.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 MODULE = Irssi::Rawlog  PACKAGE = Irssi

--- a/src/perl/common/Server.xs
+++ b/src/perl/common/Server.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 MODULE = Irssi::Server  PACKAGE = Irssi

--- a/src/perl/common/Settings.xs
+++ b/src/perl/common/Settings.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 #include "misc.h"
 

--- a/src/perl/irc/Channel.xs
+++ b/src/perl/irc/Channel.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 MODULE = Irssi::Irc::Channel	PACKAGE = Irssi::Irc  PREFIX = irc_

--- a/src/perl/irc/Client.xs
+++ b/src/perl/irc/Client.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 MODULE = Irssi::Irc::Client  PACKAGE = Irssi::Irc

--- a/src/perl/irc/Ctcp.xs
+++ b/src/perl/irc/Ctcp.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 #include "ctcp.h"
 

--- a/src/perl/irc/Dcc.xs
+++ b/src/perl/irc/Dcc.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 MODULE = Irssi::Irc::Dcc  PACKAGE = Irssi::Irc

--- a/src/perl/irc/Irc.xs
+++ b/src/perl/irc/Irc.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 static int initialized = FALSE;

--- a/src/perl/irc/Modes.xs
+++ b/src/perl/irc/Modes.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 MODULE = Irssi::Irc::Modes	PACKAGE = Irssi::Irc

--- a/src/perl/irc/Netsplit.xs
+++ b/src/perl/irc/Netsplit.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 MODULE = Irssi::Irc::Netsplit	PACKAGE = Irssi::Irc::Server

--- a/src/perl/irc/Notifylist.xs
+++ b/src/perl/irc/Notifylist.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 MODULE = Irssi::Irc::Notifylist  PACKAGE = Irssi::Irc

--- a/src/perl/irc/Query.xs
+++ b/src/perl/irc/Query.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 MODULE = Irssi::Irc::Query	PACKAGE = Irssi::Irc::Server  PREFIX = irc_

--- a/src/perl/irc/Server.xs
+++ b/src/perl/irc/Server.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 static GSList *register_hash2list(HV *hv)

--- a/src/perl/perl-common.c
+++ b/src/perl/perl-common.c
@@ -19,6 +19,7 @@
 */
 
 #define NEED_PERL_H
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 #include "modules.h"
 #include "signals.h"

--- a/src/perl/perl-core.c
+++ b/src/perl/perl-core.c
@@ -19,6 +19,7 @@
 */
 
 #define NEED_PERL_H
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 #include "modules.h"
 #include "core.h"

--- a/src/perl/perl-signals.c
+++ b/src/perl/perl-signals.c
@@ -19,6 +19,7 @@
 */
 
 #define NEED_PERL_H
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 #include "modules.h"
 #include "signals.h"

--- a/src/perl/perl-sources.c
+++ b/src/perl/perl-sources.c
@@ -19,6 +19,7 @@
 */
 
 #define NEED_PERL_H
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 #include "signals.h"
 

--- a/src/perl/textui/Statusbar.xs
+++ b/src/perl/textui/Statusbar.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 static GHashTable *perl_sbar_defs;

--- a/src/perl/textui/TextBuffer.xs
+++ b/src/perl/textui/TextBuffer.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 MODULE = Irssi::TextUI::TextBuffer  PACKAGE = Irssi

--- a/src/perl/textui/TextBufferView.xs
+++ b/src/perl/textui/TextBufferView.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 MODULE = Irssi::TextUI::TextBufferView  PACKAGE = Irssi::TextUI::TextBuffer  PREFIX = textbuffer_

--- a/src/perl/textui/TextUI.xs
+++ b/src/perl/textui/TextUI.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 void perl_statusbar_init(void);

--- a/src/perl/ui/Formats.xs
+++ b/src/perl/ui/Formats.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 static int magic_free_text_dest(pTHX_ SV *sv, MAGIC *mg)

--- a/src/perl/ui/Themes.xs
+++ b/src/perl/ui/Themes.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 static void printformat_perl(TEXT_DEST_REC *dest, char *format, char **arglist)

--- a/src/perl/ui/UI.xs
+++ b/src/perl/ui/UI.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 void perl_themes_init(void);

--- a/src/perl/ui/Window.xs
+++ b/src/perl/ui/Window.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "module.h"
 
 #include "window-activity.h"


### PR DESCRIPTION
This removes the calls to Perl_get_context() that get automatically
added to XS code for ancient source code compatibility reasons.

The result is about a ~60K size reduction in the binary (based on
comparing two 64-bit stripped irssi binaries compiled
--with-perl-staticlib).
