### PR TITLE
Add bindings for exec-type window items to Perl

### DIFF
--- a/src/perl/perl-common.c
+++ b/src/perl/perl-common.c
@@ -351,10 +351,12 @@ void perl_window_item_fill_hash(HV *hv, WI_ITEM_REC *item)
         g_return_if_fail(item != NULL);
 
 	type = (char *) module_find_id_str("WINDOW ITEM TYPE", item->type);
-	chat_type = (char *) chat_protocol_find_id(item->chat_type)->name;
 
 	(void) hv_store(hv, "type", 4, new_pv(type), 0);
-	(void) hv_store(hv, "chat_type", 9, new_pv(chat_type), 0);
+	if (item->chat_type) {
+		chat_type = (char *) chat_protocol_find_id(item->chat_type)->name;
+		(void) hv_store(hv, "chat_type", 9, new_pv(chat_type), 0);
+	}
 
 	if (item->server != NULL) {
 		(void) hv_store(hv, "server", 6, iobject_bless(item->server), 0);

--- a/src/perl/ui/UI.xs
+++ b/src/perl/ui/UI.xs
@@ -64,6 +64,19 @@ static void perl_text_dest_fill_hash(HV *hv, TEXT_DEST_REC *dest)
 	(void) hv_store(hv, "hilight_color", 13, new_pv(dest->hilight_color), 0);
 }
 
+static void perl_exec_fill_hash(HV *hv, EXEC_WI_REC *item)
+{
+	g_return_if_fail(hv != NULL);
+	g_return_if_fail(item != NULL);
+
+	perl_window_item_fill_hash(hv, (WI_ITEM_REC *) item);
+	/* we don't bless to Process here to avoid infinite recursion
+	   in the simplistic script binding */
+	if (item->process != NULL) {
+		(void) hv_store(hv, "process_id", 10, newSViv(item->process->id), 0);
+	}
+}
+
 static PLAIN_OBJECT_INIT_REC fe_plains[] = {
 	{ "Irssi::UI::Process", (PERL_OBJECT_FUNC) perl_process_fill_hash },
 	{ "Irssi::UI::Window", (PERL_OBJECT_FUNC) perl_window_fill_hash },
@@ -94,6 +107,10 @@ CODE:
 	initialized = TRUE;
 
         irssi_add_plains(fe_plains);
+        /* window items: fe-exec */
+        irssi_add_object(module_get_uniq_id_str("WINDOW ITEM TYPE", "EXEC"),
+			 0, "Irssi::UI::Exec",
+                         (PERL_OBJECT_FUNC) perl_exec_fill_hash);
         perl_themes_init();
 
 void


### PR DESCRIPTION
These bindings were missing and resulted in non-hash non-undef active
entries when an interactive process is executing.

Up for discussion! Currently does not bless the processes.

dg> kind of ugly, just means scripts end up working around it
    which would then be more of a mess to clean up