### PR TITLE
Silence unused value warnings in perl binding code

### DIFF
--- a/src/perl/common/Core.xs
+++ b/src/perl/common/Core.xs
@@ -63,7 +63,7 @@ static void add_tuple(gpointer key_, gpointer value_, gpointer user_data)
 	HV *hash = user_data;
 	char *key = key_;
 	char *value = value_;
-	hv_store(hash, key, strlen(key), new_pv(value), 0);
+	(void) hv_store(hash, key, strlen(key), new_pv(value), 0);
 }
 
 static void wrap_signal_emit(void *signal, void **p) {

--- a/src/perl/irc/Irc.xs
+++ b/src/perl/irc/Irc.xs
@@ -6,90 +6,90 @@ static int initialized = FALSE;
 static void perl_irc_connect_fill_hash(HV *hv, IRC_SERVER_CONNECT_REC *conn)
 {
 	perl_connect_fill_hash(hv, (SERVER_CONNECT_REC *) conn);
-	hv_store(hv, "alternate_nick", 14, new_pv(conn->alternate_nick), 0);
+	(void) hv_store(hv, "alternate_nick", 14, new_pv(conn->alternate_nick), 0);
 }
 
 static void perl_irc_server_fill_hash(HV *hv, IRC_SERVER_REC *server)
 {
        	perl_server_fill_hash(hv, (SERVER_REC *) server);
 
-       	hv_store(hv, "real_address", 12, new_pv(server->real_address), 0);
-       	hv_store(hv, "usermode", 8, new_pv(server->usermode), 0);
-       	hv_store(hv, "userhost", 8, new_pv(server->userhost), 0);
+       	(void) hv_store(hv, "real_address", 12, new_pv(server->real_address), 0);
+       	(void) hv_store(hv, "usermode", 8, new_pv(server->usermode), 0);
+       	(void) hv_store(hv, "userhost", 8, new_pv(server->userhost), 0);
 
-	hv_store(hv, "max_cmds_at_once", 16, newSViv(server->max_cmds_at_once), 0);
-	hv_store(hv, "cmd_queue_speed", 15, newSViv(server->cmd_queue_speed), 0);
-	hv_store(hv, "max_query_chans", 15, newSViv(server->max_query_chans), 0);
+	(void) hv_store(hv, "max_cmds_at_once", 16, newSViv(server->max_cmds_at_once), 0);
+	(void) hv_store(hv, "cmd_queue_speed", 15, newSViv(server->cmd_queue_speed), 0);
+	(void) hv_store(hv, "max_query_chans", 15, newSViv(server->max_query_chans), 0);
 
-	hv_store(hv, "max_kicks_in_cmd", 16, newSViv(server->max_kicks_in_cmd), 0);
-	hv_store(hv, "max_msgs_in_cmd", 15, newSViv(server->max_msgs_in_cmd), 0);
-	hv_store(hv, "max_modes_in_cmd", 16, newSViv(server->max_modes_in_cmd), 0);
-	hv_store(hv, "max_whois_in_cmd", 16, newSViv(server->max_whois_in_cmd), 0);
-	hv_store(hv, "isupport_sent", 13, newSViv(server->isupport_sent), 0);
+	(void) hv_store(hv, "max_kicks_in_cmd", 16, newSViv(server->max_kicks_in_cmd), 0);
+	(void) hv_store(hv, "max_msgs_in_cmd", 15, newSViv(server->max_msgs_in_cmd), 0);
+	(void) hv_store(hv, "max_modes_in_cmd", 16, newSViv(server->max_modes_in_cmd), 0);
+	(void) hv_store(hv, "max_whois_in_cmd", 16, newSViv(server->max_whois_in_cmd), 0);
+	(void) hv_store(hv, "isupport_sent", 13, newSViv(server->isupport_sent), 0);
 }
 
 static void perl_ban_fill_hash(HV *hv, BAN_REC *ban)
 {
-	hv_store(hv, "ban", 3, new_pv(ban->ban), 0);
-	hv_store(hv, "setby", 5, new_pv(ban->setby), 0);
-	hv_store(hv, "time", 4, newSViv(ban->time), 0);
+	(void) hv_store(hv, "ban", 3, new_pv(ban->ban), 0);
+	(void) hv_store(hv, "setby", 5, new_pv(ban->setby), 0);
+	(void) hv_store(hv, "time", 4, newSViv(ban->time), 0);
 }
 
 static void perl_dcc_fill_hash(HV *hv, DCC_REC *dcc)
 {
-	hv_store(hv, "type", 4, new_pv(dcc_type2str(dcc->type)), 0);
-	hv_store(hv, "orig_type", 9, new_pv(dcc_type2str(dcc->orig_type)), 0);
-	hv_store(hv, "created", 7, newSViv(dcc->created), 0);
+	(void) hv_store(hv, "type", 4, new_pv(dcc_type2str(dcc->type)), 0);
+	(void) hv_store(hv, "orig_type", 9, new_pv(dcc_type2str(dcc->orig_type)), 0);
+	(void) hv_store(hv, "created", 7, newSViv(dcc->created), 0);
 
-	hv_store(hv, "server", 6, iobject_bless(dcc->server), 0);
-	hv_store(hv, "servertag", 9, new_pv(dcc->servertag), 0);
-	hv_store(hv, "mynick", 6, new_pv(dcc->mynick), 0);
-	hv_store(hv, "nick", 4, new_pv(dcc->nick), 0);
+	(void) hv_store(hv, "server", 6, iobject_bless(dcc->server), 0);
+	(void) hv_store(hv, "servertag", 9, new_pv(dcc->servertag), 0);
+	(void) hv_store(hv, "mynick", 6, new_pv(dcc->mynick), 0);
+	(void) hv_store(hv, "nick", 4, new_pv(dcc->nick), 0);
 
-	hv_store(hv, "chat", 4, simple_iobject_bless(dcc->chat), 0);
-	hv_store(hv, "target", 6, new_pv(dcc->target), 0);
-	hv_store(hv, "arg", 3, new_pv(dcc->arg), 0);
+	(void) hv_store(hv, "chat", 4, simple_iobject_bless(dcc->chat), 0);
+	(void) hv_store(hv, "target", 6, new_pv(dcc->target), 0);
+	(void) hv_store(hv, "arg", 3, new_pv(dcc->arg), 0);
 
-	hv_store(hv, "addr", 4, new_pv(dcc->addrstr), 0);
-	hv_store(hv, "port", 4, newSViv(dcc->port), 0);
+	(void) hv_store(hv, "addr", 4, new_pv(dcc->addrstr), 0);
+	(void) hv_store(hv, "port", 4, newSViv(dcc->port), 0);
 
-	hv_store(hv, "starttime", 9, newSViv(dcc->starttime), 0);
-	hv_store(hv, "transfd", 7, newSViv(dcc->transfd), 0);
+	(void) hv_store(hv, "starttime", 9, newSViv(dcc->starttime), 0);
+	(void) hv_store(hv, "transfd", 7, newSViv(dcc->transfd), 0);
 }
 
 static void perl_dcc_chat_fill_hash(HV *hv, CHAT_DCC_REC *dcc)
 {
         perl_dcc_fill_hash(hv, (DCC_REC *) dcc);
 
-	hv_store(hv, "id", 2, new_pv(dcc->id), 0);
-	hv_store(hv, "mirc_ctcp", 9, newSViv(dcc->mirc_ctcp), 0);
-	hv_store(hv, "connection_lost", 15, newSViv(dcc->connection_lost), 0);
+	(void) hv_store(hv, "id", 2, new_pv(dcc->id), 0);
+	(void) hv_store(hv, "mirc_ctcp", 9, newSViv(dcc->mirc_ctcp), 0);
+	(void) hv_store(hv, "connection_lost", 15, newSViv(dcc->connection_lost), 0);
 }
 
 static void perl_dcc_file_fill_hash(HV *hv, FILE_DCC_REC *dcc)
 {
         perl_dcc_fill_hash(hv, (DCC_REC *) dcc);
 
-	hv_store(hv, "size", 4, newSViv(dcc->size), 0);
-	hv_store(hv, "skipped", 7, newSViv(dcc->skipped), 0);
+	(void) hv_store(hv, "size", 4, newSViv(dcc->size), 0);
+	(void) hv_store(hv, "skipped", 7, newSViv(dcc->skipped), 0);
 }
 
 static void perl_dcc_get_fill_hash(HV *hv, GET_DCC_REC *dcc)
 {
         perl_dcc_file_fill_hash(hv, (FILE_DCC_REC *) dcc);
 
-	hv_store(hv, "get_type", 8, newSViv(dcc->get_type), 0);
-	hv_store(hv, "file", 4, new_pv(dcc->file), 0);
-	hv_store(hv, "file_quoted", 11, newSViv(dcc->file_quoted), 0);
+	(void) hv_store(hv, "get_type", 8, newSViv(dcc->get_type), 0);
+	(void) hv_store(hv, "file", 4, new_pv(dcc->file), 0);
+	(void) hv_store(hv, "file_quoted", 11, newSViv(dcc->file_quoted), 0);
 }
 
 static void perl_dcc_send_fill_hash(HV *hv, SEND_DCC_REC *dcc)
 {
         perl_dcc_file_fill_hash(hv, (FILE_DCC_REC *) dcc);
 
-	hv_store(hv, "file_quoted", 11, newSViv(dcc->file_quoted), 0);
-	hv_store(hv, "waitforend", 10, newSViv(dcc->waitforend), 0);
-	hv_store(hv, "gotalldata", 10, newSViv(dcc->gotalldata), 0);
+	(void) hv_store(hv, "file_quoted", 11, newSViv(dcc->file_quoted), 0);
+	(void) hv_store(hv, "waitforend", 10, newSViv(dcc->waitforend), 0);
+	(void) hv_store(hv, "gotalldata", 10, newSViv(dcc->gotalldata), 0);
 }
 
 static void perl_netsplit_fill_hash(HV *hv, NETSPLIT_REC *netsplit)
@@ -97,11 +97,11 @@ static void perl_netsplit_fill_hash(HV *hv, NETSPLIT_REC *netsplit)
         AV *av;
         GSList *tmp;
 
-	hv_store(hv, "nick", 4, new_pv(netsplit->nick), 0);
-	hv_store(hv, "address", 7, new_pv(netsplit->address), 0);
-	hv_store(hv, "destroy", 7, newSViv(netsplit->destroy), 0);
+	(void) hv_store(hv, "nick", 4, new_pv(netsplit->nick), 0);
+	(void) hv_store(hv, "address", 7, new_pv(netsplit->address), 0);
+	(void) hv_store(hv, "destroy", 7, newSViv(netsplit->destroy), 0);
 
-	hv_store(hv, "server", 6,
+	(void) hv_store(hv, "server", 6,
 		 plain_bless(netsplit->server,
 			     "Irssi::Irc::Netsplitserver"), 0);
 
@@ -110,22 +110,22 @@ static void perl_netsplit_fill_hash(HV *hv, NETSPLIT_REC *netsplit)
 		av_push(av, plain_bless(tmp->data,
 					"Irssi::Irc::Netsplitchannel"));
 	}
-	hv_store(hv, "channels", 8, newRV_noinc((SV*)av), 0);
+	(void) hv_store(hv, "channels", 8, newRV_noinc((SV*)av), 0);
 }
 
 static void perl_netsplit_server_fill_hash(HV *hv, NETSPLIT_SERVER_REC *rec)
 {
-	hv_store(hv, "server", 6, new_pv(rec->server), 0);
-	hv_store(hv, "destserver", 10, new_pv(rec->destserver), 0);
-	hv_store(hv, "count", 5, newSViv(rec->count), 0);
+	(void) hv_store(hv, "server", 6, new_pv(rec->server), 0);
+	(void) hv_store(hv, "destserver", 10, new_pv(rec->destserver), 0);
+	(void) hv_store(hv, "count", 5, newSViv(rec->count), 0);
 }
 
 static void perl_netsplit_channel_fill_hash(HV *hv, NETSPLIT_CHAN_REC *rec)
 {
-	hv_store(hv, "name", 4, new_pv(rec->name), 0);
-	hv_store(hv, "op", 2, newSViv(rec->op), 0);
-	hv_store(hv, "halfop", 6, newSViv(rec->halfop), 0);
-	hv_store(hv, "voice", 5, newSViv(rec->voice), 0);
+	(void) hv_store(hv, "name", 4, new_pv(rec->name), 0);
+	(void) hv_store(hv, "op", 2, newSViv(rec->op), 0);
+	(void) hv_store(hv, "halfop", 6, newSViv(rec->halfop), 0);
+	(void) hv_store(hv, "voice", 5, newSViv(rec->voice), 0);
 }
 
 static void perl_notifylist_fill_hash(HV *hv, NOTIFYLIST_REC *notify)
