### PR TITLE
source cleanup: remove trailing whitespaces

### DIFF
--- a/src/fe-common/core/chat-completion.c
+++ b/src/fe-common/core/chat-completion.c
@@ -574,7 +574,7 @@ GList *completion_get_aliases(const char *word)
 
 		list = g_list_append(list, g_strdup(node->key));
 	}
-	
+
 	return list;
 }
 
@@ -781,7 +781,7 @@ GList *completion_get_servers(const char *word)
 	for (tmp = setupservers; tmp != NULL; tmp = tmp->next) {
 		SERVER_SETUP_REC *rec = tmp->data;
 
-		if (g_ascii_strncasecmp(rec->address, word, len) == 0) 
+		if (g_ascii_strncasecmp(rec->address, word, len) == 0)
 			list = g_list_append(list, g_strdup(rec->address));
 	}
 
@@ -814,12 +814,12 @@ GList *completion_get_targets(const char *word)
 
 		list = g_list_append(list, g_strdup(node->key));
 	}
-	
+
 	return list;
 }
 
 static void sig_complete_connect(GList **list, WINDOW_REC *window,
-				 const char *word, const char *line, 
+				 const char *word, const char *line,
 				 int *want_space)
 {
 	g_return_if_fail(list != NULL);
@@ -895,7 +895,7 @@ static void sig_complete_alias(GList **list, WINDOW_REC *window,
 				int *want_space)
 {
 	const char *definition;
-	
+
 	g_return_if_fail(list != NULL);
 	g_return_if_fail(word != NULL);
 	g_return_if_fail(line != NULL);
@@ -905,7 +905,7 @@ static void sig_complete_alias(GList **list, WINDOW_REC *window,
 			*list = g_list_append(NULL, g_strdup(definition));
 			signal_stop();
 		}
-	} else {	
+	} else {
 		*list = completion_get_aliases(word);
 		if (*list != NULL) signal_stop();
 	}
@@ -965,7 +965,7 @@ static void sig_complete_target(GList **list, WINDOW_REC *window,
 				int *want_space)
 {
 	const char *definition;
-	
+
 	g_return_if_fail(list != NULL);
 	g_return_if_fail(word != NULL);
 	g_return_if_fail(line != NULL);
@@ -975,7 +975,7 @@ static void sig_complete_target(GList **list, WINDOW_REC *window,
 			*list = g_list_append(NULL, g_strdup(definition));
 			signal_stop();
 		}
-	} else {	
+	} else {
 		*list = completion_get_targets(word);
 		if (*list != NULL) signal_stop();
 	}

--- a/src/fe-common/core/command-history.c
+++ b/src/fe-common/core/command-history.c
@@ -45,7 +45,7 @@ void command_history_add(HISTORY_REC *history, const char *text)
 	if (link != NULL && strcmp(link->data, text) == 0)
 	  return; /* same as previous entry */
 
-	if (settings_get_int("max_command_history") < 1 || 
+	if (settings_get_int("max_command_history") < 1 ||
 	    history->lines < settings_get_int("max_command_history"))
 		history->lines++;
 	else {
@@ -78,12 +78,12 @@ HISTORY_REC *command_history_find_name(const char *name)
 
 	for (tmp = histories; tmp != NULL; tmp = tmp->next) {
 		HISTORY_REC *rec = tmp->data;
-		
+
 		if (rec->name != NULL &&
 		    g_ascii_strcasecmp(rec->name, name) == 0)
 			return rec;
 	}
-	
+
 	return NULL;
 }
 
@@ -135,7 +135,7 @@ const char *command_history_next(WINDOW_REC *window, const char *text)
 	GList *pos;
 
 	history = command_history_current(window);
-	pos = history->pos; 
+	pos = history->pos;
 
 	if (pos != NULL)
 		history->pos = history->pos->next;
@@ -160,21 +160,21 @@ void command_history_clear_pos_func(HISTORY_REC *history, gpointer user_data)
 
 void command_history_clear_pos(WINDOW_REC *window)
 {
-	g_slist_foreach(histories, 
+	g_slist_foreach(histories,
 		       (GFunc) command_history_clear_pos_func, NULL);
 }
 
 HISTORY_REC *command_history_create(const char *name)
 {
 	HISTORY_REC *rec;
-	
+
 	rec = g_new0(HISTORY_REC, 1);
-	
+
 	if (name != NULL)
 		rec->name = g_strdup(name);
 
 	histories = g_slist_append(histories, rec);
-	
+
 	return rec;
 }
 

--- a/src/fe-common/core/fe-channels.c
+++ b/src/fe-common/core/fe-channels.c
@@ -403,7 +403,7 @@ static void display_sorted_nicks(CHANNEL_REC *channel, GSList *nicklist)
 			nickmode[0] = rec->prefixes[0];
 		else
 			nickmode[0] = ' ';
-		
+
 		if (linebuf_size < columns[col]-item_extra+1) {
 			linebuf_size = (columns[col]-item_extra+1)*2;
                         linebuf = g_realloc(linebuf, linebuf_size);

--- a/src/fe-common/core/fe-ignore.c
+++ b/src/fe-common/core/fe-ignore.c
@@ -65,7 +65,7 @@ static void ignore_print(int index, IGNORE_REC *rec)
 	}
 	if (rec->fullword) g_string_append(options, "-full ");
 	if (rec->replies) g_string_append(options, "-replies ");
-	if (rec->servertag != NULL) 
+	if (rec->servertag != NULL)
 		g_string_append_printf(options, "-network %s ", rec->servertag);
 	if (rec->pattern != NULL)
 		g_string_append_printf(options, "-pattern %s ", rec->pattern);
@@ -137,7 +137,7 @@ static void cmd_ignore(const char *data)
 	/* Allow -ircnet for backwards compatibility */
 	if (!servertag)
 		servertag = g_hash_table_lookup(optlist, "ircnet");
-	
+
 	if (*mask == '\0') cmd_param_error(CMDERR_NOT_ENOUGH_PARAMS);
         if (*levels == '\0') levels = "ALL";
 	level = level2bits(levels, NULL);

--- a/src/fe-common/core/fe-messages.c
+++ b/src/fe-common/core/fe-messages.c
@@ -92,7 +92,7 @@ char *expand_emphasis(WI_ITEM_REC *item, const char *text)
 			   use emphasis on them. */
 			int found;
                         char c;
-			char *end2; 
+			char *end2;
 
 			/* check if _foo_ is a nick */
 			c = end[1];
@@ -234,7 +234,7 @@ static void sig_message_public(SERVER_REC *server, const char *msg,
 				    for_me ? TXT_PUBMSG_ME_CHANNEL :
 				    TXT_PUBMSG_CHANNEL,
 				    printnick, target, msg, nickmode);
-	}						
+	}
 
 	g_free_not_null(nickmode);
 	g_free_not_null(freemsg);

--- a/src/fe-common/core/fe-windows.c
+++ b/src/fe-common/core/fe-windows.c
@@ -184,7 +184,7 @@ void window_change_server(WINDOW_REC *window, void *server)
 	if (window->active_server != active) {
 		window->active_server = active;
 		signal_emit("window server changed", 2, window, active);
-	} 
+	}
 }
 
 void window_set_refnum(WINDOW_REC *window, int refnum)

