### PR TITLE
lastlog doc fix

### DIFF
--- a/docs/help/in/lastlog.in
+++ b/docs/help/in/lastlog.in
@@ -35,7 +35,7 @@
 
     /LASTLOG holiday
     /LASTLOG 'is on vacation' 10
-    /LASTLOG -file -force ~/mike.log 'mike'
+    /LASTLOG -force -file ~/mike.log 'mike'
     /LASTLOG -hilight
     /LASTLOG -5 searchterm
 


### PR DESCRIPTION
Only the filename can come right after `-file`. Having `-force` in that position causes an
`Irssi: Could not open lastlog: No such file or directory` error.