### PR TITLE
Allow to specify the maximum length of a line with the new split lines feature

### DIFF
--- a/src/irc/core/irc-servers.c
+++ b/src/irc/core/irc-servers.c
@@ -89,6 +89,10 @@ static char **split_line(const SERVER_REC *server, const char *line,
 	char *recoded_end = recode_out(server, end, target);
 	char **lines;
 	int i;
+	int split_max_length = settings_get_int("split_max_length");
+
+	if (split_max_length > 0)
+		len = split_max_length;
 
 	/*
 	 * Having the same length limit on all lines will make the first line
@@ -980,6 +984,7 @@ void irc_server_init_isupport(IRC_SERVER_REC *server)
 void irc_servers_init(void)
 {
 	settings_add_str("misc", "usermode", DEFAULT_USER_MODE);
+	settings_add_int("misc", "split_max_length", 0);
 	settings_add_str("misc", "split_line_start", "");
 	settings_add_str("misc", "split_line_end", "");
 	settings_add_time("flood", "cmd_queue_speed", DEFAULT_CMD_QUEUE_SPEED);


### PR DESCRIPTION
This adds a new setting to irssi called "split_max_length" as it existed on splitlines.pl.

It allows the user to define the max length of the messages before they are split.
If it is set to 0 (the default) it will use the default split lines algorithm to find the max_length.

This is an addition to Pull Request #29.
