### PR TITLE
Add bounds check to array access in terminfo driver.

### DIFF
--- a/src/fe-text/term-terminfo.c
+++ b/src/fe-text/term-terminfo.c
@@ -293,7 +293,7 @@ void term_window_scroll(TERM_WINDOW *window, int count)
         term_move_reset(vcx, vcy);
 
         /* set the newly scrolled area dirty */
-	for (y = 0; y < window->height; y++)
+	for (y = 0; (window->y+y) < term_height && y < window->height; y++)
 		term_lines_empty[window->y+y] = FALSE;
 }
 


### PR DESCRIPTION
this fixes a crash due to illegal memory access that can occur if
something is printed to the screen on the "terminal resized"
handler. It is not clear to me whether this race condition can be
triggered by external incoming messages, but it might be better safe
than sorry.

This should fix #122
