### PR TITLE
Receive 'self messages' in the right query window

### DIFF
--- a/src/fe-common/core/fe-queries.c
+++ b/src/fe-common/core/fe-queries.c
@@ -326,12 +326,15 @@ static int sig_query_autoclose(void)
 }
 
 static void sig_message_private(SERVER_REC *server, const char *msg,
-				const char *nick, const char *address)
+				const char *nick, const char *address, const char *target)
 {
 	QUERY_REC *query;
 
+	/* own message returned by bouncer? */
+	int own = (!strcmp(nick, server->nick));
+
 	/* create query window if needed */
-	query = privmsg_get_query(server, nick, FALSE, MSGLEVEL_MSGS);
+	query = privmsg_get_query(server, own ? target : nick, FALSE, MSGLEVEL_MSGS);
 
 	/* reset the query's last_unread_msg timestamp */
         if (query != NULL)


### PR DESCRIPTION
Original patch by `hondza <sedaj2@gmail.com>`, from [FS#833](http://bugs.irssi.org/index.php?do=details&task_id=833). I applied several needed style changes, and rebased to current HEAD.

This implements the IRCv3.2 [self-message](https://github.com/ircv3/ircv3-specifications/blob/master/extensions/self-message-3.2.md) extension partially (we can't announce its support through CAP yet). This is also the format used by the [privmsg](http://wiki.znc.in/Privmsg) znc module, and is already implemented by [several other clients](http://wiki.znc.in/Privmsg).

---

Simple standalone testing script:

```
cat > input <<EOF
:localhost 001 you :welcome
:someone!someone@localhost PRIVMSG you :message sent from someone
:you!you@localhost PRIVMSG someone :own message, to someone
EOF

cat input - | nc -l -p 6667
```

And connect irssi to localhost:6667, it should show the two messages in the same query window.
