### PR TITLE
Change all strcmp() to g_strcmp0() to handle nulls gracefully

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -53,7 +53,7 @@
 #endif
 
 #if !GLIB_CHECK_VERSION(2,16,0)
-#define g_strcmp0(str1, str2) strcmp(str1, str2)
+#define g_strcmp0(a, b) (!a ? -(a != b) : (!b ? (a != b) : strcmp(a, b)))
 #endif
 
 #ifdef USE_GC

--- a/src/common.h
+++ b/src/common.h
@@ -52,6 +52,10 @@
 #define g_slice_free(type, mem)  g_free(mem)
 #endif
 
+#if !GLIB_CHECK_VERSION(2,16,0)
+#define g_strcmp0(str1, str2) strcmp(str1, str2)
+#endif
+
 #ifdef USE_GC
 #  define g_free(x) G_STMT_START { (x) = NULL; } G_STMT_END
 #endif

--- a/src/core/channels.c
+++ b/src/core/channels.c
@@ -167,7 +167,7 @@ static GSList *servers_find_chatnet_except(SERVER_REC *server)
 		SERVER_REC *rec = tmp->data;
 
 		if (server != rec && rec->connrec->chatnet != NULL &&
-		    strcmp(server->connrec->chatnet,
+		    g_strcmp0(server->connrec->chatnet,
 			   rec->connrec->chatnet) == 0) {
 			/* chatnets match */
 			list = g_slist_append(list, rec);

--- a/src/core/chat-commands.c
+++ b/src/core/chat-commands.c
@@ -58,7 +58,7 @@ static SERVER_CONNECT_REC *get_server_connect(const char *data, int *plus_addr,
 		return NULL;
 	}
 
-	if (strcmp(password, "-") == 0)
+	if (g_strcmp0(password, "-") == 0)
 		*password = '\0';
 
         /* check if -<chatnet> option is used to specify chat protocol */
@@ -283,7 +283,7 @@ static void cmd_disconnect(const char *data, SERVER_REC *server)
 	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_GETREST, &tag, &msg))
 		return;
 
