### PR TITLE
Add term_force_256colors setting.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -175,6 +175,15 @@ AC_ARG_ENABLE(true-color,
 	fi,
 	want_truecolor=no)
 
+AC_ARG_ENABLE(force-256color,
+[  --enable-force-256color Force using 256-color escapes],
+	if text x$enableval = xno ; then
+		want_force256color=no
+	else
+		want_force256color=yes
+	fi,
+	want_force256color=no)
+
 dnl **
 dnl ** SSL Library checks (OpenSSL)
 dnl **
@@ -669,6 +678,12 @@ else
 	want_truecolor=no
 fi
 
+if test "x$want_force256color" = "xyes" ; then
+	AC_DEFINE([HACK_FORCE_256COLOR], [], [force 256color escapes in terminal])
+else
+	want_force256color=no
+fi
+
 AC_CONFIG_FILES([
 Makefile
 src/Makefile
@@ -802,6 +817,7 @@ echo "Building with 64bit DCC support .. : $offt_64bit"
 echo "Building with garbage collector .. : $have_gc"
 echo "Building with DANE support ....... : $have_dane"
 echo "Building with true color support.. : $want_truecolor"
+echo "Building with force 256color hack. : $want_force256color"
 
 echo
 echo "If there are any problems, read the INSTALL file."

--- a/configure.ac
+++ b/configure.ac
@@ -175,15 +175,6 @@ AC_ARG_ENABLE(true-color,
 	fi,
 	want_truecolor=no)
 
-AC_ARG_ENABLE(force-256color,
-[  --enable-force-256color Force using 256-color escapes],
-	if text x$enableval = xno ; then
-		want_force256color=no
-	else
-		want_force256color=yes
-	fi,
-	want_force256color=no)
-
 dnl **
 dnl ** SSL Library checks (OpenSSL)
 dnl **
@@ -678,12 +669,6 @@ else
 	want_truecolor=no
 fi
 
-if test "x$want_force256color" = "xyes" ; then
-	AC_DEFINE([HACK_FORCE_256COLOR], [], [force 256color escapes in terminal])
-else
-	want_force256color=no
-fi
-
 AC_CONFIG_FILES([
 Makefile
 src/Makefile
@@ -817,7 +802,6 @@ echo "Building with 64bit DCC support .. : $offt_64bit"
 echo "Building with garbage collector .. : $have_gc"
 echo "Building with DANE support ....... : $have_dane"
 echo "Building with true color support.. : $want_truecolor"
-echo "Building with force 256color hack. : $want_force256color"
 
 echo
 echo "If there are any problems, read the INSTALL file."

--- a/src/fe-text/term.c
+++ b/src/fe-text/term.c
@@ -130,6 +130,7 @@ static void read_settings(void)
 	int old_colors = term_use_colors;
 	int old_colors24 = term_use_colors24;
         int old_type = term_type;
+	int old_forced = force_colors;
 
         /* set terminal type */
 	str = settings_get_str("term_charset");
@@ -144,8 +145,14 @@ static void read_settings(void)
                 term_set_input_type(term_type);
 
         /* change color stuff */
-	if (force_colors != settings_get_bool("term_force_colors")) {
+	if (settings_get_bool("term_force_256colors")) {
+		force_colors = 256;
+	}
+	else if (force_colors != settings_get_bool("term_force_colors")) {
 		force_colors = settings_get_bool("term_force_colors");
+	}
+
+	if (old_forced != force_colors) {
 		term_force_colors(force_colors);
 	}
 
@@ -171,7 +178,8 @@ void term_common_init(void)
 #endif
 	settings_add_bool("lookandfeel", "colors", TRUE);
 	settings_add_bool("lookandfeel", "term_force_colors", FALSE);
-        settings_add_bool("lookandfeel", "mirc_blink_fix", FALSE);
+	settings_add_bool("lookandfeel", "mirc_blink_fix", FALSE);
+	settings_add_bool("lookandfeel", "term_force_256colors", FALSE);
 
 	force_colors = FALSE;
 	term_use_colors = term_has_colors() && settings_get_bool("colors");

--- a/src/fe-text/terminfo-core.c
+++ b/src/fe-text/terminfo-core.c
@@ -449,13 +449,10 @@ void terminfo_setup_colors(TERM_REC *term, int force)
 	unsigned int i, color;
 
 	terminfo_colors_deinit(term);
-
-	if (force && term->TI_setf == NULL && term->TI_setaf == NULL)
-#ifdef HACK_FORCE_256COLOR
+	if (force == 256)
 		term->TI_colors = 256;
-#else
+	else if (force && term->TI_setf == NULL && term->TI_setaf == NULL)
 		term->TI_colors = 8;
-#endif
 
 	if ((term->TI_setf || term->TI_setaf || force) &&
 	     term->TI_colors > 0) {
@@ -468,19 +465,15 @@ void terminfo_setup_colors(TERM_REC *term, int force)
 		term->TI_colors = 0;
 		term->set_fg = term->set_bg = _ignore_parm;
 	}
-#ifdef HACK_FORCE_256COLOR
-	/* force 256-color escapes for base colors also, lets you have bold
-	 * font in konsole without bright
-	 */
-	if (force) {
+	if (force == 256) {
+		/* force 256-color escapes for base colors as well, lets you
+		 * have bold font in konsole without bright.
+		 */
 		for (i = 0; i < term->TI_colors; i++) {
 			color = i < 16 ? ansitab[i] : i;
 			term->TI_fg[i] = g_strdup_printf("\033[38;5;%dm", color);
 		}
 	} else if (term->TI_setaf) {
-#else
-	if (term->TI_setaf) {
-#endif
 		for (i = 0; i < term->TI_colors; i++) {
 			color = i < 16 ? ansitab[i] : i;
 			term->TI_fg[i] = g_strdup(tparm(term->TI_setaf, color, 0));
@@ -488,24 +481,16 @@ void terminfo_setup_colors(TERM_REC *term, int force)
 	} else if (term->TI_setf) {
 		for (i = 0; i < term->TI_colors; i++)
                         term->TI_fg[i] = g_strdup(tparm(term->TI_setf, i, 0));
-#ifdef HACK_FORCE_256COLOR
-	}
-#else
 	} else if (force) {
 		for (i = 0; i < 8; i++)
                         term->TI_fg[i] = g_strdup_printf("\033[%dm", 30+ansitab[i]);
 	}
-#endif
-#ifdef HACK_FORCE_256COLOR
-	if (force) {
+	if (force == 256) {
 		for (i = 0; i < term->TI_colors; i++) {
 			color = i < 16 ? ansitab[i] : i;
 			term->TI_bg[i] = g_strdup_printf("\033[48;5;%dm", color);
 		}
 	} else if (term->TI_setab) {
-#else
-	if (term->TI_setab) {
-#endif
 		for (i = 0; i < term->TI_colors; i++) {
 			color = i < 16 ? ansitab[i] : i;
 			term->TI_bg[i] = g_strdup(tparm(term->TI_setab, color, 0));
@@ -513,14 +498,10 @@ void terminfo_setup_colors(TERM_REC *term, int force)
 	} else if (term->TI_setb) {
 		for (i = 0; i < term->TI_colors; i++)
                         term->TI_bg[i] = g_strdup(tparm(term->TI_setb, i, 0));
-#ifdef HACK_FORCE_256COLOR
-	}
-#else
 	} else if (force) {
 		for (i = 0; i < 8; i++)
                         term->TI_bg[i] = g_strdup_printf("\033[%dm", 40+ansitab[i]);
 	}
-#endif /* HACK_FORCE_256COLOR */
 }
 
 static void terminfo_input_init(TERM_REC *term)

--- a/src/fe-text/terminfo-core.c
+++ b/src/fe-text/terminfo-core.c
@@ -453,6 +453,8 @@ void terminfo_setup_colors(TERM_REC *term, int force)
 		term->TI_colors = 256;
 	else if (force && term->TI_setf == NULL && term->TI_setaf == NULL)
 		term->TI_colors = 8;
+	else /* if we turn off force we'll need to restore the real setting */
+		term->TI_colors = term_getnum(tcaps[25]);
 
 	if ((term->TI_setf || term->TI_setaf || force) &&
 	     term->TI_colors > 0) {

--- a/src/fe-text/terminfo-core.c
+++ b/src/fe-text/terminfo-core.c
@@ -451,7 +451,11 @@ void terminfo_setup_colors(TERM_REC *term, int force)
 	terminfo_colors_deinit(term);
 
 	if (force && term->TI_setf == NULL && term->TI_setaf == NULL)
+#ifdef HACK_FORCE_256COLOR
+		term->TI_colors = 256;
+#else
 		term->TI_colors = 8;
+#endif
 
 	if ((term->TI_setf || term->TI_setaf || force) &&
 	     term->TI_colors > 0) {
@@ -464,8 +468,19 @@ void terminfo_setup_colors(TERM_REC *term, int force)
 		term->TI_colors = 0;
 		term->set_fg = term->set_bg = _ignore_parm;
 	}
-
+#ifdef HACK_FORCE_256COLOR
+	/* force 256-color escapes for base colors also, lets you have bold
+	 * font in konsole without bright
+	 */
+	if (force) {
+		for (i = 0; i < term->TI_colors; i++) {
+			color = i < 16 ? ansitab[i] : i;
+			term->TI_fg[i] = g_strdup_printf("\033[38;5;%dm", color);
+		}
+	} else if (term->TI_setaf) {
+#else
 	if (term->TI_setaf) {
+#endif
 		for (i = 0; i < term->TI_colors; i++) {
 			color = i < 16 ? ansitab[i] : i;
 			term->TI_fg[i] = g_strdup(tparm(term->TI_setaf, color, 0));
@@ -473,12 +488,24 @@ void terminfo_setup_colors(TERM_REC *term, int force)
 	} else if (term->TI_setf) {
 		for (i = 0; i < term->TI_colors; i++)
                         term->TI_fg[i] = g_strdup(tparm(term->TI_setf, i, 0));
+#ifdef HACK_FORCE_256COLOR
+	}
+#else
 	} else if (force) {
 		for (i = 0; i < 8; i++)
                         term->TI_fg[i] = g_strdup_printf("\033[%dm", 30+ansitab[i]);
 	}
-
+#endif
+#ifdef HACK_FORCE_256COLOR
+	if (force) {
+		for (i = 0; i < term->TI_colors; i++) {
+			color = i < 16 ? ansitab[i] : i;
+			term->TI_bg[i] = g_strdup_printf("\033[48;5;%dm", color);
+		}
+	} else if (term->TI_setab) {
+#else
 	if (term->TI_setab) {
+#endif
 		for (i = 0; i < term->TI_colors; i++) {
 			color = i < 16 ? ansitab[i] : i;
 			term->TI_bg[i] = g_strdup(tparm(term->TI_setab, color, 0));
@@ -486,10 +513,14 @@ void terminfo_setup_colors(TERM_REC *term, int force)
 	} else if (term->TI_setb) {
 		for (i = 0; i < term->TI_colors; i++)
                         term->TI_bg[i] = g_strdup(tparm(term->TI_setb, i, 0));
+#ifdef HACK_FORCE_256COLOR
+	}
+#else
 	} else if (force) {
 		for (i = 0; i < 8; i++)
                         term->TI_bg[i] = g_strdup_printf("\033[%dm", 40+ansitab[i]);
 	}
+#endif /* HACK_FORCE_256COLOR */
 }
 
 static void terminfo_input_init(TERM_REC *term)


### PR DESCRIPTION
This patch adds a term_force_256color option. I'd agree with requiring a proper TERM env variable, however this is the only way to get Konsole to display bold text without making it bright.
![konsole-irssi](https://cloud.githubusercontent.com/assets/8402422/3871044/927f188e-20eb-11e4-85dc-607e933c5ca3.png)
