### PR TITLE
Tiny fix to the param order in the /SERVER REMOVE help

### DIFF
--- a/docs/help/in/server.in
+++ b/docs/help/in/server.in
@@ -61,7 +61,7 @@
     /SERVER CONNECT +chat.freenode.net
     /SERVER ADD -network Freenode -noautosendcmd orwell.freenode.net
     /SERVER ADD -! -auto -host staff.irssi.org -port 6667 -4 -network Freenode -noproxy orwell.freenode.net
-    /SERVER REMOVE -network Freenode orwell.freenode.net
+    /SERVER REMOVE orwell.freenode.net Freenode
     /SERVER PURGE
     /SERVER PURGE orwell.freenode.net
 


### PR DESCRIPTION
Not much to see here, just a documentation fix.

Unrelated, but I'd like to use this opportunity to whine about how much I hate the fact that `/server` is also the command to switch the current connected server to a different address
