### PR TITLE
fix rules for italics emphasis

### DIFF
--- a/src/fe-common/core/fe-messages.c
+++ b/src/fe-common/core/fe-messages.c
@@ -82,7 +82,9 @@ char *expand_emphasis(WI_ITEM_REC *item, const char *text)
 			continue;
 		if (!ishighalnum(end[-1]) || ishighalnum(end[1]) ||
 		    end[1] == type || end[1] == '*' || end[1] == '_' ||
-		    (type == 29 && end[1] != '\0' && ishighalnum(end[2])))
+		    /* special case for italics to not emphasise
+		       common paths by skipping /.../.X */
+		    (type == 29 && i_ispunct(end[1]) && ishighalnum(end[2])))
 			continue;
 
 		if (IS_CHANNEL(item)) {


### PR DESCRIPTION
while the last patch did stop /path/.xxx from turning italic, it also
stopped any other /emphasis/ from becoming italic. correct this by
testing for ispunct, so spaces are valid italic terminators
