### PR TITLE
Try to split long lines on spaces

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 v0.8.18-head 2014-XX-YY  The Irssi team <staff@irssi.org>
 	+ Disable SSLv3 due to the POODLE vulnerability.
+	+ Try to split long lines on spaces to avoid words being splitted. Adds
+	  a new option: 'split_line_on_space' which defaults to on.
 
 v0.8.17 2014-10-11  The Irssi team <staff@irssi.org>
 	+ Document that SSL connections aren't properly handled during /UPGRADE. See Github PR #39.

--- a/src/core/misc.c
+++ b/src/core/misc.c
@@ -967,19 +967,30 @@ char *ascii_strdown(char *str)
 	return str;
 }
 
-char **strsplit_len(const char *str, int len)
+char **strsplit_len(const char *str, int len, gboolean onspace)
 {
-	char **ret;
-	size_t total_len = strlen(str);
-	int n = total_len / len;
-	int i;
+	char **ret = g_new(char *, 1);
+	int n;
+	int offset;
 
-	if (total_len % len)
-		n++;
-
-	ret = g_new(char *, n + 1);
-	for (i = 0; i < n; i++, str += len)
-		ret[i] = g_strndup(str, len);
+	for (n = 0; *str != '\0'; n++, str += MIN(len - offset, strlen(str))) {
+		offset = 0;
+		if (onspace) {
+			/*
+			 * Try to find a space to split on and leave
+			 * the space on the previous line.
+			 */
+			int i;
+			for (i = 0; i < len; i++) {
+				if (str[len-1-i] == ' ') {
+					offset = i;
+					break;
+				}
+			}
+		}
+		ret[n] = g_strndup(str, len - offset);
+		ret = g_renew(char *, ret, n + 2);
+	}
 	ret[n] = NULL;
 
 	return ret;

--- a/src/core/misc.h
+++ b/src/core/misc.h
@@ -116,6 +116,6 @@ uoff_t str_to_uofft(const char *str);
 int find_substr(const char *list, const char *item);
 
 /* split `str' into `len' sized substrings */
-char **strsplit_len(const char *str, int len);
+char **strsplit_len(const char *str, int len, gboolean onspace);
 
 #endif

--- a/src/core/recode.h
+++ b/src/core/recode.h
@@ -4,7 +4,7 @@
 char *recode_in (const SERVER_REC *server, const char *str, const char *target);
 char *recode_out (const SERVER_REC *server, const char *str, const char *target);
 char **recode_split(const SERVER_REC *server, const char *str,
-		    const char *target, int len);
+		    const char *target, int len, gboolean onspace);
 gboolean is_valid_charset(const char *charset);
 gboolean is_utf8(void);
 void recode_update_charset(void);

--- a/src/irc/core/irc-servers.c
+++ b/src/irc/core/irc-servers.c
@@ -85,6 +85,7 @@ static char **split_line(const SERVER_REC *server, const char *line,
 {
 	const char *start = settings_get_str("split_line_start");
 	const char *end = settings_get_str("split_line_end");
+	gboolean onspace = settings_get_bool("split_line_on_space");
 	char *recoded_start = recode_out(server, start, target);
 	char *recoded_end = recode_out(server, end, target);
 	char **lines;
@@ -103,7 +104,7 @@ static char **split_line(const SERVER_REC *server, const char *line,
 		return NULL;
 	}
 
-	lines = recode_split(server, line, target, len);
+	lines = recode_split(server, line, target, len, onspace);
 	for (i = 0; lines[i] != NULL; i++) {
 		if (i != 0 && *start != '\0') {
 			/* Not the first line. */
@@ -972,6 +973,7 @@ void irc_servers_init(void)
 	settings_add_str("misc", "usermode", DEFAULT_USER_MODE);
 	settings_add_str("misc", "split_line_start", "");
 	settings_add_str("misc", "split_line_end", "");
+	settings_add_bool("misc", "split_line_on_space", TRUE);
 	settings_add_time("flood", "cmd_queue_speed", DEFAULT_CMD_QUEUE_SPEED);
 	settings_add_int("flood", "cmds_max_at_once", DEFAULT_CMDS_MAX_AT_ONCE);
 


### PR DESCRIPTION
I didn't add this in the first splitlong-PR because I thought it was a bad idea: it's dependent on the terminal encoding; but a couple of users said they want this and the most common encodings uses ASCII spaces anyway, so it should work properly for the majority. Spaces are left intact on the previous line, so if a user has an encoding where 0x20 isn't space, it won't get removed. It can be turned off with the option "split_line_on_space".