@@ -133,8 +133,8 @@ static void perl_notifylist_fill_hash(HV *hv, NOTIFYLIST_REC *notify)
 	AV *av;
 	char **tmp;
 
-	hv_store(hv, "mask", 4, new_pv(notify->mask), 0);
-	hv_store(hv, "away_check", 10, newSViv(notify->away_check), 0);
+	(void) hv_store(hv, "mask", 4, new_pv(notify->mask), 0);
+	(void) hv_store(hv, "away_check", 10, newSViv(notify->away_check), 0);
 
 	av = newAV();
 	if (notify->ircnets != NULL) {
@@ -142,20 +142,20 @@ static void perl_notifylist_fill_hash(HV *hv, NOTIFYLIST_REC *notify)
 			av_push(av, new_pv(*tmp));
 		}
 	}
-	hv_store(hv, "ircnets", 7, newRV_noinc((SV*)av), 0);
+	(void) hv_store(hv, "ircnets", 7, newRV_noinc((SV*)av), 0);
 }
 
 static void perl_client_fill_hash(HV *hv, CLIENT_REC *client)
 {
-	hv_store(hv, "nick", 4, new_pv(client->nick), 0);
-	hv_store(hv, "host", 4, new_pv(client->host), 0);
-	hv_store(hv, "proxy_address", 13, new_pv(client->proxy_address), 0);
-	hv_store(hv, "server", 6, iobject_bless(client->server), 0);
-	hv_store(hv, "pass_sent", 9, newSViv(client->pass_sent), 0);
-	hv_store(hv, "user_sent", 9, newSViv(client->user_sent), 0);
-	hv_store(hv, "connected", 9, newSViv(client->connected), 0);
-	hv_store(hv, "want_ctcp", 9, newSViv(client->want_ctcp), 0);
-	hv_store(hv, "ircnet", 6, new_pv(client->listen->ircnet), 0);
+	(void) hv_store(hv, "nick", 4, new_pv(client->nick), 0);
+	(void) hv_store(hv, "host", 4, new_pv(client->host), 0);
+	(void) hv_store(hv, "proxy_address", 13, new_pv(client->proxy_address), 0);
+	(void) hv_store(hv, "server", 6, iobject_bless(client->server), 0);
+	(void) hv_store(hv, "pass_sent", 9, newSViv(client->pass_sent), 0);
+	(void) hv_store(hv, "user_sent", 9, newSViv(client->user_sent), 0);
+	(void) hv_store(hv, "connected", 9, newSViv(client->connected), 0);
+	(void) hv_store(hv, "want_ctcp", 9, newSViv(client->want_ctcp), 0);
+	(void) hv_store(hv, "ircnet", 6, new_pv(client->listen->ircnet), 0);
 }
 
 static PLAIN_OBJECT_INIT_REC irc_plains[] = {

--- a/src/perl/perl-common.c
+++ b/src/perl/perl-common.c
@@ -135,7 +135,7 @@ SV *irssi_bless_iobject(int type, int chat_type, void *object)
 	stash = gv_stashpv(rec->stash, 1);
 
 	hv = newHV();
-	hv_store(hv, "_irssi", 6, create_sv_ptr(object), 0);
+	(void) hv_store(hv, "_irssi", 6, create_sv_ptr(object), 0);
         rec->fill_func(hv, object);
 	return sv_bless(newRV_noinc((SV*)hv), stash);
 }
