### PR TITLE
Add the signal for printtext_after that was missed in the original commit.

### DIFF
--- a/docs/signals.txt
+++ b/docs/signals.txt
@@ -333,6 +333,7 @@ gui-readline.c:
 
 gui-printtext.c:
  "beep"
+ "gui print text after finished", WINDOW_REC, LINE_REC *line, LINE_REC *prev_line
 
 textbuffer-view.c
  "gui textbuffer line removed", TEXTBUFFER_VIEW_REC *view, LINE_REC *line, LINE_REC *prev_line

--- a/src/fe-text/gui-printtext.c
+++ b/src/fe-text/gui-printtext.c
@@ -120,6 +120,7 @@ void gui_printtext_after_time(TEXT_DEST_REC *dest, LINE_REC *prev, const char *s
 	gui->insert_after_time = time;
 	format_send_to_gui(dest, str);
 	gui->use_insert_after = FALSE;
+	signal_emit("gui print text after finished", 3, dest->window, gui->insert_after, prev);
 }
 
 void gui_printtext_after(TEXT_DEST_REC *dest, LINE_REC *prev, const char *str)


### PR DESCRIPTION
Now properly sends "gui print text after finished" signal when using
the printtext_after API that was fixed after 0.8.16
