### PR TITLE
handle an already used nick different from the one we send

### DIFF
--- a/src/irc/core/irc-nicklist.c
+++ b/src/irc/core/irc-nicklist.c
@@ -343,7 +343,7 @@ static void event_nick_invalid(IRC_SERVER_REC *server, const char *data)
 
 static void event_nick_in_use(IRC_SERVER_REC *server, const char *data)
 {
-	char *str, *cmd;
+	char *str, *cmd, *params, *nick;
 	int n;
 
 	g_return_if_fail(data != NULL);
@@ -352,6 +352,14 @@ static void event_nick_in_use(IRC_SERVER_REC *server, const char *data)
 		/* Already connected, no need to handle this anymore. */
 		return;
 	}
+
+	params = event_get_params(data, 2, NULL, &nick);
+	if (g_ascii_strcasecmp(server->nick, nick) != 0) {
+		/* the server uses a nick different from the one we send */
+		g_free(server->nick);
+		server->nick = g_strdup(nick);
+	}
+	g_free(params);
 
 	/* nick already in use - need to change it .. */
 	if (g_ascii_strcasecmp(server->nick, server->connrec->nick) == 0 &&


### PR DESCRIPTION
This commit fixes the following bug.

If we set a nick with a space, like "abc d", the IRC server only understands the first part, here "abc". Now imagine the case where this nick ("abc") is already used. The server notifies Irssi, but Irssi think the nick is "abc d" so it tries "abc d_". The server only understands the "abc" part, and so on, so the connection stays stuck.

This commit fixes that by checking when receiving a "nick already used" message if the nick sent by the server is the same as the one we have registered. If not, we use the nick from the server, and the classic process (with underscores and numbers) continues.