@@ -148,7 +148,7 @@ SV *irssi_bless_plain(const char *stash, void *object)
 	fill_func = g_hash_table_lookup(plain_stashes, stash);
 
 	hv = newHV();
-	hv_store(hv, "_irssi", 6, create_sv_ptr(object), 0);
+	(void) hv_store(hv, "_irssi", 6, create_sv_ptr(object), 0);
 	if (fill_func != NULL)
 		fill_func(hv, object);
 	return sv_bless(newRV_noinc((SV*)hv), gv_stashpv((char *)stash, 1));
@@ -264,17 +264,17 @@ void perl_chatnet_fill_hash(HV *hv, CHATNET_REC *chatnet)
 	type = "CHATNET";
 	chat_type = (char *) chat_protocol_find_id(chatnet->chat_type)->name;
 
-	hv_store(hv, "type", 4, new_pv(type), 0);
-	hv_store(hv, "chat_type", 9, new_pv(chat_type), 0);
+	(void) hv_store(hv, "type", 4, new_pv(type), 0);
+	(void) hv_store(hv, "chat_type", 9, new_pv(chat_type), 0);
 
-	hv_store(hv, "name", 4, new_pv(chatnet->name), 0);
+	(void) hv_store(hv, "name", 4, new_pv(chatnet->name), 0);
 
-	hv_store(hv, "nick", 4, new_pv(chatnet->nick), 0);
-	hv_store(hv, "username", 8, new_pv(chatnet->username), 0);
-	hv_store(hv, "realname", 8, new_pv(chatnet->realname), 0);
+	(void) hv_store(hv, "nick", 4, new_pv(chatnet->nick), 0);
+	(void) hv_store(hv, "username", 8, new_pv(chatnet->username), 0);
+	(void) hv_store(hv, "realname", 8, new_pv(chatnet->realname), 0);
 
-	hv_store(hv, "own_host", 8, new_pv(chatnet->own_host), 0);
-	hv_store(hv, "autosendcmd", 11, new_pv(chatnet->autosendcmd), 0);
+	(void) hv_store(hv, "own_host", 8, new_pv(chatnet->own_host), 0);
+	(void) hv_store(hv, "autosendcmd", 11, new_pv(chatnet->autosendcmd), 0);
 }
 
 void perl_connect_fill_hash(HV *hv, SERVER_CONNECT_REC *conn)
@@ -287,25 +287,25 @@ void perl_connect_fill_hash(HV *hv, SERVER_CONNECT_REC *conn)
 	type = "SERVER CONNECT";
 	chat_type = (char *) chat_protocol_find_id(conn->chat_type)->name;
 
-	hv_store(hv, "type", 4, new_pv(type), 0);
-	hv_store(hv, "chat_type", 9, new_pv(chat_type), 0);
+	(void) hv_store(hv, "type", 4, new_pv(type), 0);
+	(void) hv_store(hv, "chat_type", 9, new_pv(chat_type), 0);
 
-	hv_store(hv, "tag", 3, new_pv(conn->tag), 0);
-	hv_store(hv, "address", 7, new_pv(conn->address), 0);
-	hv_store(hv, "port", 4, newSViv(conn->port), 0);
-	hv_store(hv, "chatnet", 7, new_pv(conn->chatnet), 0);
+	(void) hv_store(hv, "tag", 3, new_pv(conn->tag), 0);
+	(void) hv_store(hv, "address", 7, new_pv(conn->address), 0);
+	(void) hv_store(hv, "port", 4, newSViv(conn->port), 0);
+	(void) hv_store(hv, "chatnet", 7, new_pv(conn->chatnet), 0);
 
-	hv_store(hv, "password", 8, new_pv(conn->password), 0);
-	hv_store(hv, "wanted_nick", 11, new_pv(conn->nick), 0);
-	hv_store(hv, "username", 8, new_pv(conn->username), 0);
-	hv_store(hv, "realname", 8, new_pv(conn->realname), 0);
+	(void) hv_store(hv, "password", 8, new_pv(conn->password), 0);
+	(void) hv_store(hv, "wanted_nick", 11, new_pv(conn->nick), 0);
+	(void) hv_store(hv, "username", 8, new_pv(conn->username), 0);
+	(void) hv_store(hv, "realname", 8, new_pv(conn->realname), 0);
 
