### PR TITLE
more strict rules for italic emphasis to avoid file name clashes

### DIFF
--- a/src/fe-common/core/fe-messages.c
+++ b/src/fe-common/core/fe-messages.c
@@ -81,7 +81,8 @@ char *expand_emphasis(WI_ITEM_REC *item, const char *text)
 		if ((end = strchr(bgn+1, *bgn)) == NULL)
 			continue;
 		if (!ishighalnum(end[-1]) || ishighalnum(end[1]) ||
-		    end[1] == type || end[1] == '*' || end[1] == '_')
+		    end[1] == type || end[1] == '*' || end[1] == '_' ||
+		    (type == 29 && end[1] != NULL && ishighalnum(end[2])))
 			continue;
 
 		if (IS_CHANNEL(item)) {


### PR DESCRIPTION
this additional check avoids /root/.hiddendir from italicising /root/,
because that is often used in path names
