### PR TITLE
Only show banner if not connecting to servers

### DIFF
--- a/src/fe-text/irssi.c
+++ b/src/fe-text/irssi.c
@@ -96,7 +96,7 @@ static const char *firsttimer_text =
 	"documentation to get you going.\n\n"
 	"Our community and staff are available to assist you or\n"
 	"to answer any questions you may have.\n\n"
-	"Use the HELP command to get detailed information about\n"
+	"Use the /HELP command to get detailed information about\n"
 	"the available commands.\n"
 	"- - - - - - - - - - - - - - - - - - - - - - - - - - - -";
 


### PR DESCRIPTION
It's tricky to make the banner show first in all cases and it's unlikely
to be seen if someone is connecting to a server already, so just don't
show it.
