### PR TITLE
Make ^ key and Ctrl+^ key usable with /BIND

### DIFF
--- a/src/fe-common/core/keyboard.c
+++ b/src/fe-common/core/keyboard.c
@@ -292,12 +292,18 @@ static int expand_key(const char *key, GSList **out)
 			}
 			last_hyphen = !last_hyphen;
 		} else if (*key == '^') {
-                        /* ctrl-code */
-			if (key[1] != '\0')
-				key++;
-
 			expand_out_char(*out, '^');
-			expand_out_char(*out, *key);
+
+                        /* ctrl-code */
+			if (key[1] != '\0' && key[1] != '-') {
+				key++;
+				expand_out_char(*out, *key);
+			}
+			else {
+				/* escaped syntax for ^, see gui-readline.c */
+				expand_out_char(*out, '-');
+			}
+
 			expand_out_char(*out, '-');
                         last_hyphen = FALSE; /* optional */
 		} else if (last_hyphen && i_isalpha(*key)) {

--- a/src/fe-text/gui-readline.c
+++ b/src/fe-text/gui-readline.c
@@ -393,8 +393,8 @@ static void sig_gui_key_pressed(gpointer keyp)
 	}
 
 	if (strcmp(str, "^") == 0) {
-		/* change it as ^^ */
-		str[1] = '^';
+		/* change it as ^-, that is an invalid control char */
+		str[1] = '-';
 		str[2] = '\0';
 	}
 


### PR DESCRIPTION
Fixes FS#721

This makes Ctrl+^ and ^ bindable again as different keys.

Please test.