### PR TITLE
Implement paste detection via the bracketed paste mode

### DIFF
--- a/src/fe-text/gui-readline.c
+++ b/src/fe-text/gui-readline.c
@@ -666,15 +666,11 @@ static void sig_input(void)
 		/* use the bracketed paste mode to detect when the user pastes
 		 * some text into the entry */
 		if (paste_use_bracketed_mode != FALSE && paste_buffer->len > 12) {
-			/* try to find the start/end sequence */
-			int seq_start = memmem(paste_buffer->data,
-					       paste_buffer->len * g_array_get_element_size(paste_buffer),
-					       bp_start, sizeof(bp_start)) != NULL,
-			    seq_end   = memmem(paste_buffer->data,
-					       paste_buffer->len * g_array_get_element_size(paste_buffer),
-					       bp_end, sizeof(bp_end)) != NULL;
-
-			g_warning("found sequences : start %d end %d", seq_start, seq_end);
+			/* try to find the start/end sequence, we know that we
+			 * either find those at the start/end of the buffer or
+			 * we don't find those at all. */
+			int seq_start = !memcmp(paste_buffer->data, bp_start, sizeof(bp_start)),
+			    seq_end = !memcmp(paste_buffer->data + paste_buffer->len * g_array_get_element_size(paste_buffer) - sizeof(bp_end), bp_end, sizeof(bp_end));
 
 			if (seq_start) {
 				paste_bracketed_mode = TRUE;

--- a/src/fe-text/gui-readline.c
+++ b/src/fe-text/gui-readline.c
@@ -679,9 +679,7 @@ static void sig_input(void)
 			if (seq_start) {
 				paste_bracketed_mode = TRUE;
 				/* remove the leading sequence chars */
-				memmove(paste_buffer->data, paste_buffer->data + sizeof(bp_start),
-					paste_buffer->len * g_array_get_element_size(paste_buffer) - sizeof(bp_start));
-				g_array_set_size(paste_buffer, paste_buffer->len - 6);
+				g_array_remove_range(paste_buffer, 0, 6);
 			}
 
 			if (seq_end) {

--- a/src/fe-text/gui-readline.c
+++ b/src/fe-text/gui-readline.c
@@ -969,6 +969,9 @@ static void setup_changed(void)
 	paste_verify_line_count = settings_get_int("paste_verify_line_count");
 	paste_join_multiline = settings_get_bool("paste_join_multiline");
 	paste_use_bracketed_mode = settings_get_bool("paste_use_bracketed_mode");
+
+	/* Enable the bracketed paste mode on demand */
+	term_set_bracketed_paste_mode(paste_use_bracketed_mode);
 }
 
 void gui_readline_init(void)

--- a/src/fe-text/term-terminfo.c
+++ b/src/fe-text/term-terminfo.c
@@ -689,3 +689,11 @@ void term_gets(GArray *buffer, int *line_count)
 		}
 	}
 }
+
+void term_set_bracketed_paste_mode(int enable)
+{
+	if (enable)
+		tputs("\e[?2004h", 0, term_putchar);
+	else
+		tputs("\e[?2004l", 0, term_putchar);
+}

--- a/src/fe-text/term.h
+++ b/src/fe-text/term.h
@@ -94,6 +94,8 @@ void term_refresh(TERM_WINDOW *window);
 
 void term_stop(void);
 
+void term_set_bracketed_paste_mode(int enable);
+
 /* keyboard input handling */
 void term_set_input_type(int type);
 void term_gets(GArray *buffer, int *line_count);


### PR DESCRIPTION
Disabled by default as there's no way to check whether the terminal supports the bracketed paste mode, anyway `readline` approximates the detection in some way that might work quite well and we could be interested in that.

ping @dequis
ticket #9