--- a/src/fe-common/core/hilight-text.h
+++ b/src/fe-common/core/hilight-text.h
@@ -42,7 +42,7 @@ HILIGHT_REC *hilight_match(SERVER_REC *server, const char *channel,
 HILIGHT_REC *hilight_match_nick(SERVER_REC *server, const char *channel,
 			 const char *nick, const char *address,
 			 int level, const char *msg);
-			 
+
 char *hilight_get_color(HILIGHT_REC *rec);
 void hilight_update_text_dest(TEXT_DEST_REC *dest, HILIGHT_REC *rec);
 

--- a/src/fe-common/core/printtext.c
+++ b/src/fe-common/core/printtext.c
@@ -170,13 +170,13 @@ static void print_line(TEXT_DEST_REC *dest, const char *text)
 
 	g_return_if_fail(dest != NULL);
 	g_return_if_fail(text != NULL);
-	
+
         theme = window_get_theme(dest->window);
 	tmp = format_get_level_tag(theme, dest);
 	str = !theme->info_eol ? format_add_linestart(text, tmp) :
 		format_add_lineend(text, tmp);
 	g_free_not_null(tmp);
-	
+
 	/* send both the formatted + stripped (for logging etc.) */
 	stripped = strip_codes(str);
 	signal_emit_id(signal_print_text, 3, dest, str, stripped);

--- a/src/fe-common/core/themes.c
+++ b/src/fe-common/core/themes.c
@@ -385,7 +385,7 @@ char *theme_format_expand_get(THEME_REC *theme, const char **format)
 						 &dummy, &dummy, 0);
 			continue;
 		}
