### PR TITLE
Introduce check for git commands in autogen

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -18,6 +18,10 @@ perl syntax.pl
 
 echo "Creating ChangeLog..."
 git log > $srcdir/ChangeLog
+if test "$?" -ne 0; then
+    echo "**Error**: ${PKG_NAME} Autogen must be run in a git clone, cannot proceed."
+    exit 1
+fi
 
 files=`echo docs/help/in/*.in|sed -e 's,docs/help/in/Makefile.in ,,' -e 's,docs/help/in/,!,g' -e 's/\.in /.in ?/g'`
 cat docs/help/in/Makefile.am.gen|sed "s/@HELPFILES@/$files/g"|sed 's/?/\\?/g'|tr '!?' '\t\n' > docs/help/in/Makefile.am

--- a/irssi-version.sh
+++ b/irssi-version.sh
@@ -5,6 +5,12 @@ DATE=`GIT_DIR=$1/.git git log -1 --pretty=format:%ai HEAD`
 VERSION_DATE=`echo $DATE | cut -f 1 -d ' ' | tr -d -`
 VERSION_TIME=`echo $DATE | cut -f 2 -d ' ' | awk -F: '{printf "%d", $1$2}'`
 
+if test -z "$VERSION_DATE"; then
+    exec>&2
+    echo "**Error**: `basename "$0"` must be run in a git clone, cannot proceed."
+    exit 1
+fi
+
 echo "#define IRSSI_VERSION_DATE $VERSION_DATE"
 echo "#define IRSSI_VERSION_TIME $VERSION_TIME"
 


### PR DESCRIPTION
This avoids a misleading compile error when users try to `make` an
incomplete (or non-git) check-out.