-	hv_store(hv, "reconnection", 12, newSViv(conn->reconnection), 0);
-	hv_store(hv, "no_autojoin_channels", 20, newSViv(conn->no_autojoin_channels), 0);
-	hv_store(hv, "no_autosendcmd", 14, newSViv(conn->no_autosendcmd), 0);
-	hv_store(hv, "unix_socket", 11, newSViv(conn->unix_socket), 0);
-	hv_store(hv, "use_ssl", 7, newSViv(conn->use_ssl), 0);
-	hv_store(hv, "no_connect", 10, newSViv(conn->no_connect), 0);
+	(void) hv_store(hv, "reconnection", 12, newSViv(conn->reconnection), 0);
+	(void) hv_store(hv, "no_autojoin_channels", 20, newSViv(conn->no_autojoin_channels), 0);
+	(void) hv_store(hv, "no_autosendcmd", 14, newSViv(conn->no_autosendcmd), 0);
+	(void) hv_store(hv, "unix_socket", 11, newSViv(conn->unix_socket), 0);
+	(void) hv_store(hv, "use_ssl", 7, newSViv(conn->use_ssl), 0);
+	(void) hv_store(hv, "no_connect", 10, newSViv(conn->no_connect), 0);
 }
 
 void perl_server_fill_hash(HV *hv, SERVER_REC *server)
@@ -319,28 +319,28 @@ void perl_server_fill_hash(HV *hv, SERVER_REC *server)
 	perl_connect_fill_hash(hv, server->connrec);
 
 	type = "SERVER";
-	hv_store(hv, "type", 4, new_pv(type), 0);
+	(void) hv_store(hv, "type", 4, new_pv(type), 0);
 
-	hv_store(hv, "connect_time", 12, newSViv(server->connect_time), 0);
-	hv_store(hv, "real_connect_time", 17, newSViv(server->real_connect_time), 0);
+	(void) hv_store(hv, "connect_time", 12, newSViv(server->connect_time), 0);
+	(void) hv_store(hv, "real_connect_time", 17, newSViv(server->real_connect_time), 0);
 
-	hv_store(hv, "tag", 3, new_pv(server->tag), 0);
-	hv_store(hv, "nick", 4, new_pv(server->nick), 0);
+	(void) hv_store(hv, "tag", 3, new_pv(server->tag), 0);
+	(void) hv_store(hv, "nick", 4, new_pv(server->nick), 0);
 
-	hv_store(hv, "connected", 9, newSViv(server->connected), 0);
-	hv_store(hv, "connection_lost", 15, newSViv(server->connection_lost), 0);
+	(void) hv_store(hv, "connected", 9, newSViv(server->connected), 0);
+	(void) hv_store(hv, "connection_lost", 15, newSViv(server->connection_lost), 0);
 
 	stash = gv_stashpv("Irssi::Rawlog", 0);
-	hv_store(hv, "rawlog", 6, sv_bless(newRV_noinc(newSViv((IV)server->rawlog)), stash), 0);
+	(void) hv_store(hv, "rawlog", 6, sv_bless(newRV_noinc(newSViv((IV)server->rawlog)), stash), 0);
 
-	hv_store(hv, "version", 7, new_pv(server->version), 0);
-	hv_store(hv, "away_reason", 11, new_pv(server->away_reason), 0);
-	hv_store(hv, "last_invite", 11, new_pv(server->last_invite), 0);
-	hv_store(hv, "server_operator", 15, newSViv(server->server_operator), 0);
-	hv_store(hv, "usermode_away", 13, newSViv(server->usermode_away), 0);
-	hv_store(hv, "banned", 6, newSViv(server->banned), 0);
+	(void) hv_store(hv, "version", 7, new_pv(server->version), 0);
+	(void) hv_store(hv, "away_reason", 11, new_pv(server->away_reason), 0);
+	(void) hv_store(hv, "last_invite", 11, new_pv(server->last_invite), 0);
+	(void) hv_store(hv, "server_operator", 15, newSViv(server->server_operator), 0);
+	(void) hv_store(hv, "usermode_away", 13, newSViv(server->usermode_away), 0);
+	(void) hv_store(hv, "banned", 6, newSViv(server->banned), 0);
 
-	hv_store(hv, "lag", 3, newSViv(server->lag), 0);
+	(void) hv_store(hv, "lag", 3, newSViv(server->lag), 0);
 }
 
 void perl_window_item_fill_hash(HV *hv, WI_ITEM_REC *item)
@@ -353,17 +353,17 @@ void perl_window_item_fill_hash(HV *hv, WI_ITEM_REC *item)
 	type = (char *) module_find_id_str("WINDOW ITEM TYPE", item->type);
 	chat_type = (char *) chat_protocol_find_id(item->chat_type)->name;
 
-	hv_store(hv, "type", 4, new_pv(type), 0);
-	hv_store(hv, "chat_type", 9, new_pv(chat_type), 0);
+	(void) hv_store(hv, "type", 4, new_pv(type), 0);
+	(void) hv_store(hv, "chat_type", 9, new_pv(chat_type), 0);
 
 	if (item->server != NULL) {
-		hv_store(hv, "server", 6, iobject_bless(item->server), 0);
+		(void) hv_store(hv, "server", 6, iobject_bless(item->server), 0);
 	}
-	hv_store(hv, "visible_name", 12, new_pv(item->visible_name), 0);
+	(void) hv_store(hv, "visible_name", 12, new_pv(item->visible_name), 0);
 
-	hv_store(hv, "createtime", 10, newSViv(item->createtime), 0);
-	hv_store(hv, "data_level", 10, newSViv(item->data_level), 0);
-	hv_store(hv, "hilight_color", 13, new_pv(item->hilight_color), 0);
+	(void) hv_store(hv, "createtime", 10, newSViv(item->createtime), 0);
+	(void) hv_store(hv, "data_level", 10, newSViv(item->data_level), 0);
+	(void) hv_store(hv, "hilight_color", 13, new_pv(item->hilight_color), 0);
 }
 
 void perl_channel_fill_hash(HV *hv, CHANNEL_REC *channel)
@@ -374,26 +374,26 @@ void perl_channel_fill_hash(HV *hv, CHANNEL_REC *channel)
 	perl_window_item_fill_hash(hv, (WI_ITEM_REC *) channel);
 
         if (channel->ownnick != NULL)
-		hv_store(hv, "ownnick", 7, iobject_bless(channel->ownnick), 0);
+		(void) hv_store(hv, "ownnick", 7, iobject_bless(channel->ownnick), 0);
 
-	hv_store(hv, "name", 4, new_pv(channel->name), 0);
-	hv_store(hv, "topic", 5, new_pv(channel->topic), 0);
-	hv_store(hv, "topic_by", 8, new_pv(channel->topic_by), 0);
-	hv_store(hv, "topic_time", 10, newSViv(channel->topic_time), 0);
+	(void) hv_store(hv, "name", 4, new_pv(channel->name), 0);
+	(void) hv_store(hv, "topic", 5, new_pv(channel->topic), 0);
+	(void) hv_store(hv, "topic_by", 8, new_pv(channel->topic_by), 0);
+	(void) hv_store(hv, "topic_time", 10, newSViv(channel->topic_time), 0);
 
