### PR TITLE
Die if the wrong type of node is found when traversing config

### DIFF
--- a/src/lib-config/get.c
+++ b/src/lib-config/get.c
@@ -109,6 +109,12 @@ CONFIG_NODE *config_node_traverse(CONFIG_REC *rec, const char *section, int crea
 	}
 	g_strfreev(list);
 
+        if (!is_node_list(node)) {
+		/* Will die. Better to not corrupt the config further in this case. */
+		g_error("Attempt to use non-list node as list. Corrupt config?");
+		return NULL;
+	}
+
 	/* save to cache */
         str = g_strdup(section);
 	g_hash_table_insert(rec->cache, str, node);


### PR DESCRIPTION
Fixes issue #187. It's a bit annoying this can't do anything other than
exit, however as there's no schema for the config it's only possible to
validate on use. This level of config can't be accessed from Perl so a
script can't cause Irssi to die (via this method at least).