### PR TITLE
ssl: Add option to specify SSL cipher suite preference list

### DIFF
--- a/docs/help/in/connect.in
+++ b/docs/help/in/connect.in
@@ -15,6 +15,7 @@
     -ssl_verify:    Verifies the SSL certificate of the server.
     -ssl_cafile:    The file with the list of CA certificates.
     -ssl_capath:    The directory which contains the CA certificates.
+    -ssl_ciphers:   SSL cipher suite preference lists
     -noproxy:       Ignores the global proxy configuration.
     -network:       The network this connection belongs to.
     -host:          The hostname you would like to connect from.

--- a/docs/help/in/server.in
+++ b/docs/help/in/server.in
@@ -22,6 +22,7 @@
     -ssl_verify:       Verifies the SSL certificate of the server.
     -ssl_cafile:       The file with the list of CA certificates.
     -ssl_capath:       The directory which contains the CA certificates.
+    -ssl_ciphers:      SSL cipher suite preference lists
     -auto:             Automatically connects to the server on startup.
     -noauto:           Doesn't connect to the server on startup.
     -network:          The network the server belongs to.

--- a/src/core/chat-commands.c
+++ b/src/core/chat-commands.c
@@ -106,6 +106,8 @@ static SERVER_CONNECT_REC *get_server_connect(const char *data, int *plus_addr,
 		conn->ssl_cafile = g_strdup(tmp);
 	if ((tmp = g_hash_table_lookup(optlist, "ssl_capath")) != NULL)
 		conn->ssl_capath = g_strdup(tmp);
+	if ((tmp = g_hash_table_lookup(optlist, "ssl_ciphers")) != NULL)
+		conn->ssl_ciphers = g_strdup(tmp);
 	if ((conn->ssl_capath != NULL && conn->ssl_capath[0] != '\0')
 	||  (conn->ssl_cafile != NULL && conn->ssl_cafile[0] != '\0'))
 		conn->ssl_verify = TRUE;
@@ -138,6 +140,7 @@ static SERVER_CONNECT_REC *get_server_connect(const char *data, int *plus_addr,
 
 /* SYNTAX: CONNECT [-4 | -6] [-ssl] [-ssl_cert <cert>] [-ssl_pkey <pkey>] [-ssl_pass <password>]
                    [-ssl_verify] [-ssl_cafile <cafile>] [-ssl_capath <capath>]
+                   [-ssl_ciphers <list>]
                    [-!] [-noautosendcmd]
 		   [-noproxy] [-network <network>] [-host <hostname>]
 		   [-rawlog <file>]
@@ -244,6 +247,7 @@ static void sig_default_command_server(const char *data, SERVER_REC *server,
 
 /* SYNTAX: SERVER [-4 | -6] [-ssl] [-ssl_cert <cert>] [-ssl_pkey <pkey>] [-ssl_pass <password>]
                   [-ssl_verify] [-ssl_cafile <cafile>] [-ssl_capath <capath>]
+                  [-ssl_ciphers <list>]
                   [-!] [-noautosendcmd]
 		  [-noproxy] [-network <network>] [-host <hostname>]
 		  [-rawlog <file>]
@@ -483,7 +487,7 @@ void chat_commands_init(void)
 	signal_add("default command server", (SIGNAL_FUNC) sig_default_command_server);
 	signal_add("server sendmsg", (SIGNAL_FUNC) sig_server_sendmsg);
 
-	command_set_options("connect", "4 6 !! -network ssl +ssl_cert +ssl_pkey +ssl_pass ssl_verify +ssl_cafile +ssl_capath +host noproxy -rawlog noautosendcmd");
+	command_set_options("connect", "4 6 !! -network ssl +ssl_cert +ssl_pkey +ssl_pass ssl_verify +ssl_cafile +ssl_capath +ssl_ciphers +host noproxy -rawlog noautosendcmd");
 	command_set_options("msg", "channel nick");
 }
 

--- a/src/core/network-openssl.c
+++ b/src/core/network-openssl.c
@@ -460,6 +460,7 @@ static GIOChannel *irssi_ssl_get_iochannel(GIOChannel *handle, int port, SERVER_
 	const char *mypass = server->connrec->ssl_pass;
 	const char *cafile = server->connrec->ssl_cafile;
 	const char *capath = server->connrec->ssl_capath;
+	const char *ciphers = server->connrec->ssl_ciphers;
 	gboolean verify = server->connrec->ssl_verify;
 
 	g_return_val_if_fail(handle != NULL, NULL);
@@ -478,6 +479,7 @@ static GIOChannel *irssi_ssl_get_iochannel(GIOChannel *handle, int port, SERVER_
 	SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
 	SSL_CTX_set_default_passwd_cb(ctx, get_pem_password_callback);
 	SSL_CTX_set_default_passwd_cb_userdata(ctx, (void *)mypass);
+	SSL_CTX_set_cipher_list(ctx, ciphers);
 
 	if (mycert && *mycert) {
 		char *scert = NULL, *spkey = NULL;

--- a/src/core/network-openssl.c
+++ b/src/core/network-openssl.c
@@ -479,7 +479,10 @@ static GIOChannel *irssi_ssl_get_iochannel(GIOChannel *handle, int port, SERVER_
 	SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
 	SSL_CTX_set_default_passwd_cb(ctx, get_pem_password_callback);
 	SSL_CTX_set_default_passwd_cb_userdata(ctx, (void *)mypass);
-	SSL_CTX_set_cipher_list(ctx, ciphers);
+	if (ciphers && *ciphers) {
+		if (SSL_CTX_set_cipher_list(ctx, ciphers) != 1)
+			g_warning("No valid SSL cipher suite could be selected");
+	}
 
 	if (mycert && *mycert) {
 		char *scert = NULL, *spkey = NULL;

--- a/src/core/server-connect-rec.h
+++ b/src/core/server-connect-rec.h
@@ -28,6 +28,7 @@ char *ssl_pkey;
 char *ssl_pass;
 char *ssl_cafile;
 char *ssl_capath;
+char *ssl_ciphers;
 
 GIOChannel *connect_handle; /* connect using this handle */
 

--- a/src/core/server-setup-rec.h
+++ b/src/core/server-setup-rec.h
@@ -13,6 +13,7 @@ char *ssl_pkey;
 char *ssl_pass;
 char *ssl_cafile;
 char *ssl_capath;
+char *ssl_ciphers;
 
 char *own_host; /* address to use when connecting this server */
 IPADDR *own_ip4, *own_ip6; /* resolved own_address if not NULL */

--- a/src/core/servers-reconnect.c
+++ b/src/core/servers-reconnect.c
@@ -197,6 +197,7 @@ server_connect_copy_skeleton(SERVER_CONNECT_REC *src, int connect_info)
 	dest->ssl_verify = src->ssl_verify;
 	dest->ssl_cafile = g_strdup(src->ssl_cafile);
 	dest->ssl_capath = g_strdup(src->ssl_capath);
+	dest->ssl_ciphers = g_strdup(src->ssl_ciphers);
 
 	return dest;
 }

--- a/src/core/servers-setup.c
+++ b/src/core/servers-setup.c
@@ -179,6 +179,8 @@ static void server_setup_fill_server(SERVER_CONNECT_REC *conn,
 		conn->ssl_cafile = g_strdup(sserver->ssl_cafile);
 	if (conn->ssl_capath == NULL && sserver->ssl_capath != NULL && sserver->ssl_capath[0] != '\0')
 		conn->ssl_capath = g_strdup(sserver->ssl_capath);
+	if (conn->ssl_ciphers == NULL && sserver->ssl_ciphers != NULL && sserver->ssl_ciphers[0] != '\0')
+		conn->ssl_ciphers = g_strdup(sserver->ssl_ciphers);
 
 	server_setup_fill_reconn(conn, sserver);
 
@@ -405,6 +407,7 @@ static SERVER_SETUP_REC *server_setup_read(CONFIG_NODE *node)
 	rec->ssl_verify = config_node_get_bool(node, "ssl_verify", FALSE);
 	rec->ssl_cafile = g_strdup(config_node_get_str(node, "ssl_cafile", NULL));
 	rec->ssl_capath = g_strdup(config_node_get_str(node, "ssl_capath", NULL));
+	rec->ssl_ciphers = g_strdup(config_node_get_str(node, "ssl_ciphers", NULL));
 	if (rec->ssl_cafile || rec->ssl_capath)
 		rec->ssl_verify = TRUE;
 	if (rec->ssl_cert != NULL || rec->ssl_verify)
@@ -445,6 +448,7 @@ static void server_setup_save(SERVER_SETUP_REC *rec)
 	iconfig_node_set_bool(node, "ssl_verify", rec->ssl_verify);
 	iconfig_node_set_str(node, "ssl_cafile", rec->ssl_cafile);
 	iconfig_node_set_str(node, "ssl_capath", rec->ssl_capath);
+	iconfig_node_set_str(node, "ssl_ciphers", rec->ssl_ciphers);
 	iconfig_node_set_str(node, "own_host", rec->own_host);
 
 	iconfig_node_set_str(node, "family",
@@ -486,6 +490,7 @@ static void server_setup_destroy(SERVER_SETUP_REC *rec)
 	g_free_not_null(rec->ssl_pass);
 	g_free_not_null(rec->ssl_cafile);
 	g_free_not_null(rec->ssl_capath);
+	g_free_not_null(rec->ssl_ciphers);
 	g_free(rec->address);
 	g_free(rec);
 }

--- a/src/core/servers.c
+++ b/src/core/servers.c
@@ -636,6 +636,7 @@ void server_connect_unref(SERVER_CONNECT_REC *conn)
 	g_free_not_null(conn->ssl_pass);
 	g_free_not_null(conn->ssl_cafile);
 	g_free_not_null(conn->ssl_capath);
+	g_free_not_null(conn->ssl_ciphers);
 
 	g_free_not_null(conn->channels);
         g_free_not_null(conn->away_reason);

--- a/src/core/session.c
+++ b/src/core/session.c
@@ -165,6 +165,7 @@ static void session_save_server(SERVER_REC *server, CONFIG_REC *config,
 	config_node_set_bool(config, node, "ssl_verify", server->connrec->ssl_verify);
 	config_node_set_str(config, node, "ssl_cafile", server->connrec->ssl_cafile);
 	config_node_set_str(config, node, "ssl_capath", server->connrec->ssl_capath);
+	config_node_set_str(config, node, "ssl_ciphers", server->connrec->ssl_ciphers);
 
 	handle = g_io_channel_unix_get_fd(net_sendbuffer_handle(server->handle));
 	config_node_set_int(config, node, "handle", handle);

--- a/src/fe-common/core/fe-server.c
+++ b/src/fe-common/core/fe-server.c
@@ -173,6 +173,10 @@ static void cmd_server_add(const char *data)
 	if (value != NULL && *value != '\0')
 		rec->ssl_capath = g_strdup(value);
 
+	value = g_hash_table_lookup(optlist, "ssl_ciphers");
+	if (value != NULL && *value != '\0')
+		rec->ssl_ciphers = g_strdup(value);
+
 	if ((rec->ssl_cafile != NULL && rec->ssl_cafile[0] != '\0')
 	||  (rec->ssl_capath != NULL && rec->ssl_capath[0] != '\0'))
 		rec->ssl_verify = TRUE;
@@ -387,7 +391,7 @@ void fe_server_init(void)
 	command_bind("server remove", NULL, (SIGNAL_FUNC) cmd_server_remove);
 	command_bind_first("server", NULL, (SIGNAL_FUNC) server_command);
 	command_bind_first("disconnect", NULL, (SIGNAL_FUNC) server_command);
-	command_set_options("server add", "4 6 !! ssl +ssl_cert +ssl_pkey +ssl_pass ssl_verify +ssl_cafile +ssl_capath auto noauto proxy noproxy -host -port noautosendcmd");
+	command_set_options("server add", "4 6 !! ssl +ssl_cert +ssl_pkey +ssl_pass ssl_verify +ssl_cafile +ssl_capath +ssl_ciphers auto noauto proxy noproxy -host -port noautosendcmd");
 
 	signal_add("server looking", (SIGNAL_FUNC) sig_server_looking);
 	signal_add("server connecting", (SIGNAL_FUNC) sig_server_connecting);

--- a/src/fe-common/irc/fe-irc-server.c
+++ b/src/fe-common/irc/fe-irc-server.c
@@ -52,6 +52,7 @@ const char *get_visible_target(IRC_SERVER_REC *server, const char *target)
 }
 /* SYNTAX: SERVER ADD [-4 | -6] [-ssl] [-ssl_cert <cert>] [-ssl_pkey <pkey>] [-ssl_pass <password>]
                       [-ssl_verify] [-ssl_cafile <cafile>] [-ssl_capath <capath>]
+                      [-ssl_ciphers <list>]
                       [-auto | -noauto] [-network <network>] [-host <hostname>]
                       [-cmdspeed <ms>] [-cmdmax <count>] [-port <port>]
                       <address> [<port> [<password>]] */
@@ -121,6 +122,8 @@ static void cmd_server_list(const char *data)
 				g_string_append_printf(str, "ssl_cafile: %s, ", rec->ssl_cafile);
 			if (rec->ssl_capath)
 				g_string_append_printf(str, "ssl_capath: %s, ", rec->ssl_capath);
+			if (rec->ssl_ciphers)
+				g_string_append_printf(str, "ssl_ciphers: %s, ", rec->ssl_ciphers);
 
 		}
 		if (rec->max_cmds_at_once > 0)


### PR DESCRIPTION
This allows us to specify specific cipher to try connect with. Examples shown below.

Using a list of preferred cipher suites:

    | /connect -ssl -ssl_ciphers "EECDH+AESGCM+AES128:EDH+AESGCM+AES128:HIGH:!MEDIUM:!aNULL:!NULL:!LOW:!3DES:!DSS:!EXP:!PSK:!SRP" irc.staging.canonical.com <password>

Gets us:

    | 20:54 !0.irc.staging.canonical.com *** You are connected using SSL cipher "ECDHE-RSA-AES-128-GCM-AEAD"

Or we can specify a specific cipher suite to use:

    | /connect -ssl -ssl_ciphers "CAMELLIA256-SHA" irc.staging.canonical.com <password>

Gets us:

    | 20:58 !0.irc.staging.canonical.com *** You are connected using SSL cipher "RSA-CAMELLIA-256-CBC-SHA1"