### PR TITLE
fix uninitialised copy on 24bit colours

### DIFF
--- a/src/fe-text/textbuffer-view.c
+++ b/src/fe-text/textbuffer-view.c
@@ -213,7 +213,7 @@ view_update_line_cache(TEXT_BUFFER_VIEW_REC *view, LINE_REC *line)
 	color = ATTR_RESETFG | ATTR_RESETBG;
 	xpos = 0; indent_pos = view->default_indent;
 	last_space = last_color = 0; last_space_ptr = NULL; sub = NULL;
-	last_bg24 = last_fg24 = UINT_MAX;
+	bg24 = fg24 = last_bg24 = last_fg24 = UINT_MAX;
 
         indent_func = view->default_indent_func;
         linecount = 1;


### PR DESCRIPTION
I missed to default-initialise some variables which could cause random
memory assignment. shouldn't be of any practical relevance
