### PR TITLE
Strip trailing whitespace from cmd args to avoid poor autocompletion UI

### DIFF
--- a/src/core/commands.c
+++ b/src/core/commands.c
@@ -857,7 +857,12 @@ static void parse_command(const char *command, int expand_aliases,
 
 	cmd = orig = g_strconcat("command ", command, NULL);
 	args = strchr(cmd+8, ' ');
-	if (args != NULL) *args++ = '\0'; else args = "";
+	if (args == NULL)
+		args = "";
+	else {
+		*args++ = '\0';
+		strchomp(args);
+	}
 
 	/* check if there's an alias for command. Don't allow
 	   recursive aliases */

--- a/src/core/misc.c
+++ b/src/core/misc.c
@@ -1019,3 +1019,12 @@ char **strsplit_len(const char *str, int len, gboolean onspace)
 
 	return ret;
 }
+
+void strchomp(char *str) {
+	char *i, *j;
+
+	for (i = j = str; *i; i++)
+		if (!isspace(*i)) *j++ = *i;
+
+	*j = '\0';
+}

--- a/src/core/misc.h
+++ b/src/core/misc.h
@@ -121,4 +121,7 @@ int find_substr(const char *list, const char *item);
 /* split `str' into `len' sized substrings */
 char **strsplit_len(const char *str, int len, gboolean onspace);
 
+/* trim trailing whitespace */
+void strchomp(char *str);
+
 #endif


### PR DESCRIPTION
On my Android phone the keyboard will "helpfully" always add a trailing
space when I select one of the autocomplete suggestions anticipating that
I will be adding another word. This seems a sensible default option in a
phone environment.

However, a command such as "/win 4 " is not accepted by irssi, thus when
using the auto-completion I have to manually remove this trailing space if
I want it to work. This patch therefore removes the trailing whitespaces
from command arguments, improving the mobile user experience.

See also:

 * http://bugs.irssi.org/index.php?do=details&task_id=727
 * http://bugs.irssi.org/index.php?do=details&task_id=769

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>