### PR TITLE
Make the new banner appear on the status window if there is one

### DIFF
--- a/src/fe-text/irssi.c
+++ b/src/fe-text/irssi.c
@@ -205,8 +205,7 @@ static void textui_finish_init(void)
 	signal_emit("irssi init finished", 0);
 	statusbar_redraw(NULL, TRUE);
 
-	printtext_window(active_win, MSGLEVEL_CRAP,
-				 "%s", banner_text);
+	printtext(NULL, NULL, MSGLEVEL_CRAP|MSGLEVEL_NO_ACT, "%s", banner_text);
 
 	if (display_firsttimer) {
 		printtext_window(active_win, MSGLEVEL_CRAP,


### PR DESCRIPTION
This avoids it appearing in the last active window after a /layout save
on a previous run.