-	hv_store(hv, "no_modes", 8, newSViv(channel->no_modes), 0);
-	hv_store(hv, "mode", 4, new_pv(channel->mode), 0);
-	hv_store(hv, "limit", 5, newSViv(channel->limit), 0);
-	hv_store(hv, "key", 3, new_pv(channel->key), 0);
+	(void) hv_store(hv, "no_modes", 8, newSViv(channel->no_modes), 0);
+	(void) hv_store(hv, "mode", 4, new_pv(channel->mode), 0);
+	(void) hv_store(hv, "limit", 5, newSViv(channel->limit), 0);
+	(void) hv_store(hv, "key", 3, new_pv(channel->key), 0);
 
-	hv_store(hv, "chanop", 6, newSViv(channel->chanop), 0);
-	hv_store(hv, "names_got", 9, newSViv(channel->names_got), 0);
-	hv_store(hv, "wholist", 7, newSViv(channel->wholist), 0);
-	hv_store(hv, "synced", 6, newSViv(channel->synced), 0);
+	(void) hv_store(hv, "chanop", 6, newSViv(channel->chanop), 0);
+	(void) hv_store(hv, "names_got", 9, newSViv(channel->names_got), 0);
+	(void) hv_store(hv, "wholist", 7, newSViv(channel->wholist), 0);
+	(void) hv_store(hv, "synced", 6, newSViv(channel->synced), 0);
 
-	hv_store(hv, "joined", 6, newSViv(channel->joined), 0);
-	hv_store(hv, "left", 4, newSViv(channel->left), 0);
-	hv_store(hv, "kicked", 6, newSViv(channel->kicked), 0);
+	(void) hv_store(hv, "joined", 6, newSViv(channel->joined), 0);
+	(void) hv_store(hv, "left", 4, newSViv(channel->left), 0);
+	(void) hv_store(hv, "kicked", 6, newSViv(channel->kicked), 0);
 }
 
 void perl_query_fill_hash(HV *hv, QUERY_REC *query)
@@ -403,11 +403,11 @@ void perl_query_fill_hash(HV *hv, QUERY_REC *query)
 
 	perl_window_item_fill_hash(hv, (WI_ITEM_REC *) query);
 
-	hv_store(hv, "name", 4, new_pv(query->name), 0);
-	hv_store(hv, "last_unread_msg", 15, newSViv(query->last_unread_msg), 0);
-	hv_store(hv, "address", 7, new_pv(query->address), 0);
-	hv_store(hv, "server_tag", 10, new_pv(query->server_tag), 0);
-	hv_store(hv, "unwanted", 8, newSViv(query->unwanted), 0);
+	(void) hv_store(hv, "name", 4, new_pv(query->name), 0);
+	(void) hv_store(hv, "last_unread_msg", 15, newSViv(query->last_unread_msg), 0);
+	(void) hv_store(hv, "address", 7, new_pv(query->address), 0);
+	(void) hv_store(hv, "server_tag", 10, new_pv(query->server_tag), 0);
+	(void) hv_store(hv, "unwanted", 8, newSViv(query->unwanted), 0);
 }
 
 void perl_nick_fill_hash(HV *hv, NICK_REC *nick)
@@ -420,31 +420,31 @@ void perl_nick_fill_hash(HV *hv, NICK_REC *nick)
 	type = "NICK";
 	chat_type = (char *) chat_protocol_find_id(nick->chat_type)->name;
 
-	hv_store(hv, "type", 4, new_pv(type), 0);
-	hv_store(hv, "chat_type", 9, new_pv(chat_type), 0);
+	(void) hv_store(hv, "type", 4, new_pv(type), 0);
+	(void) hv_store(hv, "chat_type", 9, new_pv(chat_type), 0);
 
-	hv_store(hv, "nick", 4, new_pv(nick->nick), 0);
-	hv_store(hv, "host", 4, new_pv(nick->host), 0);
-	hv_store(hv, "realname", 8, new_pv(nick->realname), 0);
-	hv_store(hv, "hops", 4, newSViv(nick->hops), 0);
+	(void) hv_store(hv, "nick", 4, new_pv(nick->nick), 0);
+	(void) hv_store(hv, "host", 4, new_pv(nick->host), 0);
+	(void) hv_store(hv, "realname", 8, new_pv(nick->realname), 0);
+	(void) hv_store(hv, "hops", 4, newSViv(nick->hops), 0);
 
-	hv_store(hv, "gone", 4, newSViv(nick->gone), 0);
-	hv_store(hv, "serverop", 8, newSViv(nick->serverop), 0);
+	(void) hv_store(hv, "gone", 4, newSViv(nick->gone), 0);
+	(void) hv_store(hv, "serverop", 8, newSViv(nick->serverop), 0);
 
-	hv_store(hv, "op", 2, newSViv(nick->op), 0);
-	hv_store(hv, "halfop", 6, newSViv(nick->halfop), 0);
-	hv_store(hv, "voice", 5, newSViv(nick->voice), 0);
-	hv_store(hv, "other", 5, newSViv(nick->prefixes[0]), 0);
-	hv_store(hv, "prefixes", 8, new_pv(nick->prefixes), 0);
+	(void) hv_store(hv, "op", 2, newSViv(nick->op), 0);
+	(void) hv_store(hv, "halfop", 6, newSViv(nick->halfop), 0);
+	(void) hv_store(hv, "voice", 5, newSViv(nick->voice), 0);
+	(void) hv_store(hv, "other", 5, newSViv(nick->prefixes[0]), 0);
+	(void) hv_store(hv, "prefixes", 8, new_pv(nick->prefixes), 0);
 
-	hv_store(hv, "last_check", 10, newSViv(nick->last_check), 0);
-	hv_store(hv, "send_massjoin", 13, newSViv(nick->send_massjoin), 0);
+	(void) hv_store(hv, "last_check", 10, newSViv(nick->last_check), 0);
+	(void) hv_store(hv, "send_massjoin", 13, newSViv(nick->send_massjoin), 0);
 }
 
 static void perl_command_fill_hash(HV *hv, COMMAND_REC *cmd)
 {
-	hv_store(hv, "category", 8, new_pv(cmd->category), 0);
-	hv_store(hv, "cmd", 3, new_pv(cmd->cmd), 0);
+	(void) hv_store(hv, "category", 8, new_pv(cmd->category), 0);
+	(void) hv_store(hv, "cmd", 3, new_pv(cmd->cmd), 0);
 }
 
 static void perl_ignore_fill_hash(HV *hv, IGNORE_REC *ignore)
@@ -452,22 +452,22 @@ static void perl_ignore_fill_hash(HV *hv, IGNORE_REC *ignore)
 	AV *av;
 	char **tmp;
 