-		
+
 		if (braces == 0) {
 			(*format)++;
 			break;

--- a/src/fe-common/core/wcwidth.c
+++ b/src/fe-common/core/wcwidth.c
@@ -187,7 +187,7 @@ int mk_wcwidth(unichar ucs)
 
   /* if we arrive here, ucs is not a combining or C0/C1 control character */
 
-  return 1 + 
+  return 1 +
     (ucs >= 0x1100 &&
      (ucs <= 0x115f ||                    /* Hangul Jamo init. consonants */
       ucs == 0x2329 || ucs == 0x232a ||

--- a/src/fe-common/core/window-commands.c
+++ b/src/fe-common/core/window-commands.c
@@ -529,7 +529,7 @@ static void cmd_window_item_goto(const char *data, SERVER_REC *server)
 	GSList *tmp;
 	void *free_arg;
 	char *target;
-	
+
 	if (!cmd_get_params(data, &free_arg, 1, &target))
 		return;
 

--- a/src/fe-common/core/windows-layout.c
+++ b/src/fe-common/core/windows-layout.c
@@ -68,7 +68,7 @@ static void sig_layout_restore_item(WINDOW_REC *window, const char *type,
 			   (SIGNAL_FUNC) signal_query_created_curwin);
 
                 restore_win = window;
-		
+
 		protocol = chat_protocol_find(chat_type);
 		if (protocol == NULL)
 			window_bind_add(window, tag, name);

--- a/src/fe-common/irc/dcc/fe-dcc-chat-messages.c
+++ b/src/fe-common/irc/dcc/fe-dcc-chat-messages.c
@@ -60,7 +60,7 @@ static void sig_message_dcc_own_action(CHAT_DCC_REC *dcc, const char *msg)
 	format_create_dest_tag(&dest, dcc->server, dcc->servertag, tag,
 			       MSGLEVEL_DCCMSGS | MSGLEVEL_ACTIONS |
 			       MSGLEVEL_NOHILIGHT | MSGLEVEL_NO_ACT, NULL);
-        
+
         printformat_dest(&dest, query != NULL ? IRCTXT_OWN_DCC_ACTION_QUERY :
 			 IRCTXT_OWN_DCC_ACTION, dcc->mynick, dcc->id, msg);
         g_free(tag);

--- a/src/fe-common/irc/fe-events-numeric.c
+++ b/src/fe-common/irc/fe-events-numeric.c
@@ -118,7 +118,7 @@ static void event_who(IRC_SERVER_REC *server, const char *data)
 	while (*realname != '\0' && *realname != ' ') realname++;
 	if (*realname == ' ')
 		*realname++ = '\0';
-	
+
 	recoded = recode_in(SERVER(server), realname, nick);
 	printformat(server, NULL, MSGLEVEL_CRAP, IRCTXT_WHO,
 		    channel, nick, stat, hops, user, host, recoded, serv);

--- a/src/fe-common/irc/fe-irc-commands.c
+++ b/src/fe-common/irc/fe-irc-commands.c
@@ -115,9 +115,9 @@ static void cmd_notice(const char *data, IRC_SERVER_REC *server,
 
 	if (*target == '\0' || *msg == '\0')
 		cmd_param_error(CMDERR_NOT_ENOUGH_PARAMS);
-		
+
 	signal_emit("message irc own_notice", 3, server, msg, target);
-	
+
 	cmd_params_free(free_arg);
 }
 

--- a/src/fe-common/irc/fe-irc-messages.c
+++ b/src/fe-common/irc/fe-irc-messages.c
@@ -87,7 +87,7 @@ static void sig_message_own_public(SERVER_REC *server, const char *msg,
 		g_free(nickmode);
                 signal_stop();
 	}
-	
+
 }
 
 /* received msg to all ops in channel */
@@ -201,7 +201,7 @@ static void sig_message_irc_action(IRC_SERVER_REC *server, const char *msg,
 			    IRCTXT_ACTION_PRIVATE_QUERY,
 			    nick, address == NULL ? "" : address, msg);
 	}
-	
+
 	g_free_not_null(freemsg);
 }
 