-	if (*tag != '\0' && strcmp(tag, "*") != 0) {
+	if (*tag != '\0' && g_strcmp0(tag, "*") != 0) {
 		server = server_find_tag(tag);
 		if (server == NULL)
 			server = server_find_lookup_tag(tag);
@@ -343,7 +343,7 @@ static void cmd_msg(const char *data, SERVER_REC *server, WI_ITEM_REC *item)
 
         origtarget = target;
 	free_ret = FALSE;
-	if (strcmp(target, ",") == 0 || strcmp(target, ".") == 0) {
+	if (g_strcmp0(target, ",") == 0 || g_strcmp0(target, ".") == 0) {
 		target = parse_special(&target, server, item,
 				       NULL, &free_ret, NULL, 0);
 		if (target != NULL && *target == '\0') {
@@ -355,7 +355,7 @@ static void cmd_msg(const char *data, SERVER_REC *server, WI_ITEM_REC *item)
 	}
 
 	if (target != NULL) {
-		if (strcmp(target, "*") == 0) {
+		if (g_strcmp0(target, "*") == 0) {
                         /* send to active channel/query */
 			if (item == NULL)
 				cmd_param_error(CMDERR_NOT_JOINED);

--- a/src/core/commands.c
+++ b/src/core/commands.c
@@ -674,7 +674,7 @@ get_optional_channel(WI_ITEM_REC *active_item, char **data, int require_name)
 	origtmp = tmp = g_strdup(*data);
 	channel = cmd_get_param(&tmp);
 
-	if (strcmp(channel, "*") == 0 && !require_name) {
+	if (g_strcmp0(channel, "*") == 0 && !require_name) {
                 /* "*" means active channel */
 		cmd_get_param(data);
 		ret = window_item_get_target(active_item);

--- a/src/core/ignore.c
+++ b/src/core/ignore.c
@@ -201,10 +201,10 @@ IGNORE_REC *ignore_find_noact(const char *servertag, const char *mask,
 	char **chan;
 	int ignore_servertag;
 
-	if (mask != NULL && (*mask == '\0' || strcmp(mask, "*") == 0))
+	if (mask != NULL && (*mask == '\0' || g_strcmp0(mask, "*") == 0))
 		mask = NULL;
 
-	ignore_servertag = servertag != NULL && strcmp(servertag, "*") == 0;
+	ignore_servertag = servertag != NULL && g_strcmp0(servertag, "*") == 0;
 	for (tmp = ignores; tmp != NULL; tmp = tmp->next) {
 		IGNORE_REC *rec = tmp->data;
 
@@ -232,7 +232,7 @@ IGNORE_REC *ignore_find_noact(const char *servertag, const char *mask,
 		if ((channels == NULL && rec->channels == NULL))
 			return rec; /* no channels - ok */
 
-		if (channels != NULL && strcmp(*channels, "*") == 0)
+		if (channels != NULL && g_strcmp0(*channels, "*") == 0)
 			return rec; /* ignore channels */
 
 		if (channels == NULL || rec->channels == NULL)

--- a/src/core/levels.c
+++ b/src/core/levels.c
@@ -54,7 +54,7 @@ int level_get(const char *level)
 {
 	int n, len, match;
 
-	if (g_ascii_strcasecmp(level, "ALL") == 0 || strcmp(level, "*") == 0)
+	if (g_ascii_strcasecmp(level, "ALL") == 0 || g_strcmp0(level, "*") == 0)
 		return MSGLEVEL_ALL;
 
 	if (g_ascii_strcasecmp(level, "NEVER") == 0)
@@ -177,7 +177,7 @@ int combine_level(int dest, const char *src)
 		itemname = *item + (**item == '+' || **item == '-' ? 1 : 0);
 		itemlevel = level_get(itemname);
 
-		if (strcmp(itemname, "NONE") == 0)
+		if (g_strcmp0(itemname, "NONE") == 0)
                         dest = 0;
 		else if (**item == '-')
 			dest &= ~(itemlevel);

--- a/src/core/log.c
+++ b/src/core/log.c
@@ -110,7 +110,7 @@ int log_start_logging(LOG_REC *log)
 	log->real_fname = log_filename(log);
 
 	if (log->real_fname != NULL &&
-	    strcmp(log->real_fname, log->fname) != 0) {
+	    g_strcmp0(log->real_fname, log->fname) != 0) {
 		/* path may contain variables (%time, $vars),
 		   make sure the directory is created */
 		dir = g_path_get_dirname(log->real_fname);
@@ -181,7 +181,7 @@ static void log_rotate_check(LOG_REC *log)
 		return;
 
 	new_fname = log_filename(log);
-	if (strcmp(new_fname, log->real_fname) != 0) {
+	if (g_strcmp0(new_fname, log->real_fname) != 0) {
 		/* rotate log */
 		log_stop_logging(log);
 		signal_emit("log rotated", 1, log);
@@ -245,7 +245,7 @@ static int itemcmp(const char *patt, const char *item)
 {
 	/* returns 0 on match, nonzero otherwise */
 
-	if (!strcmp(patt, "*"))
+	if (!g_strcmp0(patt, "*"))
 		return 0;
         return item ? g_ascii_strcasecmp(patt, item) : 1;
 }
@@ -320,7 +320,7 @@ LOG_REC *log_find(const char *fname)
 	for (tmp = logs; tmp != NULL; tmp = tmp->next) {
 		LOG_REC *rec = tmp->data;
 
-		if (strcmp(rec->fname, fname) == 0)
+		if (g_strcmp0(rec->fname, fname) == 0)
 			return rec;
 	}
 

--- a/src/core/misc.c
+++ b/src/core/misc.c
@@ -184,7 +184,7 @@ int strarray_find(char **array, const char *item)
 GSList *gslist_find_string(GSList *list, const char *key)
 {
 	for (; list != NULL; list = list->next)
-		if (strcmp(list->data, key) == 0) return list;
+		if (g_strcmp0(list->data, key) == 0) return list;
 
 	return NULL;
 }
@@ -269,7 +269,7 @@ GSList *hashtable_get_keys(GHashTable *hash)
 GList *glist_find_string(GList *list, const char *key)
 {
 	for (; list != NULL; list = list->next)
-		if (strcmp(list->data, key) == 0) return list;
+		if (g_strcmp0(list->data, key) == 0) return list;
 
 	return NULL;
 }

--- a/src/core/modules-load.c
+++ b/src/core/modules-load.c
@@ -78,7 +78,7 @@ static char *module_get_root(const char *name, char **prefixes)
 
 	/* skip the _core part */
         len = strlen(name);
-	if (len > 5 && strcmp(name+len-5, "_core") == 0)
+	if (len > 5 && g_strcmp0(name+len-5, "_core") == 0)
 		return g_strndup(name, len-5);
 
         return g_strdup(name);
@@ -94,11 +94,11 @@ static char *module_get_sub(const char *name, const char *root)
         g_return_val_if_fail(namelen >= rootlen, g_strdup(name));
 
 	if (strncmp(name, root, rootlen) == 0 &&
-	    strcmp(name+rootlen, "_core") == 0)
+	    g_strcmp0(name+rootlen, "_core") == 0)
                 return g_strdup("core");
 
 	if (namelen > rootlen && name[namelen-rootlen-1] == '_' &&
-	    strcmp(name+namelen-rootlen, root) == 0)
+	    g_strcmp0(name+namelen-rootlen, root) == 0)
                 return g_strndup(name, namelen-rootlen-1);
 
         return g_strdup(name);
@@ -140,10 +140,10 @@ static GModule *module_open(const char *name, int *found)
 static char *module_get_func(const char *rootmodule, const char *submodule,
 			     const char *function)
 {
-	if (strcmp(submodule, "core") == 0)
+	if (g_strcmp0(submodule, "core") == 0)
 		return g_strconcat(rootmodule, "_core_", function, NULL);
 
-	if (strcmp(rootmodule, submodule) == 0)
+	if (g_strcmp0(rootmodule, submodule) == 0)
 		return g_strconcat(rootmodule, "_", function, NULL);
 
 	return g_strconcat(submodule, "_", rootmodule, "_", function, NULL);
@@ -200,7 +200,7 @@ static int module_load_name(const char *path, const char *rootmodule,
 
 	module = module_find(rootmodule);
 	rec = module == NULL ? NULL :
-                strcmp(rootmodule, submodule) == 0 ?
+                g_strcmp0(rootmodule, submodule) == 0 ?
 		module_file_find(module, "core") :
 		module_file_find(module, submodule);
 	if (rec == NULL) {
@@ -277,7 +277,7 @@ static int module_load_full(const char *path, const char *rootmodule,
 		return FALSE;
 
 	module = module_find(rootmodule);
-	if (module != NULL && (strcmp(submodule, rootmodule) == 0 ||
+	if (module != NULL && (g_strcmp0(submodule, rootmodule) == 0 ||
 			       module_file_find(module, submodule) != NULL)) {
                 /* module is already loaded */
 		module_error(MODULE_ERROR_ALREADY_LOADED, NULL,
@@ -286,7 +286,7 @@ static int module_load_full(const char *path, const char *rootmodule,
 	}
 
 	/* check if the given module exists.. */
-	try_prefixes = strcmp(rootmodule, submodule) == 0;
+	try_prefixes = g_strcmp0(rootmodule, submodule) == 0;
 	status = module_load_name(path, rootmodule, submodule, try_prefixes);
 	if (status == -1 && try_prefixes) {
 		/* nope, try loading the module_core,
@@ -340,7 +340,7 @@ int module_load_sub(const char *path, const char *submodule, char **prefixes)
 	g_free(name);
 
         full_path = g_string_new(exppath);
-	if (strcmp(submodule, "core") == 0)
+	if (g_strcmp0(submodule, "core") == 0)
 		g_string_insert(full_path, end, "_core");
 	else {
 		g_string_insert_c(full_path, start, '_');

--- a/src/core/modules.c
+++ b/src/core/modules.c
@@ -44,7 +44,7 @@ void *module_check_cast_module(void *object, int type_pos,
 
 	str = module_find_id_str(module,
 				 G_STRUCT_MEMBER(int, object, type_pos));
-	return str == NULL || strcmp(str, id) != 0 ? NULL : object;
+	return str == NULL || g_strcmp0(str, id) != 0 ? NULL : object;
 }
 
 /* return unique number across all modules for `id' */
@@ -251,7 +251,7 @@ MODULE_FILE_REC *module_file_find(MODULE_REC *module, const char *name)
 	for (tmp = module->files; tmp != NULL; tmp = tmp->next) {
 		MODULE_FILE_REC *rec = tmp->data;
 
-		if (strcmp(rec->name, name) == 0)
+		if (g_strcmp0(rec->name, name) == 0)
                         return rec;
 	}
 

--- a/src/core/nicklist.c
+++ b/src/core/nicklist.c
@@ -478,7 +478,7 @@ static NICK_REC *nick_nfind(CHANNEL_REC *channel, const char *nick, int len)
 	if (rec != NULL) {
 		/* if there's multiple, get the one with identical case */
 		while (rec->next != NULL) {
-			if (strcmp(rec->nick, tmpnick) == 0)
+			if (g_strcmp0(rec->nick, tmpnick) == 0)
 				break;
                         rec = rec->next;
 		}

--- a/src/core/servers-reconnect.c
+++ b/src/core/servers-reconnect.c
@@ -384,7 +384,7 @@ static void cmd_reconnect(const char *data, SERVER_REC *server)
 	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_GETREST, &tag, &msg))
 		return;
 
-	if (*tag != '\0' && strcmp(tag, "*") != 0)
+	if (*tag != '\0' && g_strcmp0(tag, "*") != 0)
 		server = server_find_tag(tag);
 
 	if (server != NULL) {

--- a/src/core/servers-setup.c
+++ b/src/core/servers-setup.c
@@ -526,7 +526,7 @@ static void read_servers(void)
 static void read_settings(void)
 {
 	if (old_source_host == NULL ||
-	    strcmp(old_source_host, settings_get_str("hostname")) != 0) {
+	    g_strcmp0(old_source_host, settings_get_str("hostname")) != 0) {
                 g_free_not_null(old_source_host);
 		old_source_host = g_strdup(settings_get_str("hostname"));
 

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -295,7 +295,7 @@ void settings_remove(const char *key)
 static int settings_remove_hash(const char *key, SETTINGS_REC *rec,
 				const char *module)
 {
-	if (strcmp(rec->module, module) == 0) {
+	if (g_strcmp0(rec->module, module) == 0) {
 		settings_unref(rec, FALSE);
                 return TRUE;
 	}
@@ -428,7 +428,7 @@ static void settings_clean_invalid_module(const char *module)
                 next = config_node_next(tmp);
 
 		set = g_hash_table_lookup(settings, subnode->key);
-		if (set == NULL || strcmp(set->module, module) != 0)
+		if (set == NULL || g_strcmp0(set->module, module) != 0)
                         iconfig_node_remove(node, subnode);
 	}
 }
@@ -458,7 +458,7 @@ static int backwards_compatibility(const char *module, CONFIG_NODE *node,
 	new_value = NULL; new_key = NULL; new_module = NULL;
 
 	/* fe-text term_type -> fe-common/core term_charset - for 0.8.10-> */
-	if (strcmp(module, "fe-text") == 0) {
+	if (g_strcmp0(module, "fe-text") == 0) {
 		if (g_ascii_strcasecmp(node->key, "term_type") == 0 ||
 		    /* kludge for cvs-version where term_charset was in fe-text */
 		    g_ascii_strcasecmp(node->key, "term_charset") == 0) {
@@ -520,7 +520,7 @@ void settings_check_module(const char *module)
 		if (backwards_compatibility(module, node, parent))
 			continue;
 
-		if (set == NULL || strcmp(set->module, module) != 0) {
+		if (set == NULL || g_strcmp0(set->module, module) != 0) {
 			g_string_append_printf(errors, " %s", node->key);
                         count++;
 		}
@@ -548,9 +548,9 @@ void settings_check_module(const char *module)
 
 static int settings_compare(SETTINGS_REC *v1, SETTINGS_REC *v2)
 {
-	int cmp = strcmp(v1->section, v2->section);
+	int cmp = g_strcmp0(v1->section, v2->section);
 	if (!cmp)
-		cmp = strcmp(v1->key, v2->key);
+		cmp = g_strcmp0(v1->key, v2->key);
 	return cmp;
 }
 

--- a/src/fe-common/core/command-history.c
+++ b/src/fe-common/core/command-history.c
@@ -42,7 +42,7 @@ void command_history_add(HISTORY_REC *history, const char *text)
 	g_return_if_fail(text != NULL);
 
 	link = g_list_last(history->list);
-	if (link != NULL && strcmp(link->data, text) == 0)
+	if (link != NULL && g_strcmp0(link->data, text) == 0)
 	  return; /* same as previous entry */
 
 	if (settings_get_int("max_command_history") < 1 ||
@@ -121,7 +121,7 @@ const char *command_history_prev(WINDOW_REC *window, const char *text)
 	}
 
 	if (*text != '\0' &&
-	    (pos == NULL || strcmp(pos->data, text) != 0)) {
+	    (pos == NULL || g_strcmp0(pos->data, text) != 0)) {
 		/* save the old entry to history */
 		command_history_add(history, text);
 	}
@@ -145,7 +145,7 @@ const char *command_history_next(WINDOW_REC *window, const char *text)
 	}
 
 	if (*text != '\0' &&
-	    (pos == NULL || strcmp(pos->data, text) != 0)) {
+	    (pos == NULL || g_strcmp0(pos->data, text) != 0)) {
 		/* save the old entry to history */
 		command_history_add(history, text);
 	}

--- a/src/fe-common/core/completion.c
+++ b/src/fe-common/core/completion.c
@@ -141,7 +141,7 @@ char *word_complete(WINDOW_REC *window, const char *line, int *pos, int erase, i
 	g_return_val_if_fail(pos != NULL, NULL);
 
 	continue_complete = complist != NULL && *pos == last_line_pos &&
-		strcmp(line, last_line) == 0;
+		g_strcmp0(line, last_line) == 0;
 
 	if (erase && !continue_complete)
 		return NULL;
@@ -681,7 +681,7 @@ static void sig_complete_set(GList **list, WINDOW_REC *window,
 	g_return_if_fail(line != NULL);
 
 	if (*line == '\0' ||
-	    !strcmp("-clear", line) || !strcmp("-default", line))
+	    !g_strcmp0("-clear", line) || !g_strcmp0("-default", line))
 		*list = completion_get_settings(word, -1);
 	else if (*line != '\0' && *word == '\0') {
 		SETTINGS_REC *rec = settings_get_record(line);

--- a/src/fe-common/core/fe-channels.c
+++ b/src/fe-common/core/fe-channels.c
@@ -287,7 +287,7 @@ static void cmd_channel_add(const char *data)
 	if (g_hash_table_lookup(optlist, "noauto")) rec->autojoin = FALSE;
 	if (botarg != NULL && *botarg != '\0') rec->botmasks = g_strdup(botarg);
 	if (botcmdarg != NULL && *botcmdarg != '\0') rec->autosendcmd = g_strdup(botcmdarg);
-	if (*password != '\0' && strcmp(password, "-") != 0) rec->password = g_strdup(password);
+	if (*password != '\0' && g_strcmp0(password, "-") != 0) rec->password = g_strdup(password);
 
 	signal_emit("channel add fill", 2, rec, optlist);
 
@@ -523,7 +523,7 @@ static void cmd_names(const char *data, SERVER_REC *server, WI_ITEM_REC *item)
 			    "names", &optlist, &channel))
 		return;
 
-	if (strcmp(channel, "*") == 0 || *channel == '\0') {
+	if (g_strcmp0(channel, "*") == 0 || *channel == '\0') {
 		if (!IS_CHANNEL(item))
                         cmd_param_error(CMDERR_NOT_JOINED);
 
@@ -561,7 +561,7 @@ static void cmd_names(const char *data, SERVER_REC *server, WI_ITEM_REC *item)
 	if (unknowns->len > 1)
                 g_string_truncate(unknowns, unknowns->len-1);
 
-	if (unknowns->len > 0 && strcmp(channel, unknowns->str) != 0)
+	if (unknowns->len > 0 && g_strcmp0(channel, unknowns->str) != 0)
                 signal_emit("command names", 3, unknowns->str, server, item);
         g_string_free(unknowns, TRUE);
 

--- a/src/fe-common/core/fe-exec.c
+++ b/src/fe-common/core/fe-exec.c
@@ -161,7 +161,7 @@ static PROCESS_REC *process_find(const char *name, int verbose)
 	for (tmp = processes; tmp != NULL; tmp = tmp->next) {
 		PROCESS_REC *rec = tmp->data;
 
-		if (rec->name != NULL && strcmp(rec->name, name) == 0)
+		if (rec->name != NULL && g_strcmp0(rec->name, name) == 0)
 			return rec;
 	}
 

--- a/src/fe-common/core/fe-help.c
+++ b/src/fe-common/core/fe-help.c
@@ -37,12 +37,12 @@ static int commands_equal(COMMAND_REC *rec, COMMAND_REC *rec2)
 	if (rec2->category == NULL && rec->category != NULL)
 		return 1;
 	if (rec->category != NULL && rec2->category != NULL) {
-		i = strcmp(rec->category, rec2->category);
+		i = g_strcmp0(rec->category, rec2->category);
 		if (i != 0)
 			return i;
 	}
 
-	return strcmp(rec->cmd, rec2->cmd);
+	return g_strcmp0(rec->cmd, rec2->cmd);
 }
 
 static int get_cmd_length(void *data)
@@ -176,7 +176,7 @@ static void show_help(const char *data)
 
 		if (last != NULL && rec->category != NULL &&
 		    (last->category == NULL ||
-		     strcmp(rec->category, last->category) != 0)) {
+		     g_strcmp0(rec->category, last->category) != 0)) {
 			/* category changed */
 			if (items > 0) {
 				if (!header) {

--- a/src/fe-common/core/fe-ignore.c
+++ b/src/fe-common/core/fe-ignore.c
@@ -165,7 +165,7 @@ static void cmd_ignore(const char *data)
 		rec = g_new0(IGNORE_REC, 1);
 
 		rec->mask = mask == NULL || *mask == '\0' ||
-			strcmp(mask, "*") == 0 ? NULL : g_strdup(mask);
+			g_strcmp0(mask, "*") == 0 ? NULL : g_strdup(mask);
 		rec->channels = channels;
 	} else {
                 g_free_and_null(rec->pattern);

--- a/src/fe-common/core/fe-log.c
+++ b/src/fe-common/core/fe-log.c
@@ -485,7 +485,7 @@ static void autolog_open_check(TEXT_DEST_REC *dest)
 		return;
 
 	if (target != NULL)
-		autolog_open(server, server_tag, strcmp(target, "*") ? target : deftarget);
+		autolog_open(server, server_tag, g_strcmp0(target, "*") ? target : deftarget);
 }
 
 static void log_single_line(WINDOW_REC *window, const char *server_tag,
@@ -629,7 +629,7 @@ static void sig_log_create_failed(LOG_REC *log)
 static void sig_log_new(LOG_REC *log)
 {
 	if (!settings_get_bool("awaylog_colors") &&
-	    strcmp(log->fname, settings_get_str("awaylog_file")) == 0)
+	    g_strcmp0(log->fname, settings_get_str("awaylog_file")) == 0)
                 log->colorizer = log_colorizer_strip;
 }
 

--- a/src/fe-common/core/fe-messages.c
+++ b/src/fe-common/core/fe-messages.c
@@ -249,7 +249,7 @@ static void sig_message_private(SERVER_REC *server, const char *msg,
 	int level = MSGLEVEL_MSGS;
 
 	/* own message returned by bouncer? */
-	int own = (!strcmp(nick, server->nick));
+	int own = (!g_strcmp0(nick, server->nick));
 
 	query = query_find(server, own ? target : nick);
 
@@ -323,8 +323,8 @@ static void sig_message_own_private(SERVER_REC *server, const char *msg,
 		/* this should only happen if some special target failed and
 		   we should display some error message. currently the special
 		   targets are only ',' and '.'. */
-		g_return_if_fail(strcmp(origtarget, ",") == 0 ||
-				 strcmp(origtarget, ".") == 0);
+		g_return_if_fail(g_strcmp0(origtarget, ",") == 0 ||
+				 g_strcmp0(origtarget, ".") == 0);
 
 		printformat(NULL, NULL, MSGLEVEL_CLIENTNOTICE,
 			    *origtarget == ',' ? TXT_NO_MSGS_GOT :
@@ -569,7 +569,7 @@ static int printnick_exists(NICK_REC *first, NICK_REC *ignore,
 	while (first != NULL) {
 		if (first != ignore) {
 			printnick = g_hash_table_lookup(printnicks, first);
-			if (printnick != NULL && strcmp(printnick, nick) == 0)
+			if (printnick != NULL && g_strcmp0(printnick, nick) == 0)
 				return TRUE;
 		}
 

--- a/src/fe-common/core/fe-queries.c
+++ b/src/fe-common/core/fe-queries.c
@@ -331,7 +331,7 @@ static void sig_message_private(SERVER_REC *server, const char *msg,
 	QUERY_REC *query;
 
 	/* own message returned by bouncer? */
-	int own = (!strcmp(nick, server->nick));
+	int own = (!g_strcmp0(nick, server->nick));
 
 	/* create query window if needed */
 	query = privmsg_get_query(server, own ? target : nick, FALSE, MSGLEVEL_MSGS);

--- a/src/fe-common/core/fe-recode.c
+++ b/src/fe-common/core/fe-recode.c
@@ -45,7 +45,7 @@ static const char *fe_recode_get_target (WI_ITEM_REC *witem)
 
 static int fe_recode_compare_func (CONFIG_NODE *node1, CONFIG_NODE *node2)
 {
-	return strcmp(node1->key, node2->key);
+	return g_strcmp0(node1->key, node2->key);
 }
 
 /* SYNTAX: RECODE */

--- a/src/fe-common/core/fe-server.c
+++ b/src/fe-common/core/fe-server.c
@@ -185,7 +185,7 @@ static void cmd_server_add(const char *data)
 	if (g_hash_table_lookup(optlist, "proxy")) rec->no_proxy = FALSE;
 	if (g_hash_table_lookup(optlist, "noproxy")) rec->no_proxy = TRUE;
 
-	if (*password != '\0' && strcmp(password, "-") != 0) rec->password = g_strdup(password);
+	if (*password != '\0' && g_strcmp0(password, "-") != 0) rec->password = g_strdup(password);
 	value = g_hash_table_lookup(optlist, "host");
 	if (value != NULL && *value != '\0') {
 		rec->own_host = g_strdup(value);
@@ -264,7 +264,7 @@ static void cmd_server_connect(const char *data)
 			    "connect", &optlist, &addr))
 		return;
 
-	if (*addr == '\0' || strcmp(addr, "+") == 0)
+	if (*addr == '\0' || g_strcmp0(addr, "+") == 0)
 		cmd_param_error(CMDERR_NOT_ENOUGH_PARAMS);
 	if (*addr == '+') window_create(NULL, FALSE);
 

--- a/src/fe-common/core/fe-settings.c
+++ b/src/fe-common/core/fe-settings.c
@@ -53,7 +53,7 @@ static void set_print_pattern(const char *pattern)
 
 		if (stristr(rec->key, pattern) == NULL)
 			continue;
-		if (strcmp(last_section, rec->section) != 0) {
+		if (g_strcmp0(last_section, rec->section) != 0) {
 			/* print section */
 			printformat(NULL, NULL, MSGLEVEL_CLIENTCRAP,
 				    TXT_SET_TITLE, rec->section);

--- a/src/fe-common/core/hilight-text.c
+++ b/src/fe-common/core/hilight-text.c
@@ -168,7 +168,7 @@ static HILIGHT_REC *hilight_find(const char *text, char **channels)
 		if ((channels == NULL && rec->channels == NULL))
 			return rec; /* no channels - ok */
 
-		if (channels != NULL && strcmp(*channels, "*") == 0)
+		if (channels != NULL && g_strcmp0(*channels, "*") == 0)
 			return rec; /* ignore channels */
 
 		if (channels == NULL || rec->channels == NULL)
@@ -306,7 +306,7 @@ void hilight_update_text_dest(TEXT_DEST_REC *dest, HILIGHT_REC *rec)
 		dest->hilight_priority = rec->priority;
 
 	g_free_and_null(dest->hilight_color);
-	if (rec->act_color != NULL && strcmp(rec->act_color, "%n") == 0)
+	if (rec->act_color != NULL && g_strcmp0(rec->act_color, "%n") == 0)
 		dest->level |= MSGLEVEL_NO_ACT;
         else
 		dest->hilight_color = hilight_get_act_color(rec);

--- a/src/fe-common/core/keyboard.c
+++ b/src/fe-common/core/keyboard.c
@@ -118,7 +118,7 @@ static CONFIG_NODE *key_config_find(const char *key)
 	for (; tmp != NULL; tmp = config_node_next(tmp)) {
 		node = tmp->data;
 
-		if (strcmp(config_node_get_str(node, "key", ""), key) == 0)
+		if (g_strcmp0(config_node_get_str(node, "key", ""), key) == 0)
                         return node;
 	}
 
@@ -211,7 +211,7 @@ static int expand_combo(const char *start, const char *end, GSList **out)
 	for (tmp = info->keys; tmp != NULL; tmp = tmp->next) {
 		KEY_REC *rec = tmp->data;
 
-		if (strcmp(rec->data, str) == 0)
+		if (g_strcmp0(rec->data, str) == 0)
                         list = g_slist_append(list, rec);
 	}
 
@@ -347,7 +347,7 @@ static void key_states_scan_key(const char *key, KEY_REC *rec)
 {
 	GSList *tmp, *out;
 
-	if (strcmp(rec->info->id, "key") == 0)
+	if (g_strcmp0(rec->info->id, "key") == 0)
 		return;
 
         out = g_slist_append(NULL, g_string_new(NULL));
@@ -383,7 +383,7 @@ static void key_states_rescan(void)
 	g_tree_foreach(key_states, (GTraverseFunc) key_state_destroy,
 			NULL);
 	g_tree_destroy(key_states);
-	key_states = g_tree_new((GCompareFunc) strcmp);
+	key_states = g_tree_new((GCompareFunc) g_strcmp0);
 
         temp = g_string_new(NULL);
 	g_hash_table_foreach(keys, (GHFunc) key_states_scan_key, temp);
@@ -860,7 +860,7 @@ void keyboard_init(void)
 	default_keys = g_hash_table_new((GHashFunc) g_str_hash,
 					(GCompareFunc) g_str_equal);
 	keyinfos = NULL;
-	key_states = g_tree_new((GCompareFunc) strcmp);
+	key_states = g_tree_new((GCompareFunc) g_strcmp0);
         key_config_frozen = 0;
 	memset(used_keys, 0, sizeof(used_keys));
 

--- a/src/fe-common/core/themes.c
+++ b/src/fe-common/core/themes.c
@@ -895,7 +895,7 @@ THEME_REC *theme_load(const char *setname)
 
         name = g_strdup(setname);
 	p = strrchr(name, '.');
-	if (p != NULL && strcmp(p, ".theme") == 0) {
+	if (p != NULL && g_strcmp0(p, ".theme") == 0) {
 		/* remove the trailing .theme */
                 *p = '\0';
 	}
@@ -1358,9 +1358,9 @@ static void read_settings(void)
 
 	theme = settings_get_str("theme");
 	len = strlen(current_theme->name);
-	if (strcmp(current_theme->name, theme) != 0 &&
+	if (g_strcmp0(current_theme->name, theme) != 0 &&
 	    (strncmp(current_theme->name, theme, len) != 0 ||
-	     strcmp(theme+len, ".theme") != 0))
+	     g_strcmp0(theme+len, ".theme") != 0))
 		change_theme(theme, TRUE);
 }
 

--- a/src/fe-common/core/window-commands.c
+++ b/src/fe-common/core/window-commands.c
@@ -127,7 +127,7 @@ static void cmd_window_info(WINDOW_REC *win)
 				   win->active_server->tag : "NONE");
 	} else {
 		if (win->active_server != NULL &&
-		    strcmp(win->active_server->tag, win->servertag) != 0)
+		    g_strcmp0(win->active_server->tag, win->servertag) != 0)
                         g_warning("Active server isn't the sticky server!");
 
 		printformat_window(win, MSGLEVEL_CLIENTCRAP,
@@ -609,7 +609,7 @@ static void cmd_window_name(const char *data)
 	if (win == NULL || win == active_win)
 		window_set_name(active_win, data);
 	else if (active_win->name == NULL ||
-		 strcmp(active_win->name, data) != 0) {
+		 g_strcmp0(active_win->name, data) != 0) {
 		printformat_window(active_win, MSGLEVEL_CLIENTERROR,
 				   TXT_WINDOW_NAME_NOT_UNIQUE, data);
 	}

--- a/src/fe-common/irc/dcc/fe-dcc-chat.c
+++ b/src/fe-common/irc/dcc/fe-dcc-chat.c
@@ -243,7 +243,7 @@ static void cmd_msg(const char *data, SERVER_REC *server, WI_ITEM_REC *item)
 		return;
 
 	/* handle only DCC messages */
-	if (strcmp(target, "*") == 0)
+	if (g_strcmp0(target, "*") == 0)
 		dcc = item_get_dcc(item);
 	else if (*target == '=')
 		dcc = dcc_chat_find_id(target+1);

--- a/src/fe-common/irc/fe-events-numeric.c
+++ b/src/fe-common/irc/fe-events-numeric.c
@@ -427,7 +427,7 @@ static void event_no_such_nick(IRC_SERVER_REC *server, const char *data,
 	g_return_if_fail(data != NULL);
 
 	params = event_get_params(data, 2, NULL, &unick);
-	if (!strcmp(unick, "*"))
+	if (!g_strcmp0(unick, "*"))
 		/* more information will be in the description,
 		 * e.g. * :Target left IRC. Failed to deliver: [hi] */
 		print_event_received(server, data, nick, FALSE);
@@ -605,7 +605,7 @@ static void print_event_received(IRC_SERVER_REC *server, const char *data,
 
 	recoded = recode_in(SERVER(server), args, NULL);
 	format = nick == NULL || server->real_address == NULL ||
-		strcmp(nick, server->real_address) == 0 ?
+		g_strcmp0(nick, server->real_address) == 0 ?
 		IRCTXT_DEFAULT_EVENT : IRCTXT_DEFAULT_EVENT_SERVER;
 	printformat(server, target, MSGLEVEL_CRAP, format,
 		    nick, recoded, current_server_event);

--- a/src/fe-common/irc/fe-irc-commands.c
+++ b/src/fe-common/irc/fe-irc-commands.c
@@ -110,7 +110,7 @@ static void cmd_notice(const char *data, IRC_SERVER_REC *server,
 	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_GETREST,
 			    &target, &msg))
 		return;
-	if (strcmp(target, "*") == 0)
+	if (g_strcmp0(target, "*") == 0)
 		target = item == NULL ? "" : window_item_get_target(item);
 
 	if (*target == '\0' || *msg == '\0')
@@ -133,7 +133,7 @@ static void cmd_ctcp(const char *data, IRC_SERVER_REC *server,
 	if (!cmd_get_params(data, &free_arg, 3 | PARAM_FLAG_GETREST,
 			    &target, &ctcpcmd, &ctcpdata))
 		return;
-	if (strcmp(target, "*") == 0)
+	if (g_strcmp0(target, "*") == 0)
 		target = item == NULL ? "" : window_item_get_target(item);
 	if (*target == '\0' || *ctcpcmd == '\0')
 		cmd_param_error(CMDERR_NOT_ENOUGH_PARAMS);
@@ -162,7 +162,7 @@ static void cmd_nctcp(const char *data, IRC_SERVER_REC *server,
 	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_GETREST,
 			    &target, &text))
 		return;
-	if (strcmp(target, "*") == 0)
+	if (g_strcmp0(target, "*") == 0)
 		target = item == NULL ? "" : window_item_get_target(item);
 	if (*target == '\0' || *text == '\0')
 		cmd_param_error(CMDERR_NOT_ENOUGH_PARAMS);
@@ -262,7 +262,7 @@ static void cmd_ban(const char *data, IRC_SERVER_REC *server,
 	if (chanrec == NULL && *channel == '\0')
 		cmd_param_error(CMDERR_NOT_JOINED);
 
-	if (*channel != '\0' && strcmp(channel, "*") != 0)
+	if (*channel != '\0' && g_strcmp0(channel, "*") != 0)
 		chanrec = irc_channel_find(server, channel);
 
 	if (chanrec == NULL || !chanrec->synced) {

--- a/src/fe-common/irc/fe-irc-messages.c
+++ b/src/fe-common/irc/fe-irc-messages.c
@@ -178,7 +178,7 @@ static void sig_message_irc_action(IRC_SERVER_REC *server, const char *msg,
 	if (ischannel(*target)) {
 		item = irc_channel_find(server, target);
 	} else {
-		own = (!strcmp(nick, server->nick));
+		own = (!g_strcmp0(nick, server->nick));
 		item = privmsg_get_query(SERVER(server), own ? target : nick, FALSE, level);
 	}
 

--- a/src/fe-common/irc/fe-modes.c
+++ b/src/fe-common/irc/fe-modes.c
@@ -135,7 +135,7 @@ static void msg_multi_mode(IRC_CHANNEL_REC *channel, const char *sender,
 		signal_add("print starting", (SIGNAL_FUNC) sig_print_starting);
 
 	rec = mode_find_channel(channel);
-	if (rec != NULL && strcmp(rec->mode, mode) != 0) {
+	if (rec != NULL && g_strcmp0(rec->mode, mode) != 0) {
 		/* different mode than last time, show and remove the old */
 		print_mode(rec);
 		mode_destroy(rec);

--- a/src/fe-common/irc/fe-whois.c
+++ b/src/fe-common/irc/fe-whois.c
@@ -134,8 +134,8 @@ static void event_whois_realhost(IRC_SERVER_REC *server, const char *data)
         /* <yournick> real hostname <nick> <hostname> */
 	params = event_get_params(data, 5, NULL, &nick, &txt_real,
 				  &txt_hostname, &hostname);
-	if (strcmp(txt_real, "real") != 0 ||
-	    strcmp(txt_hostname, "hostname") != 0) {
+	if (g_strcmp0(txt_real, "real") != 0 ||
+	    g_strcmp0(txt_hostname, "hostname") != 0) {
 		/* <yournick> <nick> :... from <hostname> */
                 g_free(params);
 		params = event_get_params(data, 3, NULL, &nick, &hostname);
@@ -219,7 +219,7 @@ static void event_whois_usermode(IRC_SERVER_REC *server, const char *data)
 	params = event_get_params(data, 4, NULL, &txt_usermodes,
 				  &nick, &usermode);
 
-	if (strcmp(txt_usermodes, "usermodes") == 0) {
+	if (g_strcmp0(txt_usermodes, "usermodes") == 0) {
 		/* <yournick> usermodes <nick> usermode */
 		printformat(server, nick, MSGLEVEL_CRAP,
 			    IRCTXT_WHOIS_USERMODE, nick, usermode);

--- a/src/fe-text/gui-readline.c
+++ b/src/fe-text/gui-readline.c
@@ -392,7 +392,7 @@ static void sig_gui_key_pressed(gpointer keyp)
 		str[g_unichar_to_utf8(key, str)] = '\0';
 	}
 
-	if (strcmp(str, "^") == 0) {
+	if (g_strcmp0(str, "^") == 0) {
 		/* change it as ^-, that is an invalid control char */
 		str[1] = '-';
 		str[2] = '\0';

--- a/src/fe-text/statusbar-config.c
+++ b/src/fe-text/statusbar-config.c
@@ -95,7 +95,7 @@ statusbar_config_find(STATUSBAR_GROUP_REC *group, const char *name)
 	for (tmp = group->config_bars; tmp != NULL; tmp = tmp->next) {
 		STATUSBAR_CONFIG_REC *config = tmp->data;
 
-		if (strcmp(config->name, name) == 0)
+		if (g_strcmp0(config->name, name) == 0)
                         return config;
 	}
 
@@ -137,7 +137,7 @@ static void statusbar_read_item(STATUSBAR_CONFIG_REC *bar, CONFIG_NODE *node)
 	int priority, right_alignment;
 
 	priority = config_node_get_int(node, "priority", 0);
-	right_alignment = strcmp(config_node_get_str(node, "alignment", ""), "right") == 0;
+	right_alignment = g_strcmp0(config_node_get_str(node, "alignment", ""), "right") == 0;
 	statusbar_item_config_create(bar, node->key,
 				     priority, right_alignment);
 }

--- a/src/fe-text/statusbar.c
+++ b/src/fe-text/statusbar.c
@@ -129,7 +129,7 @@ STATUSBAR_GROUP_REC *statusbar_group_find(const char *name)
 	for (tmp = statusbar_groups; tmp != NULL; tmp = tmp->next) {
 		STATUSBAR_GROUP_REC *rec = tmp->data;
 
-		if (strcmp(rec->name, name) == 0)
+		if (g_strcmp0(rec->name, name) == 0)
                         return rec;
 	}
 
@@ -617,7 +617,7 @@ STATUSBAR_REC *statusbar_find(STATUSBAR_GROUP_REC *group, const char *name,
 		STATUSBAR_REC *rec = tmp->data;
 
 		if (rec->parent_window == window &&
-		    strcmp(rec->config->name, name) == 0)
+		    g_strcmp0(rec->config->name, name) == 0)
                         return rec;
 	}
 

--- a/src/fe-text/terminfo-core.c
+++ b/src/fe-text/terminfo-core.c
@@ -646,11 +646,11 @@ static int term_setup(TERM_REC *term)
         str = g_string_new(NULL);
 	if (term->TI_sgr0)
 		g_string_append(str, term->TI_sgr0);
-	if (term->TI_rmul && (term->TI_sgr0 == NULL || strcmp(term->TI_rmul, term->TI_sgr0) != 0))
+	if (term->TI_rmul && (term->TI_sgr0 == NULL || g_strcmp0(term->TI_rmul, term->TI_sgr0) != 0))
 		g_string_append(str, term->TI_rmul);
-	if (term->TI_rmso && (term->TI_sgr0 == NULL || strcmp(term->TI_rmso, term->TI_sgr0) != 0))
+	if (term->TI_rmso && (term->TI_sgr0 == NULL || g_strcmp0(term->TI_rmso, term->TI_sgr0) != 0))
 		g_string_append(str, term->TI_rmso);
-	if (term->TI_ritm && (term->TI_sgr0 == NULL || strcmp(term->TI_ritm, term->TI_sgr0) != 0))
+	if (term->TI_ritm && (term->TI_sgr0 == NULL || g_strcmp0(term->TI_ritm, term->TI_sgr0) != 0))
 		g_string_append(str, term->TI_ritm);
         term->TI_normal = str->str;
 	g_string_free(str, FALSE);

--- a/src/irc/core/bans.c
+++ b/src/irc/core/bans.c
@@ -188,7 +188,7 @@ static void command_set_ban(const char *data, IRC_SERVER_REC *server,
 			    item, &channel, &nicks)) return;
 	if (!ischannel(*channel)) cmd_param_error(CMDERR_NOT_JOINED);
 	if (*nicks == '\0') {
-		if (strcmp(data, "*") != 0)
+		if (g_strcmp0(data, "*") != 0)
 			cmd_param_error(CMDERR_NOT_ENOUGH_PARAMS);
                 /* /BAN * or /UNBAN * - ban/unban everyone */
 		nicks = (char *) data;
@@ -318,7 +318,7 @@ static void cmd_unban(const char *data, IRC_SERVER_REC *server, void *item)
 static void read_settings(void)
 {
 	if (default_ban_type_str != NULL &&
-	    strcmp(default_ban_type_str, settings_get_str("ban_type")) == 0)
+	    g_strcmp0(default_ban_type_str, settings_get_str("ban_type")) == 0)
 		return;
 
 	g_free_not_null(default_ban_type_str);

--- a/src/irc/core/channel-events.c
+++ b/src/irc/core/channel-events.c
@@ -270,7 +270,7 @@ static void event_join(IRC_SERVER_REC *server, const char *data, const char *nic
 	}
 
 	chanrec->joined = TRUE;
-	if (strcmp(chanrec->name, channel) != 0) {
+	if (g_strcmp0(chanrec->name, channel) != 0) {
                 g_free(chanrec->name);
 		chanrec->name = g_strdup(channel);
 	}

--- a/src/irc/core/irc-commands.c
+++ b/src/irc/core/irc-commands.c
@@ -72,7 +72,7 @@ static void cmd_notice(const char *data, IRC_SERVER_REC *server,
 	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_GETREST,
 			    &target, &msg))
 		return;
-	if (strcmp(target, "*") == 0)
+	if (g_strcmp0(target, "*") == 0)
 		target = item == NULL ? NULL : window_item_get_target(item);
 	if (target == NULL || *target == '\0' || *msg == '\0')
 		cmd_param_error(CMDERR_NOT_ENOUGH_PARAMS);
@@ -99,7 +99,7 @@ static void cmd_ctcp(const char *data, IRC_SERVER_REC *server,
 	if (!cmd_get_params(data, &free_arg, 3 | PARAM_FLAG_GETREST,
 			    &target, &ctcpcmd, &ctcpdata))
 		return;
-	if (strcmp(target, "*") == 0)
+	if (g_strcmp0(target, "*") == 0)
 		target = item == NULL ? NULL : window_item_get_target(item);
 	if (target == NULL || *target == '\0' || *ctcpcmd == '\0')
 		cmd_param_error(CMDERR_NOT_ENOUGH_PARAMS);
@@ -133,7 +133,7 @@ static void cmd_nctcp(const char *data, IRC_SERVER_REC *server,
 	if (!cmd_get_params(data, &free_arg, 3 | PARAM_FLAG_GETREST,
 			    &target, &ctcpcmd, &ctcpdata))
 		return;
-	if (strcmp(target, "*") == 0)
+	if (g_strcmp0(target, "*") == 0)
 		target = item == NULL ? NULL : window_item_get_target(item);
 	if (target == NULL || *target == '\0' || *ctcpcmd == '\0')
 		cmd_param_error(CMDERR_NOT_ENOUGH_PARAMS);
@@ -238,7 +238,7 @@ static void cmd_invite(const char *data, IRC_SERVER_REC *server, WI_ITEM_REC *it
 		return;
 
 	if (*nick == '\0') cmd_param_error(CMDERR_NOT_ENOUGH_PARAMS);
-	if (*channame == '\0' || strcmp(channame, "*") == 0) {
+	if (*channame == '\0' || g_strcmp0(channame, "*") == 0) {
 		if (!IS_IRC_CHANNEL(item))
 			cmd_param_error(CMDERR_NOT_JOINED);
 
@@ -284,13 +284,13 @@ static void cmd_who(const char *data, IRC_SERVER_REC *server,
 	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_GETREST, &channel, &rest))
 		return;
 
-	if (strcmp(channel, "*") == 0 || *channel == '\0') {
+	if (g_strcmp0(channel, "*") == 0 || *channel == '\0') {
 		if (!IS_IRC_CHANNEL(item))
                         cmd_param_error(CMDERR_NOT_JOINED);
 
 		channel = IRC_CHANNEL(item)->name;
 	}
-	if (strcmp(channel, "**") == 0) {
+	if (g_strcmp0(channel, "**") == 0) {
 		/* ** displays all nicks.. */
 		*channel = '\0';
 	}
@@ -313,14 +313,14 @@ static void cmd_names(const char *data, IRC_SERVER_REC *server,
 			    PARAM_FLAG_GETREST, "names", &optlist, &channel))
 		return;
 
-	if (strcmp(channel, "*") == 0 || *channel == '\0') {
+	if (g_strcmp0(channel, "*") == 0 || *channel == '\0') {
 		if (!IS_IRC_CHANNEL(item))
                         cmd_param_error(CMDERR_NOT_JOINED);
 
 		channel = IRC_CHANNEL(item)->name;
 	}
 
-	if (strcmp(channel, "**") == 0) {
+	if (g_strcmp0(channel, "**") == 0) {
 		/* ** displays all nicks.. */
                 irc_send_cmd(server, "NAMES");
 	} else {
@@ -409,7 +409,7 @@ static void cmd_whois(const char *data, IRC_SERVER_REC *server,
 			query = qserver = queryitem->name;
 	}
 
-	if (strcmp(query, "*") == 0 &&
+	if (g_strcmp0(query, "*") == 0 &&
 	    g_hash_table_lookup(optlist, "yes") == NULL)
 		cmd_param_error(CMDERR_NOT_GOOD_IDEA);
 
@@ -810,7 +810,7 @@ static void cmd_knockout(const char *data, IRC_SERVER_REC *server,
 		for (ptr = server->knockoutlist; ptr != NULL; ptr = ptr->next) {
 			rec = ptr->data;
 			if (channel == rec->channel &&
-					!strcmp(rec->ban, banmasks))
+					!g_strcmp0(rec->ban, banmasks))
 				break;
 		}
 		if (ptr == NULL) {

--- a/src/irc/core/irc-queries.c
+++ b/src/irc/core/irc-queries.c
@@ -67,13 +67,13 @@ static void check_query_changes(IRC_SERVER_REC *server, const char *nick,
 	if (query == NULL)
 		return;
 
-	if (strcmp(query->name, nick) != 0) {
+	if (g_strcmp0(query->name, nick) != 0) {
 		/* upper/lowercase chars in nick changed */
 		query_change_nick(query, nick);
 	}
 
 	if (address != NULL && (query->address == NULL ||
-				strcmp(query->address, address) != 0)) {
+				g_strcmp0(query->address, address) != 0)) {
                 /* host changed */
 		query_change_address(query, address);
 	}
@@ -109,7 +109,7 @@ static void event_nick(SERVER_REC *server, const char *data,
 	query = query_find(server, orignick);
 	if (query != NULL) {
 		params = event_get_params(data, 1, &nick);
-		if (strcmp(query->name, nick) != 0)
+		if (g_strcmp0(query->name, nick) != 0)
 			query_change_nick(query, nick);
 		g_free(params);
 	}

--- a/src/irc/core/irc-servers.c
+++ b/src/irc/core/irc-servers.c
@@ -638,7 +638,7 @@ static void event_connected(IRC_SERVER_REC *server, const char *data, const char
 
 	params = event_get_params(data, 1, &nick);
 
-	if (strcmp(server->nick, nick) != 0) {
+	if (g_strcmp0(server->nick, nick) != 0) {
 		/* nick changed unexpectedly .. connected via proxy, etc. */
 		g_free(server->nick);
 		server->nick = g_strdup(nick);

--- a/src/irc/core/modes.c
+++ b/src/irc/core/modes.c
@@ -398,7 +398,7 @@ void parse_channel_modes(IRC_CHANNEL_REC *channel, const char *setby,
 		old_key = NULL;
 	}
 
-	if (strcmp(newmode->str, channel->mode) != 0) {
+	if (g_strcmp0(newmode->str, channel->mode) != 0) {
 		g_free(channel->mode);
 		channel->mode = g_strdup(newmode->str);
 
@@ -842,7 +842,7 @@ static void cmd_mode(const char *data, IRC_SERVER_REC *server,
 			return;
 	}
 
-	if (strcmp(target, "*") == 0) {
+	if (g_strcmp0(target, "*") == 0) {
 		if (!IS_IRC_CHANNEL(channel))
 			cmd_param_error(CMDERR_NOT_JOINED);
 

--- a/src/irc/core/servers-redirect.c
+++ b/src/irc/core/servers-redirect.c
@@ -339,7 +339,7 @@ static GSList *redirect_cmd_list_find(GSList *list, const char *event)
 	while (list != NULL) {
 		const char *str = list->data;
 
-		if (strcmp(str, event) == 0)
+		if (g_strcmp0(str, event) == 0)
                         break;
                 list = list->next->next;
 	}
@@ -365,7 +365,7 @@ static const char *redirect_match(REDIRECT_REC *redirect, const char *event,
 	   use the default signal */
         signal = NULL;
 	for (tmp = redirect->signals; tmp != NULL; tmp = tmp->next->next) {
-		if (strcmp(tmp->data, event) == 0) {
+		if (g_strcmp0(tmp->data, event) == 0) {
 			signal = tmp->next->data;
 			break;
 		}
@@ -527,7 +527,7 @@ server_redirect_get(IRC_SERVER_REC *server, const char *prefix,
 		next = ptr->next;
 		r = ptr->data;
 		if (prefix != NULL && r->prefix != NULL &&
-				strcmp(prefix, r->prefix)) {
+				g_strcmp0(prefix, r->prefix)) {
 			/* not from this server */
 			continue;
 		}

--- a/src/irc/dcc/dcc-autoget.c
+++ b/src/irc/dcc/dcc-autoget.c
@@ -57,7 +57,7 @@ static void sig_dcc_request(GET_DCC_REC *dcc, const char *nickaddr)
 	/* don't autoget files beginning with a dot, if download dir is
 	   our home dir (stupid kludge for stupid people) */
 	if (*dcc->arg == '.' &&
-	    strcmp(settings_get_str("dcc_download_path"), "~") == 0)
+	    g_strcmp0(settings_get_str("dcc_download_path"), "~") == 0)
 		return;
 
 	/* check file size limit, NOTE: it's still possible to send a

--- a/src/irc/dcc/dcc-chat.c
+++ b/src/irc/dcc/dcc-chat.c
@@ -191,7 +191,7 @@ static void cmd_msg(const char *data, SERVER_REC *server, WI_ITEM_REC *item)
 		return;
 
 	/* handle only DCC messages */
-	if (strcmp(target, "*") == 0)
+	if (g_strcmp0(target, "*") == 0)
 		dcc = item_get_dcc(item);
 	else if (*target == '=')
 		dcc = dcc_chat_find_id(target+1);
@@ -625,7 +625,7 @@ static void ctcp_msg_dcc_chat(IRC_SERVER_REC *server, const char *data,
 		g_strfreev(params);
 		return;
 	}
-	passive = paramcount == 4 && strcmp(params[2], "0") == 0;
+	passive = paramcount == 4 && g_strcmp0(params[2], "0") == 0;
 
 	dcc = DCC_CHAT(dcc_find_request(DCC_CHAT_TYPE, nick, NULL));
 	if (dcc != NULL) {

--- a/src/irc/dcc/dcc-get.c
+++ b/src/irc/dcc/dcc-get.c
@@ -554,7 +554,7 @@ void cmd_dcc_receive(const char *data, DCC_GET_FUNC accept_func,
 		next = tmp->next;
 		if (IS_DCC_GET(dcc) && g_ascii_strcasecmp(dcc->nick, nick) == 0 &&
 		    (dcc_is_waiting_user(dcc) || dcc->from_dccserver) &&
-		    (*fname == '\0' || strcmp(dcc->arg, fname) == 0)) {
+		    (*fname == '\0' || g_strcmp0(dcc->arg, fname) == 0)) {
 			found = TRUE;
 			if (!dcc_is_passive(dcc))
 				accept_func(dcc);

--- a/src/irc/dcc/dcc.c
+++ b/src/irc/dcc/dcc.c
@@ -149,7 +149,7 @@ DCC_REC *dcc_find_request(int type, const char *nick, const char *arg)
 
 		if (dcc->type == type && !dcc_is_connected(dcc) &&
 		    g_ascii_strcasecmp(dcc->nick, nick) == 0 &&
-		    (arg == NULL || strcmp(dcc->arg, arg) == 0))
+		    (arg == NULL || g_strcmp0(dcc->arg, arg) == 0))
 			return dcc;
 	}
 
@@ -516,7 +516,7 @@ static void cmd_dcc_close(char *data, IRC_SERVER_REC *server)
 
 		next = tmp->next;
 		if (dcc->type == type && g_ascii_strcasecmp(dcc->nick, nick) == 0 &&
-		    (*arg == '\0' || strcmp(dcc->arg, arg) == 0)) {
+		    (*arg == '\0' || g_strcmp0(dcc->arg, arg) == 0)) {
 			dcc_reject(dcc, server);
 			found = TRUE;
 		}

--- a/src/irc/notifylist/notifylist.c
+++ b/src/irc/notifylist/notifylist.c
@@ -91,7 +91,7 @@ int notifylist_ircnets_match(NOTIFYLIST_REC *rec, const char *ircnet)
 
 	if (rec->ircnets == NULL) return TRUE;
 	if (ircnet == NULL) return FALSE;
-	if (strcmp(ircnet, "*") == 0) return TRUE;
+	if (g_strcmp0(ircnet, "*") == 0) return TRUE;
 
 	for (tmp = rec->ircnets; *tmp != NULL; tmp++) {
 		if (g_ascii_strcasecmp(*tmp, ircnet) == 0)

--- a/src/irc/proxy/dump.c
+++ b/src/irc/proxy/dump.c
@@ -209,7 +209,7 @@ static void dump_join(IRC_CHANNEL_REC *channel, CLIENT_REC *client)
 void proxy_client_reset_nick(CLIENT_REC *client)
 {
 	if (client->server == NULL ||
-	    strcmp(client->nick, client->server->nick) == 0)
+	    g_strcmp0(client->nick, client->server->nick) == 0)
 		return;
 
 	proxy_outdata(client, ":%s!proxy NICK :%s\n",

--- a/src/lib-config/set.c
+++ b/src/lib-config/set.c
@@ -105,7 +105,7 @@ void config_node_set_str(CONFIG_REC *rec, CONFIG_NODE *parent, const char *key, 
 	}
 
 	if (node != NULL) {
-		if (strcmp(node->value, value) == 0)
+		if (g_strcmp0(node->value, value) == 0)
 			return;
                 g_free(node->value);
 	} else {

--- a/src/perl/perl-core.c
+++ b/src/perl/perl-core.c
@@ -44,7 +44,7 @@ static int print_script_errors;
 static char *perl_args[] = {"", "-e", "0"};
 
 #define IS_PERL_SCRIPT(file) \
-	(strlen(file) > 3 && strcmp(file+strlen(file)-3, ".pl") == 0)
+	(strlen(file) > 3 && g_strcmp0(file+strlen(file)-3, ".pl") == 0)
 
 static void perl_script_destroy_package(PERL_SCRIPT_REC *script)
 {
@@ -314,7 +314,7 @@ PERL_SCRIPT_REC *perl_script_find(const char *name)
 	for (tmp = perl_scripts; tmp != NULL; tmp = tmp->next) {
 		PERL_SCRIPT_REC *rec = tmp->data;
 
-		if (strcmp(rec->name, name) == 0)
+		if (g_strcmp0(rec->name, name) == 0)
                         return rec;
 	}
 
@@ -331,7 +331,7 @@ PERL_SCRIPT_REC *perl_script_find_package(const char *package)
 	for (tmp = perl_scripts; tmp != NULL; tmp = tmp->next) {
 		PERL_SCRIPT_REC *rec = tmp->data;
 
-		if (strcmp(rec->package, package) == 0)
+		if (g_strcmp0(rec->package, package) == 0)
                         return rec;
 	}
 

--- a/src/perl/perl-fe.c
+++ b/src/perl/perl-fe.c
@@ -170,7 +170,7 @@ static void cmd_load(const char *data, SERVER_REC *server, void *item)
 		return;
 
 	len = strlen(rootmodule);
-	if (len > 3 && strcmp(rootmodule + len - 3, ".pl") == 0) {
+	if (len > 3 && g_strcmp0(rootmodule + len - 3, ".pl") == 0) {
 		/* make /LOAD script.pl work as expected */
 		signal_stop();
 		cmd_script_load(data);

--- a/src/perl/perl-signals.c
+++ b/src/perl/perl-signals.c
@@ -99,14 +99,14 @@ void perl_signal_args_to_c(
 
                 if (!SvOK(arg)) {
                         c_arg = NULL;
-                } else if (strcmp(rec->args[n], "string") == 0) {
+                } else if (g_strcmp0(rec->args[n], "string") == 0) {
                         c_arg = SvPV_nolen(arg);
-                } else if (strcmp(rec->args[n], "int") == 0) {
+                } else if (g_strcmp0(rec->args[n], "int") == 0) {
                         c_arg = (void *)SvIV(arg);
-                } else if (strcmp(rec->args[n], "ulongptr") == 0) {
+                } else if (g_strcmp0(rec->args[n], "ulongptr") == 0) {
                         saved_args[n].v_ulong = SvUV(arg);
                         c_arg = &saved_args[n].v_ulong;
-                } else if (strcmp(rec->args[n], "intptr") == 0) {
+                } else if (g_strcmp0(rec->args[n], "intptr") == 0) {
                         saved_args[n].v_int = SvIV(SvRV(arg));
                         c_arg = &saved_args[n].v_int;
                 } else if (strncmp(rec->args[n], "glistptr_", 9) == 0) {
@@ -122,7 +122,7 @@ void perl_signal_args_to_c(
                         }
                         av = (AV *)t;
 
-                        is_str = strcmp(rec->args[n]+9, "char*") == 0;
+                        is_str = g_strcmp0(rec->args[n]+9, "char*") == 0;
 
                         gl = NULL;
                         count = av_len(av) + 1;
@@ -181,7 +181,7 @@ void perl_signal_args_to_c(
                         continue;
                 }
 
-                if (strcmp(rec->args[n], "intptr") == 0) {
+                if (g_strcmp0(rec->args[n], "intptr") == 0) {
                         SV *t = SvRV(arg);
                         SvIOK_only(t);
                         SvIV_set(t, saved_args[n].v_int);
@@ -192,8 +192,8 @@ void perl_signal_args_to_c(
                         AV *av;
                         GList *gl, *tmp;
 
-                        is_iobject = strcmp(rec->args[n]+9, "iobject") == 0;
-                        is_str = strcmp(rec->args[n]+9, "char*") == 0;
+                        is_iobject = g_strcmp0(rec->args[n]+9, "iobject") == 0;
+                        is_str = g_strcmp0(rec->args[n]+9, "char*") == 0;
 
                         av = (AV *)SvRV(arg);
                         av_clear(av);
@@ -245,8 +245,8 @@ static void perl_call_signal(PERL_SCRIPT_REC *script, SV *func,
 			GList *tmp, **ptr;
                         int is_iobject, is_str;
 
-                        is_iobject = strcmp(rec->args[n]+9, "iobject") == 0;
-                        is_str = strcmp(rec->args[n]+9, "char*") == 0;
+                        is_iobject = g_strcmp0(rec->args[n]+9, "iobject") == 0;
+                        is_str = g_strcmp0(rec->args[n]+9, "char*") == 0;
 			av = newAV();
 
 			ptr = arg;
@@ -258,22 +258,22 @@ static void perl_call_signal(PERL_SCRIPT_REC *script, SV *func,
 			}
 
 			saved_args[n] = perlarg = newRV_noinc((SV *) av);
-                } else if (strcmp(rec->args[n], "int") == 0)
+                } else if (g_strcmp0(rec->args[n], "int") == 0)
                         perlarg = newSViv((IV)arg);
                 else if (arg == NULL)
                         perlarg = &PL_sv_undef;
-                else if (strcmp(rec->args[n], "string") == 0)
+                else if (g_strcmp0(rec->args[n], "string") == 0)
                         perlarg = new_pv(arg);
-                else if (strcmp(rec->args[n], "ulongptr") == 0)
+                else if (g_strcmp0(rec->args[n], "ulongptr") == 0)
                         perlarg = newSViv(*(unsigned long *) arg);
-                else if (strcmp(rec->args[n], "intptr") == 0)
+                else if (g_strcmp0(rec->args[n], "intptr") == 0)
                         saved_args[n] = perlarg = newRV_noinc(newSViv(*(int *) arg));
                 else if (strncmp(rec->args[n], "gslist_", 7) == 0) {
 			/* linked list - push as AV */
 			GSList *tmp;
 			int is_iobject;
 
-                        is_iobject = strcmp(rec->args[n]+7, "iobject") == 0;
+                        is_iobject = g_strcmp0(rec->args[n]+7, "iobject") == 0;
 			av = newAV();
 			for (tmp = arg; tmp != NULL; tmp = tmp->next) {
 				sv = is_iobject ? iobject_bless((SERVER_REC *) tmp->data) :
@@ -282,12 +282,12 @@ static void perl_call_signal(PERL_SCRIPT_REC *script, SV *func,
 			}
 
 			perlarg = newRV_noinc((SV *) av);
-		} else if (strcmp(rec->args[n], "iobject") == 0) {
+		} else if (g_strcmp0(rec->args[n], "iobject") == 0) {
 			/* "irssi object" - any struct that has
 			   "int type; int chat_type" as it's first
 			   variables (server, channel, ..) */
 			perlarg = iobject_bless((SERVER_REC *) arg);
-		} else if (strcmp(rec->args[n], "siobject") == 0) {
+		} else if (g_strcmp0(rec->args[n], "siobject") == 0) {
 			/* "simple irssi object" - any struct that has
 			   int type; as it's first variable (dcc) */
 			perlarg = simple_iobject_bless((SERVER_REC *) arg);
@@ -317,7 +317,7 @@ static void perl_call_signal(PERL_SCRIPT_REC *script, SV *func,
 		if (saved_args[n] == NULL)
                         continue;
 
-		if (strcmp(rec->args[n], "intptr") == 0) {
+		if (g_strcmp0(rec->args[n], "intptr") == 0) {
 			int *val = arg;
 			*val = SvIV(SvRV(saved_args[n]));
 		} else if (strncmp(rec->args[n], "glistptr_", 9) == 0) {
@@ -338,7 +338,7 @@ static void perl_call_signal(PERL_SCRIPT_REC *script, SV *func,
 				out = g_list_append(out, val);
 			}
 
-			if (strcmp(rec->args[n]+9, "char*") == 0)
+			if (g_strcmp0(rec->args[n]+9, "char*") == 0)
                                 g_list_foreach(*ret, (GFunc) g_free, NULL);
 			g_list_free(*ret);
                         *ret = out;
@@ -434,7 +434,7 @@ static void perl_signal_remove_list_one(GSList **siglist, PERL_SIGNAL_REC *rec)
 
 #define sv_func_cmp(f1, f2) \
 	(f1 == f2 || (SvPOK(f1) && SvPOK(f2) && \
-		strcmp(SvPV_nolen(f1), SvPV_nolen(f2)) == 0))
+		g_strcmp0(SvPV_nolen(f1), SvPV_nolen(f2)) == 0))
 
 static void perl_signal_remove_list(GSList **list, SV *func)
 {


### PR DESCRIPTION
Just a string replacement (but i did check every one of them)

    sed -i 's/strcmp(/g_strcmp0(/g' **/*.c

-----------

Also added a backwards compatibility macro since centos 5 is supported until 2017 and it's stuck with glib 2.12