-	hv_store(hv, "mask", 4, new_pv(ignore->mask), 0);
-	hv_store(hv, "servertag", 9, new_pv(ignore->servertag), 0);
+	(void) hv_store(hv, "mask", 4, new_pv(ignore->mask), 0);
+	(void) hv_store(hv, "servertag", 9, new_pv(ignore->servertag), 0);
 	av = newAV();
 	if (ignore->channels != NULL) {
 		for (tmp = ignore->channels; *tmp != NULL; tmp++) {
 			av_push(av, new_pv(*tmp));
 		}
 	}
-	hv_store(hv, "channels", 8, newRV_noinc((SV*)av), 0);
-	hv_store(hv, "pattern", 7, new_pv(ignore->pattern), 0);
+	(void) hv_store(hv, "channels", 8, newRV_noinc((SV*)av), 0);
+	(void) hv_store(hv, "pattern", 7, new_pv(ignore->pattern), 0);
 
-	hv_store(hv, "level", 5, newSViv(ignore->level), 0);
+	(void) hv_store(hv, "level", 5, newSViv(ignore->level), 0);
 
-	hv_store(hv, "exception", 9, newSViv(ignore->exception), 0);
-	hv_store(hv, "regexp", 6, newSViv(ignore->regexp), 0);
-	hv_store(hv, "fullword", 8, newSViv(ignore->fullword), 0);
+	(void) hv_store(hv, "exception", 9, newSViv(ignore->exception), 0);
+	(void) hv_store(hv, "regexp", 6, newSViv(ignore->regexp), 0);
+	(void) hv_store(hv, "fullword", 8, newSViv(ignore->fullword), 0);
 }
 
 static void perl_log_fill_hash(HV *hv, LOG_REC *log)
@@ -475,33 +475,33 @@ static void perl_log_fill_hash(HV *hv, LOG_REC *log)
 	AV *av;
 	GSList *tmp;
 
-	hv_store(hv, "fname", 5, new_pv(log->fname), 0);
-	hv_store(hv, "real_fname", 10, new_pv(log->real_fname), 0);
-	hv_store(hv, "opened", 6, newSViv(log->opened), 0);
-	hv_store(hv, "level", 5, newSViv(log->level), 0);
-	hv_store(hv, "last", 4, newSViv(log->last), 0);
-	hv_store(hv, "autoopen", 8, newSViv(log->autoopen), 0);
-	hv_store(hv, "failed", 6, newSViv(log->failed), 0);
-	hv_store(hv, "temp", 4, newSViv(log->temp), 0);
+	(void) hv_store(hv, "fname", 5, new_pv(log->fname), 0);
+	(void) hv_store(hv, "real_fname", 10, new_pv(log->real_fname), 0);
+	(void) hv_store(hv, "opened", 6, newSViv(log->opened), 0);
+	(void) hv_store(hv, "level", 5, newSViv(log->level), 0);
+	(void) hv_store(hv, "last", 4, newSViv(log->last), 0);
+	(void) hv_store(hv, "autoopen", 8, newSViv(log->autoopen), 0);
+	(void) hv_store(hv, "failed", 6, newSViv(log->failed), 0);
+	(void) hv_store(hv, "temp", 4, newSViv(log->temp), 0);
 
 	av = newAV();
 	for (tmp = log->items; tmp != NULL; tmp = tmp->next) {
 		av_push(av, plain_bless(tmp->data, "Irssi::Logitem"));
 	}
-	hv_store(hv, "items", 5, newRV_noinc((SV*)av), 0);
+	(void) hv_store(hv, "items", 5, newRV_noinc((SV*)av), 0);
 }
 
 static void perl_log_item_fill_hash(HV *hv, LOG_ITEM_REC *item)
 {
-	hv_store(hv, "type", 4, newSViv(item->type), 0);
-	hv_store(hv, "name", 4, new_pv(item->name), 0);
-	hv_store(hv, "servertag", 9, new_pv(item->servertag), 0);
+	(void) hv_store(hv, "type", 4, newSViv(item->type), 0);
+	(void) hv_store(hv, "name", 4, new_pv(item->name), 0);
+	(void) hv_store(hv, "servertag", 9, new_pv(item->servertag), 0);
 }
 
 static void perl_rawlog_fill_hash(HV *hv, RAWLOG_REC *rawlog)
 {
-	hv_store(hv, "logging", 7, newSViv(rawlog->logging), 0);
-	hv_store(hv, "nlines", 6, newSViv(rawlog->nlines), 0);
+	(void) hv_store(hv, "logging", 7, newSViv(rawlog->logging), 0);
+	(void) hv_store(hv, "nlines", 6, newSViv(rawlog->nlines), 0);
 }
 
 static void perl_reconnect_fill_hash(HV *hv, RECONNECT_REC *reconnect)
@@ -511,18 +511,18 @@ static void perl_reconnect_fill_hash(HV *hv, RECONNECT_REC *reconnect)
 	perl_connect_fill_hash(hv, reconnect->conn);
 
 	type = "RECONNECT";
-	hv_store(hv, "type", 4, new_pv(type), 0);
+	(void) hv_store(hv, "type", 4, new_pv(type), 0);
 
-	hv_store(hv, "tag", 3, newSViv(reconnect->tag), 0);
-	hv_store(hv, "next_connect", 12, newSViv(reconnect->next_connect), 0);
+	(void) hv_store(hv, "tag", 3, newSViv(reconnect->tag), 0);
+	(void) hv_store(hv, "next_connect", 12, newSViv(reconnect->next_connect), 0);
 }
 
 static void perl_script_fill_hash(HV *hv, PERL_SCRIPT_REC *script)
 {
-	hv_store(hv, "name", 4, new_pv(script->name), 0);
-	hv_store(hv, "package", 7, new_pv(script->package), 0);
-	hv_store(hv, "path", 4, new_pv(script->path), 0);
-	hv_store(hv, "data", 4, new_pv(script->data), 0);
+	(void) hv_store(hv, "name", 4, new_pv(script->name), 0);
+	(void) hv_store(hv, "package", 7, new_pv(script->package), 0);
+	(void) hv_store(hv, "path", 4, new_pv(script->path), 0);
+	(void) hv_store(hv, "data", 4, new_pv(script->data), 0);
 }
 
 static void remove_newlines(char *str)

--- a/src/perl/textui/Statusbar.xs
+++ b/src/perl/textui/Statusbar.xs
@@ -160,5 +160,5 @@ CODE:
 				       *str == '\0' ? NULL : str,
 				       data, escape_vars);
 	hv = hvref(ST(0));
-	hv_store(hv, "min_size", 8, newSViv(item->min_size), 0);
-	hv_store(hv, "max_size", 8, newSViv(item->max_size), 0);
+	(void) hv_store(hv, "min_size", 8, newSViv(item->min_size), 0);
+	(void) hv_store(hv, "max_size", 8, newSViv(item->max_size), 0);

