### PR TITLE
Fix glib warnings when tab completing in weird places

### DIFF
--- a/src/fe-common/core/completion.c
+++ b/src/fe-common/core/completion.c
@@ -162,7 +162,8 @@ char *word_complete(WINDOW_REC *window, const char *line, int *pos, int erase, i
 		if (isseparator(*line)) {
 			/* empty space at the start of line */
 			if (wordstart == line)
-				wordstart += strlen(wordstart);
+				while (wordstart != '\0' && isseparator(wordstart))
+					wordstart++;
 		} else {
 			while (wordstart > line && isseparator(wordstart[-1]))
 				wordstart--;


### PR DESCRIPTION
See github issue #125 for more details (or [flyspray issue 124](http://bugs.irssi.org/index.php?do=details&task_id=124), submitted 10 years ago), and [these IRC logs linked from the other ticket](https://gist.github.com/dequis/0673902b4dc216b79b5e) for my comments while I was writing this thing.

It was months ago so I don't really remember how sure I was if this was the correct way to fix this issue, but it does get rid of the warnings and doesn't do anything too weird.

Like I said in the other ticket, submitting "now that the chances to get patches merged are non-zero".

Fixes #125.