### PR TITLE
Fix use-after-free bug with cached settings values

### DIFF
--- a/src/core/expandos.c
+++ b/src/core/expandos.c
@@ -57,7 +57,7 @@ static char *last_sent_msg, *last_sent_msg_body;
 static char *last_privmsg_from, *last_public_from;
 static char *sysname, *sysrelease, *sysarch;
 
-static const char *timestamp_format;
+static char *timestamp_format;
 static int timestamp_seconds;
 static time_t last_timestamp;
 
@@ -567,7 +567,9 @@ static int sig_timer(void)
 
 static void read_settings(void)
 {
-	timestamp_format = settings_get_str("timestamp_format");
+	g_free_not_null(timestamp_format);
+	timestamp_format = g_strdup(settings_get_str("timestamp_format"));
+
 	timestamp_seconds =
 		strstr(timestamp_format, "%r") != NULL ||
 		strstr(timestamp_format, "%s") != NULL ||
@@ -708,14 +710,18 @@ void expandos_deinit(void)
 		g_free_not_null(char_expandos[n]);
 
 	g_hash_table_foreach_remove(expandos, free_expando, NULL);
-        g_hash_table_destroy(expandos);
+	g_hash_table_destroy(expandos);
 
-	g_free_not_null(last_sent_msg); g_free_not_null(last_sent_msg_body);
-	g_free_not_null(last_privmsg_from); g_free_not_null(last_public_from);
-	g_free_not_null(sysname); g_free_not_null(sysrelease);
-        g_free_not_null(sysarch);
+	g_free_not_null(last_sent_msg);
+	g_free_not_null(last_sent_msg_body);
+	g_free_not_null(last_privmsg_from);
+	g_free_not_null(last_public_from);
+	g_free_not_null(sysname);
+	g_free_not_null(sysrelease);
+	g_free_not_null(sysarch);
+	g_free_not_null(timestamp_format);
 
-        g_source_remove(timer_tag);
+	g_source_remove(timer_tag);
 	signal_remove("message public", (SIGNAL_FUNC) sig_message_public);
 	signal_remove("message private", (SIGNAL_FUNC) sig_message_private);
 	signal_remove("message own_private", (SIGNAL_FUNC) sig_message_own_private);

--- a/src/core/log.c
+++ b/src/core/log.c
@@ -41,7 +41,7 @@ static const char *log_item_types[] = {
 	NULL
 };
 
-const char *log_timestamp;
+static char *log_timestamp;
 static int log_file_create_mode;
 static int log_dir_create_mode;
 static int rotate_tag;
@@ -558,13 +558,15 @@ static void log_read_config(void)
 
 static void read_settings(void)
 {
-	log_timestamp = settings_get_str("log_timestamp");
+	g_free_not_null(log_timestamp);
+	log_timestamp = g_strdup(settings_get_str("log_timestamp"));
+
 	log_file_create_mode = octal2dec(settings_get_int("log_create_mode"));
 
-        log_dir_create_mode = log_file_create_mode;
-        if (log_file_create_mode & 0400) log_dir_create_mode |= 0100;
-        if (log_file_create_mode & 0040) log_dir_create_mode |= 0010;
-        if (log_file_create_mode & 0004) log_dir_create_mode |= 0001;
+	log_dir_create_mode = log_file_create_mode;
+	if (log_file_create_mode & 0400) log_dir_create_mode |= 0100;
+	if (log_file_create_mode & 0040) log_dir_create_mode |= 0010;
+	if (log_file_create_mode & 0004) log_dir_create_mode |= 0001;
 }
 
 void log_init(void)
@@ -595,7 +597,9 @@ void log_deinit(void)
 	while (logs != NULL)
 		log_close(logs->data);
 
+	g_free_not_null(log_timestamp);
+
 	signal_remove("setup changed", (SIGNAL_FUNC) read_settings);
-        signal_remove("setup reread", (SIGNAL_FUNC) log_read_config);
-        signal_remove("irssi init finished", (SIGNAL_FUNC) log_read_config);
+	signal_remove("setup reread", (SIGNAL_FUNC) log_read_config);
+	signal_remove("irssi init finished", (SIGNAL_FUNC) log_read_config);
 }

--- a/src/fe-common/core/chat-completion.c
+++ b/src/fe-common/core/chat-completion.c
@@ -40,7 +40,7 @@
 
 static int keep_privates_count, keep_publics_count;
 static int completion_lowercase;
-static const char *completion_char, *cmdchars;
+static char *completion_char, *cmdchars;
 static GSList *global_lastmsgs;
 static int completion_auto, completion_strict;
 
@@ -1126,10 +1126,15 @@ static void read_settings(void)
 	keep_privates_count = settings_get_int("completion_keep_privates");
 	keep_publics_count = settings_get_int("completion_keep_publics");
 	completion_lowercase = settings_get_bool("completion_nicks_lowercase");
-	completion_char = settings_get_str("completion_char");
-	cmdchars = settings_get_str("cmdchars");
+
 	completion_auto = settings_get_bool("completion_auto");
 	completion_strict = settings_get_bool("completion_strict");
+
+	g_free_not_null(completion_char);
+	completion_char = g_strdup(settings_get_str("completion_char"));
+
+	g_free_not_null(cmdchars);
+	cmdchars = g_strdup(settings_get_str("cmdchars"));
 
 	if (*completion_char == '\0') {
                 /* this would break.. */
@@ -1220,4 +1225,7 @@ void chat_completion_deinit(void)
 	signal_remove("server disconnected", (SIGNAL_FUNC) sig_server_disconnected);
 	signal_remove("channel destroyed", (SIGNAL_FUNC) sig_channel_destroyed);
 	signal_remove("setup changed", (SIGNAL_FUNC) read_settings);
+
+	g_free_not_null(completion_char);
+	g_free_not_null(cmdchars);
 }


### PR DESCRIPTION
This patch fixes a couple of use-after-free bugs when caching various
string related setting values.

Fixes: #143