--- a/src/perl/textui/TextUI.xs
+++ b/src/perl/textui/TextUI.xs
@@ -8,72 +8,72 @@ static int initialized = FALSE;
 
 static void perl_main_window_fill_hash(HV *hv, MAIN_WINDOW_REC *window)
 {
-	hv_store(hv, "active", 6, plain_bless(window->active, "Irssi::UI::Window"), 0);
+	(void) hv_store(hv, "active", 6, plain_bless(window->active, "Irssi::UI::Window"), 0);
 
-	hv_store(hv, "first_line", 10, newSViv(window->first_line), 0);
-	hv_store(hv, "last_line", 9, newSViv(window->last_line), 0);
-	hv_store(hv, "width", 5, newSViv(window->width), 0);
-	hv_store(hv, "height", 6, newSViv(window->height), 0);
+	(void) hv_store(hv, "first_line", 10, newSViv(window->first_line), 0);
+	(void) hv_store(hv, "last_line", 9, newSViv(window->last_line), 0);
+	(void) hv_store(hv, "width", 5, newSViv(window->width), 0);
+	(void) hv_store(hv, "height", 6, newSViv(window->height), 0);
 
-	hv_store(hv, "statusbar_lines", 15, newSViv(window->statusbar_lines), 0);
+	(void) hv_store(hv, "statusbar_lines", 15, newSViv(window->statusbar_lines), 0);
 }
 
 static void perl_text_buffer_fill_hash(HV *hv, TEXT_BUFFER_REC *buffer)
 {
-	hv_store(hv, "first_line", 10, plain_bless(buffer->first_line, "Irssi::TextUI::Line"), 0);
-	hv_store(hv, "lines_count", 11, newSViv(buffer->lines_count), 0);
-	hv_store(hv, "cur_line", 8, plain_bless(buffer->cur_line, "Irssi::TextUI::Line"), 0);
-	hv_store(hv, "last_eol", 8, newSViv(buffer->last_eol), 0);
+	(void) hv_store(hv, "first_line", 10, plain_bless(buffer->first_line, "Irssi::TextUI::Line"), 0);
+	(void) hv_store(hv, "lines_count", 11, newSViv(buffer->lines_count), 0);
+	(void) hv_store(hv, "cur_line", 8, plain_bless(buffer->cur_line, "Irssi::TextUI::Line"), 0);
+	(void) hv_store(hv, "last_eol", 8, newSViv(buffer->last_eol), 0);
 }
 
 static void perl_text_buffer_view_fill_hash(HV *hv, TEXT_BUFFER_VIEW_REC *view)
 {
-	hv_store(hv, "buffer", 6, plain_bless(view->buffer, "Irssi::TextUI::TextBuffer"), 0);
-	hv_store(hv, "width", 5, newSViv(view->width), 0);
-	hv_store(hv, "height", 6, newSViv(view->height), 0);
+	(void) hv_store(hv, "buffer", 6, plain_bless(view->buffer, "Irssi::TextUI::TextBuffer"), 0);
+	(void) hv_store(hv, "width", 5, newSViv(view->width), 0);
+	(void) hv_store(hv, "height", 6, newSViv(view->height), 0);
 
-	hv_store(hv, "default_indent", 14, newSViv(view->default_indent), 0);
-	hv_store(hv, "longword_noindent", 17, newSViv(view->longword_noindent), 0);
-	hv_store(hv, "scroll", 6, newSViv(view->scroll), 0);
+	(void) hv_store(hv, "default_indent", 14, newSViv(view->default_indent), 0);
+	(void) hv_store(hv, "longword_noindent", 17, newSViv(view->longword_noindent), 0);
+	(void) hv_store(hv, "scroll", 6, newSViv(view->scroll), 0);
 
-	hv_store(hv, "ypos", 4, newSViv(view->ypos), 0);
+	(void) hv_store(hv, "ypos", 4, newSViv(view->ypos), 0);
 
-	hv_store(hv, "startline", 9, plain_bless(view->startline, "Irssi::TextUI::Line"), 0);
-	hv_store(hv, "subline", 7, newSViv(view->subline), 0);
+	(void) hv_store(hv, "startline", 9, plain_bless(view->startline, "Irssi::TextUI::Line"), 0);
+	(void) hv_store(hv, "subline", 7, newSViv(view->subline), 0);
 
-	hv_store(hv, "bottom_startline", 16, plain_bless(view->bottom_startline, "Irssi::TextUI::Line"), 0);
-	hv_store(hv, "bottom_subline", 14, newSViv(view->bottom_subline), 0);
+	(void) hv_store(hv, "bottom_startline", 16, plain_bless(view->bottom_startline, "Irssi::TextUI::Line"), 0);
+	(void) hv_store(hv, "bottom_subline", 14, newSViv(view->bottom_subline), 0);
 
-	hv_store(hv, "empty_linecount", 15, newSViv(view->empty_linecount), 0);
-	hv_store(hv, "bottom", 6, newSViv(view->bottom), 0);
+	(void) hv_store(hv, "empty_linecount", 15, newSViv(view->empty_linecount), 0);
+	(void) hv_store(hv, "bottom", 6, newSViv(view->bottom), 0);
 }
 
 static void perl_line_fill_hash(HV *hv, LINE_REC *line)
 {
-	hv_store(hv, "info", 4, plain_bless(&line->info, "Irssi::TextUI::LineInfo"), 0);
+	(void) hv_store(hv, "info", 4, plain_bless(&line->info, "Irssi::TextUI::LineInfo"), 0);
 }
 
 static void perl_line_cache_fill_hash(HV *hv, LINE_CACHE_REC *cache)
 {
-	hv_store(hv, "last_access", 11, newSViv(cache->last_access), 0);
-	hv_store(hv, "count", 5, newSViv(cache->count), 0);
+	(void) hv_store(hv, "last_access", 11, newSViv(cache->last_access), 0);
+	(void) hv_store(hv, "count", 5, newSViv(cache->count), 0);
 	/*LINE_CACHE_SUB_REC lines[1];*/
 }
 
 static void perl_line_info_fill_hash(HV *hv, LINE_INFO_REC *info)
 {
-	hv_store(hv, "level", 5, newSViv(info->level), 0);
-	hv_store(hv, "time", 4, newSViv(info->time), 0);
+	(void) hv_store(hv, "level", 5, newSViv(info->level), 0);
+	(void) hv_store(hv, "time", 4, newSViv(info->time), 0);
 }
 
 static void perl_statusbar_item_fill_hash(HV *hv, SBAR_ITEM_REC *item)
 {
-	hv_store(hv, "min_size", 8, newSViv(item->min_size), 0);
-	hv_store(hv, "max_size", 8, newSViv(item->max_size), 0);
-	hv_store(hv, "xpos", 4, newSViv(item->xpos), 0);
-	hv_store(hv, "size", 4, newSViv(item->size), 0);
+	(void) hv_store(hv, "min_size", 8, newSViv(item->min_size), 0);
+	(void) hv_store(hv, "max_size", 8, newSViv(item->max_size), 0);
+	(void) hv_store(hv, "xpos", 4, newSViv(item->xpos), 0);
+	(void) hv_store(hv, "size", 4, newSViv(item->size), 0);
 	if (item->bar->parent_window != NULL)
-		hv_store(hv, "window", 6, plain_bless(item->bar->parent_window->active, "Irssi::UI::Window"), 0);
+		(void) hv_store(hv, "window", 6, plain_bless(item->bar->parent_window->active, "Irssi::UI::Window"), 0);
 }
 
 static PLAIN_OBJECT_INIT_REC textui_plains[] = {

--- a/src/perl/ui/UI.xs
+++ b/src/perl/ui/UI.xs
@@ -8,60 +8,60 @@ static int initialized = FALSE;
 
 static void perl_process_fill_hash(HV *hv, PROCESS_REC *process)
 {
-	hv_store(hv, "id", 2, newSViv(process->id), 0);
-	hv_store(hv, "name", 4, new_pv(process->name), 0);
-	hv_store(hv, "args", 4, new_pv(process->args), 0);
+	(void) hv_store(hv, "id", 2, newSViv(process->id), 0);
+	(void) hv_store(hv, "name", 4, new_pv(process->name), 0);
+	(void) hv_store(hv, "args", 4, new_pv(process->args), 0);
 
-	hv_store(hv, "pid", 3, newSViv(process->pid), 0);
-	hv_store(hv, "target", 6, new_pv(process->target), 0);
+	(void) hv_store(hv, "pid", 3, newSViv(process->pid), 0);
+	(void) hv_store(hv, "target", 6, new_pv(process->target), 0);
 	if (process->target_win != NULL) {
-		hv_store(hv, "target_win", 10,
+		(void) hv_store(hv, "target_win", 10,
 			 plain_bless(process->target_win, "Irssi::UI::Window"), 0);
 	}
-	hv_store(hv, "shell", 5, newSViv(process->shell), 0);
-	hv_store(hv, "notice", 6, newSViv(process->notice), 0);
-	hv_store(hv, "silent", 6, newSViv(process->silent), 0);
+	(void) hv_store(hv, "shell", 5, newSViv(process->shell), 0);
+	(void) hv_store(hv, "notice", 6, newSViv(process->notice), 0);
+	(void) hv_store(hv, "silent", 6, newSViv(process->silent), 0);
 }
 
 static void perl_window_fill_hash(HV *hv, WINDOW_REC *window)
 {
-	hv_store(hv, "refnum", 6, newSViv(window->refnum), 0);
-	hv_store(hv, "name", 4, new_pv(window->name), 0);
-	hv_store(hv, "history_name", 12, new_pv(window->history_name), 0);
+	(void) hv_store(hv, "refnum", 6, newSViv(window->refnum), 0);
+	(void) hv_store(hv, "name", 4, new_pv(window->name), 0);
+	(void) hv_store(hv, "history_name", 12, new_pv(window->history_name), 0);
 
-	hv_store(hv, "width", 5, newSViv(window->width), 0);
-	hv_store(hv, "height", 6, newSViv(window->height), 0);
+	(void) hv_store(hv, "width", 5, newSViv(window->width), 0);
+	(void) hv_store(hv, "height", 6, newSViv(window->height), 0);
 
 	if (window->active)
-		hv_store(hv, "active", 6, iobject_bless(window->active), 0);
+		(void) hv_store(hv, "active", 6, iobject_bless(window->active), 0);
 	if (window->active_server)
-		hv_store(hv, "active_server", 13, iobject_bless(window->active_server), 0);
+		(void) hv_store(hv, "active_server", 13, iobject_bless(window->active_server), 0);
 
-	hv_store(hv, "servertag", 9, new_pv(window->servertag), 0);
-	hv_store(hv, "level", 5, newSViv(window->level), 0);
+	(void) hv_store(hv, "servertag", 9, new_pv(window->servertag), 0);
+	(void) hv_store(hv, "level", 5, newSViv(window->level), 0);
 
-	hv_store(hv, "immortal", 8, newSViv(window->immortal), 0);
-	hv_store(hv, "sticky_refnum", 13, newSViv(window->sticky_refnum), 0);
+	(void) hv_store(hv, "immortal", 8, newSViv(window->immortal), 0);
+	(void) hv_store(hv, "sticky_refnum", 13, newSViv(window->sticky_refnum), 0);
 
-	hv_store(hv, "data_level", 10, newSViv(window->data_level), 0);
-	hv_store(hv, "hilight_color", 13, new_pv(window->hilight_color), 0);
+	(void) hv_store(hv, "data_level", 10, newSViv(window->data_level), 0);
+	(void) hv_store(hv, "hilight_color", 13, new_pv(window->hilight_color), 0);
 
-	hv_store(hv, "last_timestamp", 14, newSViv(window->last_timestamp), 0);
-	hv_store(hv, "last_line", 9, newSViv(window->last_line), 0);
+	(void) hv_store(hv, "last_timestamp", 14, newSViv(window->last_timestamp), 0);
+	(void) hv_store(hv, "last_line", 9, newSViv(window->last_line), 0);
 
-	hv_store(hv, "theme", 5, plain_bless(window->theme, "Irssi::UI::Theme"), 0);
-	hv_store(hv, "theme_name", 10, new_pv(window->theme_name), 0);
+	(void) hv_store(hv, "theme", 5, plain_bless(window->theme, "Irssi::UI::Theme"), 0);
+	(void) hv_store(hv, "theme_name", 10, new_pv(window->theme_name), 0);
 }
 
 static void perl_text_dest_fill_hash(HV *hv, TEXT_DEST_REC *dest)
 {
-	hv_store(hv, "window", 6, plain_bless(dest->window, "Irssi::UI::Window"), 0);
-	hv_store(hv, "server", 6, iobject_bless(dest->server), 0);
-	hv_store(hv, "target", 6, new_pv(dest->target), 0);
-	hv_store(hv, "level", 5, newSViv(dest->level), 0);
+	(void) hv_store(hv, "window", 6, plain_bless(dest->window, "Irssi::UI::Window"), 0);
+	(void) hv_store(hv, "server", 6, iobject_bless(dest->server), 0);
+	(void) hv_store(hv, "target", 6, new_pv(dest->target), 0);
+	(void) hv_store(hv, "level", 5, newSViv(dest->level), 0);
 
-	hv_store(hv, "hilight_priority", 16, newSViv(dest->hilight_priority), 0);
-	hv_store(hv, "hilight_color", 13, new_pv(dest->hilight_color), 0);
+	(void) hv_store(hv, "hilight_priority", 16, newSViv(dest->hilight_priority), 0);
+	(void) hv_store(hv, "hilight_color", 13, new_pv(dest->hilight_color), 0);
 }
 
 static PLAIN_OBJECT_INIT_REC fe_plains[] = {


### PR DESCRIPTION
sed -i 's/hv_store/(void) &/'

This only results in a warning in older gcc versions, but that includes
the one used in the Travis CI environment by default

Replaces PR #116. Quoting @ahf:

>I personally much prefer being explicit in the code (with a type-cast to void) over disabling a warning option.