@@ -219,7 +219,7 @@ static void sig_message_irc_notice(SERVER_REC *server, const char *msg,
 {
 	const char *oldtarget;
 	int level = MSGLEVEL_NOTICES;
-	
+
 	oldtarget = target;
 	target = skip_target(IRC_SERVER(server), target);
 

--- a/src/fe-common/irc/fe-irc-server.c
+++ b/src/fe-common/irc/fe-irc-server.c
@@ -63,7 +63,7 @@ static void sig_server_add_fill(IRC_SERVER_SETUP_REC *rec,
 	char *value;
 
 	value = g_hash_table_lookup(optlist, "network");
-	/* For backwards compatibility, also allow the old name 'ircnet'. 
+	/* For backwards compatibility, also allow the old name 'ircnet'.
 	   But of course only if -network was not given. */
 	if (!value)
 		value = g_hash_table_lookup(optlist, "ircnet");
@@ -121,7 +121,7 @@ static void cmd_server_list(const char *data)
 				g_string_append_printf(str, "ssl_cafile: %s, ", rec->ssl_cafile);
 			if (rec->ssl_capath)
 				g_string_append_printf(str, "ssl_capath: %s, ", rec->ssl_capath);
-			
+
 		}
 		if (rec->max_cmds_at_once > 0)
 			g_string_append_printf(str, "cmdmax: %d, ", rec->max_cmds_at_once);

--- a/src/fe-common/irc/fe-whois.c
+++ b/src/fe-common/irc/fe-whois.c
@@ -409,7 +409,7 @@ void fe_whois_init(void)
 
 	signal_add("event 311", (SIGNAL_FUNC) event_whois);
 	signal_add("event 312", (SIGNAL_FUNC) event_whois_server);
-	/* readding this events fixes the printing of /whois -yes * 
+	/* readding this events fixes the printing of /whois -yes *
 	   Bug http://bugs.irssi.org/?do=details&id=123 */
 	signal_add("event 317", (SIGNAL_FUNC) event_whois_idle);
 	signal_add("event 319", (SIGNAL_FUNC) event_whois_channels);

--- a/src/fe-text/gui-entry.c
+++ b/src/fe-text/gui-entry.c
@@ -226,8 +226,8 @@ static void gui_entry_draw_from(GUI_ENTRY_REC *entry, int pos)
 	int i;
 	int xpos, end_xpos;
 
-	xpos = entry->xpos + entry->promptlen + 
-		pos2scrpos(entry, pos + entry->scrstart) - 
+	xpos = entry->xpos + entry->promptlen +
+		pos2scrpos(entry, pos + entry->scrstart) -
 		pos2scrpos(entry, entry->scrstart);
         end_xpos = entry->xpos + entry->width;
 
@@ -730,7 +730,7 @@ void gui_entry_transpose_words(GUI_ENTRY_REC *entry)
 		g_free(second);
 
 	}
-	
+
 	gui_entry_redraw_from(entry, spos1);
 	gui_entry_fix_cursor(entry);
 	gui_entry_draw(entry);

--- a/src/fe-text/irssi.c
+++ b/src/fe-text/irssi.c
@@ -346,9 +346,9 @@ int main(int argc, char **argv)
 	   before this call.
 
 	   locales aren't actually used for anything else than autodetection
-	   of UTF-8 currently..  
+	   of UTF-8 currently..
 
-	   furthermore to get the users's charset with g_get_charset() properly 
+	   furthermore to get the users's charset with g_get_charset() properly
 	   you have to call setlocale(LC_ALL, "") */
 	setlocale(LC_ALL, "");
 

--- a/src/fe-text/statusbar.c
+++ b/src/fe-text/statusbar.c
@@ -668,7 +668,7 @@ void statusbar_item_default_handler(SBAR_ITEM_REC *item, int get_size_only,
 				    int escape_vars)
 {
 	SERVER_REC *server;
-	WI_ITEM_REC *wiitem; 
+	WI_ITEM_REC *wiitem;
 	char *tmpstr, *tmpstr2;
 	theme_rm_col reset;
 	strcpy(reset.m, "n");

--- a/src/fe-text/textbuffer-view.c
+++ b/src/fe-text/textbuffer-view.c
@@ -1228,7 +1228,7 @@ void textbuffer_view_remove_line(TEXT_BUFFER_VIEW_REC *view, LINE_REC *line)
 void textbuffer_view_remove_lines_by_level(TEXT_BUFFER_VIEW_REC *view, int level)
 {
 	LINE_REC *line, *next;
-	
+
 	term_refresh_freeze();
 	line = textbuffer_view_get_lines(view);
 

--- a/src/fe-text/textbuffer-view.h
+++ b/src/fe-text/textbuffer-view.h
@@ -72,7 +72,7 @@ struct _TEXT_BUFFER_VIEW_REC {
 
 	/* how many empty lines are in screen. a screenful when started
 	   or used /CLEAR */
-	int empty_linecount; 
+	int empty_linecount;
         /* window is at the bottom of the text buffer */
 	unsigned int bottom:1;
         /* if !bottom - new text has been printed since we were at bottom */

--- a/src/irc/core/bans.c
+++ b/src/irc/core/bans.c
@@ -309,7 +309,7 @@ static void cmd_unban(const char *data, IRC_SERVER_REC *server, void *item)
 		ban = g_strdup(BAN_LAST);
 
 	command_set_ban(ban ? ban : data, server, item, FALSE, 0);
-	
+
 	g_free(ban);
 
 	cmd_params_free(free_arg);

--- a/src/irc/core/channel-events.c
+++ b/src/irc/core/channel-events.c
@@ -123,10 +123,10 @@ static void channel_change_topic(IRC_SERVER_REC *server, const char *channel,
 {
 	CHANNEL_REC *chanrec;
 	char *recoded = NULL;
-	
+
 	chanrec = channel_find(SERVER(server), channel);
 	if (chanrec == NULL) return;
-	/* the topic may be send out encoded, so we need to 
+	/* the topic may be send out encoded, so we need to
 	   recode it back or /topic <tab> will not work properly */
 	recoded = recode_in(SERVER(server), topic, channel);
 	if (topic != NULL) {
@@ -137,7 +137,7 @@ static void channel_change_topic(IRC_SERVER_REC *server, const char *channel,
 
 	g_free_not_null(chanrec->topic_by);
 	chanrec->topic_by = g_strdup(setby);
-	
+
 	chanrec->topic_time = settime;
 
 	signal_emit("channel topic changed", 1, chanrec);

--- a/src/irc/core/channel-rejoin.c
+++ b/src/irc/core/channel-rejoin.c
@@ -84,7 +84,7 @@ static int channel_rejoin(IRC_SERVER_REC *server, const char *channel)
 		channel_destroy(CHANNEL(chanrec));
 		return 0;
 	}
-	
+
 	rec = rejoin_find(server, channel);
 	if (rec != NULL) {
 		/* already exists */

--- a/src/irc/core/irc-channels.c
+++ b/src/irc/core/irc-channels.c
@@ -114,7 +114,7 @@ static void irc_channels_join(IRC_SERVER_REC *server, const char *data,
                 	                use_keys = TRUE;
 					key = schannel->password;
 				} else key = NULL;
-				
+
 				g_string_append_printf(outkeys, "%s,", get_join_key(key));
 				channame = channel + (channel[0] == '!' &&
 						      channel[1] == '!');
@@ -126,11 +126,11 @@ static void irc_channels_join(IRC_SERVER_REC *server, const char *data,
 
 			if (*tmpkey != NULL)
                 	        tmpkey++;
-	
+
 			tmpstr = tmp;
 			tmpstr++;
 			cmdlen = outchans->len-1;
-			
+
 			if (use_keys)
 				cmdlen += outkeys->len;
 			if (*tmpstr != NULL)
@@ -138,8 +138,8 @@ static void irc_channels_join(IRC_SERVER_REC *server, const char *data,
 					  strlen(*tmpstr)+1;
 			if (*tmpkey != NULL)
 				cmdlen += strlen(*tmpkey);
-				
-			/* don't try to send too long lines 
+
+			/* don't try to send too long lines
 			   make sure it's not longer than 510
 			   so 510 - strlen("JOIN ") = 505 */
 			if (cmdlen < 505)

--- a/src/irc/core/irc-commands.c
+++ b/src/irc/core/irc-commands.c
@@ -790,7 +790,7 @@ static void cmd_knockout(const char *data, IRC_SERVER_REC *server,
 
 	bancmd = *banmasks == '\0'? NULL :
 		g_strdup_printf("%s %s", channel->name, banmasks);
-	
+
         if (settings_get_bool("kick_first_on_kickban")) {
 		signal_emit("command kick", 3, kickcmd, server, channel);
 		if (bancmd != NULL)
@@ -894,7 +894,7 @@ static void cmd_accept(const char *data, IRC_SERVER_REC *server)
 {
         CMD_IRC_SERVER(server);
 
-	if (*data == '\0') 
+	if (*data == '\0')
 		irc_send_cmd(server, "ACCEPT *");
 	else
 		irc_send_cmdv(server, "ACCEPT %s", data);
@@ -905,7 +905,7 @@ static void cmd_unsilence(const char *data, IRC_SERVER_REC *server)
 {
         CMD_IRC_SERVER(server);
 
-	if (*data == '\0') 
+	if (*data == '\0')
 		cmd_return_error(CMDERR_NOT_ENOUGH_PARAMS);
 
 	irc_send_cmdv(server, "SILENCE -%s", data);

--- a/src/irc/core/irc-nicklist.c
+++ b/src/irc/core/irc-nicklist.c
@@ -195,7 +195,7 @@ static void event_end_of_names(IRC_SERVER_REC *server, const char *data)
 	IRC_CHANNEL_REC *chanrec;
 	NICK_REC *ownnick;
 	int nicks;
-	
+
 	g_return_if_fail(server != NULL);
 
 	params = event_get_params(data, 2, NULL, &channel);
@@ -384,7 +384,7 @@ static void event_nick_in_use(IRC_SERVER_REC *server, const char *data)
 
 	cmd = g_strdup_printf("NICK %s", server->nick);
 	irc_send_cmd_now(server, cmd);
-	g_free(cmd);	
+	g_free(cmd);
 }
 
 static void event_target_unavailable(IRC_SERVER_REC *server, const char *data)

--- a/src/irc/core/irc-servers-reconnect.c
+++ b/src/irc/core/irc-servers-reconnect.c
@@ -71,7 +71,7 @@ static void sig_connected(IRC_SERVER_REC *server)
 		return;
 
 	if (server->connrec->away_reason != NULL)
-		irc_server_send_away(server, server->connrec->away_reason); 
+		irc_server_send_away(server, server->connrec->away_reason);
 }
 
 static void event_nick_collision(IRC_SERVER_REC *server, const char *data)

--- a/src/irc/core/irc-servers.c
+++ b/src/irc/core/irc-servers.c
@@ -753,7 +753,7 @@ static void event_isupport(IRC_SERVER_REC *server, const char *data)
 	char **item, *sptr, *eptr;
 	char **isupport;
 	gpointer key, value;
-   
+
 	g_return_if_fail(server != NULL);
 
 	server->isupport_sent = TRUE;

--- a/src/irc/core/irc-session.c
+++ b/src/irc/core/irc-session.c
@@ -69,7 +69,7 @@ static void sig_session_save_server(IRC_SERVER_REC *server, CONFIG_REC *config,
         isupport = config_node_section(node, "isupport", NODE_TYPE_BLOCK);
         isupport_data.config = config;
         isupport_data.node = isupport;
-		        
+
         g_hash_table_foreach(server->isupport, (GHFunc) session_isupport_foreach, &isupport_data);
 }
 

--- a/src/irc/core/modes.c
+++ b/src/irc/core/modes.c
@@ -78,7 +78,7 @@ void prefix_add(char prefixes[MAX_USER_PREFIXES+1], char newprefix, SERVER_REC *
 
 		if (*prefixlst == newprefix)
 			break; /* insert the new prefix here */
-		
+
 		if (*prefixlst == prefixes[oldpos]) {
 			/* this prefix is present.
 			 * the one we are inserting goes after it.
@@ -88,7 +88,7 @@ void prefix_add(char prefixes[MAX_USER_PREFIXES+1], char newprefix, SERVER_REC *
 		}
 		prefixlst++;
 	}
-	
+
 	/* newpos is now the position in which we wish to insert the prefix */
 	newprefixes[newpos++] = newprefix;
 
@@ -274,7 +274,7 @@ void modes_type_b(IRC_CHANNEL_REC *channel, const char *setby, char type,
 				channel->key = g_strdup(arg);
 		}
 	}
-	
+
 	mode_set_arg(channel->server, newmode, type, mode, arg, FALSE);
 }
 
@@ -285,7 +285,7 @@ void modes_type_c(IRC_CHANNEL_REC *channel, const char *setby,
 	if (mode == 'l') {
 		channel->limit = type == '-' ? 0 : atoi(arg);
 	}
-	
+
 	mode_set_arg(channel->server, newmode, type, mode, arg, FALSE);
 }
 

--- a/src/irc/dcc/dcc-chat.c
+++ b/src/irc/dcc/dcc-chat.c
@@ -428,7 +428,7 @@ static void dcc_chat_passive(CHAT_DCC_REC *dcc)
 	dcc_ip2str(&own_ip, host);
 	irc_send_cmdv(dcc->server, "PRIVMSG %s :\001DCC CHAT CHAT %s %d %d\001",
 		      dcc->nick, host, port, dcc->pasv_id);
-         
+
 }
 
 /* SYNTAX: DCC CHAT [-passive] [<nick>] */
@@ -615,7 +615,7 @@ static void ctcp_msg_dcc_chat(IRC_SERVER_REC *server, const char *data,
 	char **params;
 	int paramcount;
         int passive, autoallow = FALSE;
-	
+
         /* CHAT <unused> <address> <port> */
 	/* CHAT <unused> <address> 0 <id> (DCC CHAT passive protocol) */
 	params = g_strsplit(data, " ", -1);
@@ -656,14 +656,14 @@ static void ctcp_msg_dcc_chat(IRC_SERVER_REC *server, const char *data,
 			}
 		}
 	}
-	
+
 	dcc = dcc_chat_create(server, chat, nick, params[0]);
 	dcc->target = g_strdup(target);
 	dcc->port = atoi(params[2]);
-	
+
 	if (passive)
 		dcc->pasv_id = atoi(params[3]);
-	
+
 	dcc_str2ip(params[1], &dcc->addr);
 	net_ip2host(&dcc->addr, dcc->addrstr);
 

--- a/src/irc/dcc/dcc-get.c
+++ b/src/irc/dcc/dcc-get.c
@@ -454,7 +454,7 @@ static void ctcp_msg_dcc_send(IRC_SERVER_REC *server, const char *data,
 		g_memmove(fname, fname+1, len);
                 quoted = TRUE;
 	}
-    
+
 	if (passive && port != 0) {
 		/* This is NOT a DCC SEND request! This is a reply to our
 		   passive request. We MUST check the IDs and then connect to
@@ -501,7 +501,7 @@ static void ctcp_msg_dcc_send(IRC_SERVER_REC *server, const char *data,
 
 	if (passive && port == 0)
 		dcc->pasv_id = p_id; /* Assign the ID to the DCC */
-    
+
 	memcpy(&dcc->addr, &ip, sizeof(ip));
 	if (dcc->addr.family == AF_INET)
 		net_ip2host(&dcc->addr, dcc->addrstr);

--- a/src/irc/dcc/dcc-resume.c
+++ b/src/irc/dcc/dcc-resume.c
@@ -94,7 +94,7 @@ static int dcc_ctcp_resume_parse(int type, const char *data, const char *nick,
 		return 0;
 
 	fileparams = get_file_params_count_resume(params, paramcount);
-    
+
 	if (paramcount >= fileparams + 2) {
 		port = atoi(params[fileparams]);
 		*size = str_to_uofft(params[fileparams+1]);

--- a/src/irc/dcc/dcc-send.c
+++ b/src/irc/dcc/dcc-send.c
@@ -194,7 +194,7 @@ static void cmd_dcc_send(const char *data, IRC_SERVER_REC *server,
 		cmd_param_error(CMDERR_NOT_CONNECTED);
 
 	passive = g_hash_table_lookup(optlist, "passive") != NULL;
-    
+
 	if (g_hash_table_lookup(optlist, "rmhead") != NULL) {
 		queue = dcc_queue_old(nick, servertag);
 		if (queue != -1)
@@ -217,7 +217,7 @@ static void cmd_dcc_send(const char *data, IRC_SERVER_REC *server,
 
 		if (*fileargs == '\0')
 			cmd_param_error(CMDERR_NOT_ENOUGH_PARAMS);
-        
+
 		dcc_send_add(servertag, chat, nick, fileargs, mode, passive);
 	}
 
@@ -434,11 +434,11 @@ static int dcc_send_one_file(int queue, const char *target, const char *fname,
 	if (passive) {
 		dcc->pasv_id = rand() % 64;
 	}
-    
+
 	/* send DCC request */
 	signal_emit("dcc request send", 1, dcc);
 
-    
+
 	dcc_ip2str(&own_ip, host);
 	if (passive == FALSE) {
 		str = g_strdup_printf(dcc->file_quoted ?

--- a/src/irc/dcc/dcc.c
+++ b/src/irc/dcc/dcc.c
@@ -90,9 +90,9 @@ void dcc_init_rec(DCC_REC *dcc, IRC_SERVER_REC *server, CHAT_DCC_REC *chat,
 
 	dcc->servertag = server != NULL ? g_strdup(server->tag) :
 		(chat == NULL ? NULL : g_strdup(chat->servertag));
-	
+
 	dcc->pasv_id = -1; /* Not a passive DCC */
-	
+
 	dcc_conns = g_slist_append(dcc_conns, dcc);
 	signal_emit("dcc created", 1, dcc);
 }
@@ -454,8 +454,8 @@ static int dcc_timeout_func(void)
 			/* Timed out - don't send DCC REJECT CTCP so CTCP
 			   flooders won't affect us and it really doesn't
 			   matter that much anyway if the other side doen't
-			   get it.. 
-			   
+			   get it..
+
 			   We don't want dcc servers to time out. */
 			dcc_close(dcc);
 		}

--- a/src/irc/dcc/dcc.h
+++ b/src/irc/dcc/dcc.h
@@ -27,7 +27,7 @@ typedef struct {
 /* passive DCC */
 #define dcc_is_passive(dcc) \
 	((dcc)->pasv_id >= 0)
-		
+
 extern GSList *dcc_conns;
 
 void dcc_register_type(const char *type);

--- a/src/irc/flood/autoignore.c
+++ b/src/irc/flood/autoignore.c
@@ -38,7 +38,7 @@ void autoignore_update(IGNORE_REC *rec, int level)
 	ignore_update_rec(rec);
 }
 
-void autoignore_add(IRC_SERVER_REC *server, char *mask, int level) 
+void autoignore_add(IRC_SERVER_REC *server, char *mask, int level)
 {
 	IGNORE_REC *rec;
 

--- a/src/irc/proxy/listen.c
+++ b/src/irc/proxy/listen.c
@@ -178,7 +178,7 @@ static void handle_client_cmd(CLIENT_REC *client, char *cmd, char *args,
 			                                      rec->proxy_address, rec->nick, rec->listen->ircnet);
 						rec->want_ctcp = 0;
 		                }
-						                                      
+
 			}
 			proxy_outdata(client, ":%s NOTICE %s :You're now receiving CTCPs sent to %s\n",
 				      client->proxy_address, client->nick,client->listen->ircnet);
@@ -421,7 +421,7 @@ static void sig_server_event(IRC_SERVER_REC *server, const char *line,
 		/* CTCP - either answer ourself or forward it to one client */
 		for (tmp = proxy_clients; tmp != NULL; tmp = tmp->next) {
 	        	CLIENT_REC *rec = tmp->data;
-		                        
+
 			if (rec->want_ctcp == 1) {
                         	/* only CTCP for the chatnet where client is connected to will be forwarded */
                         	if (strstr(rec->proxy_address, server->connrec->chatnet) != NULL) {

--- a/src/perl/perl-common.c
+++ b/src/perl/perl-common.c
@@ -629,7 +629,7 @@ static void perl_register_protocol(CHAT_PROTOCOL_REC *rec)
 		perl_eval_pv(code, TRUE);
 	}
 
-	pcode = g_strdup_printf(find_use_code, 
+	pcode = g_strdup_printf(find_use_code,
 	                        settings_get_str("perl_use_lib"), name);
 	sv = perl_eval_pv(pcode, TRUE);
 	g_free(pcode);

--- a/src/perl/perl-signals.c
+++ b/src/perl/perl-signals.c
@@ -475,7 +475,7 @@ void perl_command_bind_to(const char *cmd, const char *category,
 	g_free(signal);
 }
 
-void perl_command_runsub(const char *cmd, const char *data, 
+void perl_command_runsub(const char *cmd, const char *data,
 			 SERVER_REC *server, WI_ITEM_REC *item)
 {
 	command_runsub(cmd, data, server, item);

--- a/src/perl/perl-signals.h
+++ b/src/perl/perl-signals.h
@@ -21,7 +21,7 @@ void perl_command_bind_to(const char *cmd, const char *category,
 
 void perl_command_unbind(const char *cmd, SV *func);
 
-void perl_command_runsub(const char *cmd, const char *data, 
+void perl_command_runsub(const char *cmd, const char *data,
 			 SERVER_REC *server, WI_ITEM_REC *item);
 
 void perl_signal_register(const char *signal, const char **args);


### PR DESCRIPTION
cleaning up the sourcecode by removing all trailing whitespaces and tabs.
