### PR TITLE
Remove seemingly unused variables

### DIFF
--- a/src/core/commands.c
+++ b/src/core/commands.c
@@ -297,7 +297,7 @@ void command_runsub(const char *cmd, const char *data,
 		    void *server, void *item)
 {
 	const char *newcmd;
-	char *orig, *subcmd, *defcmd, *args;
+	char *subcmd, *defcmd, *args;
 
 	g_return_if_fail(data != NULL);
 
@@ -310,7 +310,7 @@ void command_runsub(const char *cmd, const char *data,
 	}
 
 	/* get command.. */
-	orig = subcmd = g_strdup_printf("command %s %s", cmd, data);
+	subcmd = g_strdup_printf("command %s %s", cmd, data);
 	args = strchr(subcmd+8 + strlen(cmd)+1, ' ');
 	if (args != NULL) *args++ = '\0'; else args = "";
 	while (*args == ' ') args++;
@@ -319,7 +319,6 @@ void command_runsub(const char *cmd, const char *data,
 	newcmd = command_expand(subcmd+8);
 	if (newcmd == NULL) {
                 /* ambiguous command */
-		g_free(orig);
 		return;
 	}
 
@@ -336,7 +335,6 @@ void command_runsub(const char *cmd, const char *data,
 	}
 
 	g_free(subcmd);
-	g_free(orig);
 }
 
 static GSList *optlist_find(GSList *optlist, const char *option)
@@ -664,14 +662,14 @@ get_optional_channel(WI_ITEM_REC *active_item, char **data, int require_name)
 {
         CHANNEL_REC *chanrec;
 	const char *ret;
-	char *tmp, *origtmp, *channel;
+	char *tmp, *channel;
 
 	if (active_item == NULL) {
                 /* no active channel in window, channel required */
 		return cmd_get_param(data);
 	}
 
-	origtmp = tmp = g_strdup(*data);
+	tmp = g_strdup(*data);
 	channel = cmd_get_param(&tmp);
 
 	if (g_strcmp0(channel, "*") == 0 && !require_name) {
@@ -690,7 +688,6 @@ get_optional_channel(WI_ITEM_REC *active_item, char **data, int require_name)
 		ret = chanrec == NULL ? channel : chanrec->name;
 	}
 
-	g_free(origtmp);
         return ret;
 }
 
@@ -851,11 +848,11 @@ static void parse_command(const char *command, int expand_aliases,
 {
         COMMAND_REC *rec;
 	const char *alias, *newcmd;
-	char *cmd, *orig, *args, *oldcmd;
+	char *cmd, *args, *oldcmd;
 
 	g_return_if_fail(command != NULL);
 
-	cmd = orig = g_strconcat("command ", command, NULL);
+	cmd = g_strconcat("command ", command, NULL);
 	args = strchr(cmd+8, ' ');
 	if (args != NULL) *args++ = '\0'; else args = "";
 
@@ -867,7 +864,6 @@ static void parse_command(const char *command, int expand_aliases,
                 alias_runstack_push(cmd+8);
 		eval_special_string(alias, args, server, item);
                 alias_runstack_pop(cmd+8);
-		g_free(orig);
 		return;
 	}
 
@@ -875,14 +871,11 @@ static void parse_command(const char *command, int expand_aliases,
 	newcmd = command_expand(cmd+8);
 	if (newcmd == NULL) {
                 /* ambiguous command */
-		g_free(orig);
 		return;
 	}
 
 	rec = command_find(newcmd);
 	if (rec != NULL && !cmd_protocol_match(rec, server)) {
-		g_free(orig);
-
 		signal_emit("error command", 2,
 			    GINT_TO_POINTER(server == NULL ?
 					    CMDERR_NOT_CONNECTED :
@@ -908,7 +901,6 @@ static void parse_command(const char *command, int expand_aliases,
 	current_command = oldcmd;
 
 	g_free(cmd);
-	g_free(orig);
 }
 
 static void event_command(const char *line, SERVER_REC *server, void *item)

--- a/src/core/levels.c
+++ b/src/core/levels.c
@@ -87,7 +87,7 @@ int level_get(const char *level)
 
 int level2bits(const char *level, int *errorp)
 {
-	char *orig, *str, *ptr;
+	char *str, *ptr;
 	int ret, singlelevel, negative;
 
 	if (errorp != NULL)
@@ -98,7 +98,7 @@ int level2bits(const char *level, int *errorp)
 	if (*level == '\0')
 		return 0;
 
-	orig = str = g_strdup(level);
+	str = g_strdup(level);
 
 	ret = 0;
 	for (ptr = str; ; str++) {
@@ -122,7 +122,6 @@ int level2bits(const char *level, int *errorp)
 
        		ptr = str;
 	}
-	g_free(orig);
 
 	return ret;
 }

--- a/src/core/misc.c
+++ b/src/core/misc.c
@@ -496,10 +496,10 @@ unsigned int g_istr_hash(gconstpointer v)
 /* Find `mask' from `data', you can use * and ? wildcards. */
 int match_wildcards(const char *cmask, const char *data)
 {
-	char *mask, *newmask, *p1, *p2;
+	char *mask, *p1, *p2;
 	int ret;
 
-	newmask = mask = g_strdup(cmask);
+	mask = g_strdup(cmask);
 	for (; *mask != '\0' && *data != '\0'; mask++) {
 		if (*mask != '*') {
 			if (*mask != '?' && i_toupper(*mask) != i_toupper(*data))
@@ -533,7 +533,6 @@ int match_wildcards(const char *cmask, const char *data)
 	while (*mask == '*') mask++;
 
 	ret = data != NULL && *data == '\0' && *mask == '\0';
-	g_free(newmask);
 
 	return ret;
 }

--- a/src/core/special-vars.c
+++ b/src/core/special-vars.c
@@ -540,7 +540,7 @@ void eval_special_string(const char *cmd, const char *data,
 			 SERVER_REC *server, void *item)
 {
 	const char *cmdchars;
-	char *orig, *str, *start, *ret;
+	char *str, *start, *ret;
 	int arg_used, arg_used_ever;
 	GSList *commands;
 
@@ -549,7 +549,7 @@ void eval_special_string(const char *cmd, const char *data,
 	cmdchars = settings_get_str("cmdchars");
 
 	/* get a list of all the commands to run */
-	orig = start = str = g_strdup(cmd);
+	start = str = g_strdup(cmd);
 	do {
 		if (is_split_char(str, start)) {
 			*str++ = '\0';
@@ -604,7 +604,6 @@ void eval_special_string(const char *cmd, const char *data,
 		g_free(ret);
 		commands = g_slist_remove(commands, commands->data);
 	}
-	g_free(orig);
 }
 
 void special_history_func_set(SPECIAL_HISTORY_FUNC func)

--- a/src/fe-common/irc/dcc/fe-dcc-chat.c
+++ b/src/fe-common/irc/dcc/fe-dcc-chat.c
@@ -74,14 +74,10 @@ static void dcc_connected(CHAT_DCC_REC *dcc)
 
 static void dcc_closed(CHAT_DCC_REC *dcc)
 {
-	char *sender;
-
         if (!IS_DCC_CHAT(dcc)) return;
 
-	sender = g_strconcat("=", dcc->id, NULL);
 	printformat(dcc->server, NULL, MSGLEVEL_DCC,
 		    IRCTXT_DCC_CHAT_DISCONNECTED, dcc->id);
-	g_free(sender);
 }
 
 static void dcc_chat_msg(CHAT_DCC_REC *dcc, const char *msg)

--- a/src/fe-common/irc/fe-events-numeric.c
+++ b/src/fe-common/irc/fe-events-numeric.c
@@ -44,37 +44,35 @@ static char *last_away_msg = NULL;
 
 static void event_user_mode(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *mode;
+	char *mode;
 
 	g_return_if_fail(data != NULL);
 	g_return_if_fail(server != NULL);
 
-	params = event_get_params(data, 2, NULL, &mode);
+	event_get_params(data, 2, NULL, &mode);
         printformat(server, NULL, MSGLEVEL_CRAP, IRCTXT_USER_MODE,
                     g_strchomp(mode));
-	g_free(params);
 }
 
 static void event_ison(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *online;
+	char *online;
 
 	g_return_if_fail(data != NULL);
 	g_return_if_fail(server != NULL);
 
-	params = event_get_params(data, 2, NULL, &online);
+	event_get_params(data, 2, NULL, &online);
 	printformat(server, NULL, MSGLEVEL_CRAP, IRCTXT_ONLINE, online);
-	g_free(params);
 }
 
 static void event_names_list(IRC_SERVER_REC *server, const char *data)
 {
 	IRC_CHANNEL_REC *chanrec;
-	char *params, *channel, *names;
+	char *channel, *names;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 4, NULL, NULL, &channel, &names);
+	event_get_params(data, 4, NULL, NULL, &channel, &names);
 
 	chanrec = irc_channel_find(server, channel);
 	if (chanrec == NULL || chanrec->names_got) {
@@ -84,34 +82,32 @@ static void event_names_list(IRC_SERVER_REC *server, const char *data)
                 printtext(server, channel, MSGLEVEL_CRAP, "%s", names);
 
 	}
-	g_free(params);
 }
 
 static void event_end_of_names(IRC_SERVER_REC *server, const char *data,
 			       const char *nick)
 {
 	IRC_CHANNEL_REC *chanrec;
-	char *params, *channel;
+	char *channel;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2, NULL, &channel);
+	event_get_params(data, 2, NULL, &channel);
 
 	chanrec = irc_channel_find(server, channel);
 	if (chanrec == NULL || chanrec->names_got)
 		print_event_received(server, data, nick, FALSE);
-	g_free(params);
 }
 
 static void event_who(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *nick, *channel, *user, *host, *stat, *realname, *hops;
+	char *nick, *channel, *user, *host, *stat, *realname, *hops;
 	char *serv, *recoded;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 8, NULL, &channel, &user,
-				  &host, &serv, &nick, &stat, &realname);
+	event_get_params(data, 8, NULL, &channel, &user,
+			 &host, &serv, &nick, &stat, &realname);
 
 	/* split hops/realname */
 	hops = realname;
@@ -123,19 +119,17 @@ static void event_who(IRC_SERVER_REC *server, const char *data)
 	printformat(server, NULL, MSGLEVEL_CRAP, IRCTXT_WHO,
 		    channel, nick, stat, hops, user, host, recoded, serv);
 
-	g_free(params);
 	g_free(recoded);
 }
 
 static void event_end_of_who(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *channel;
+	char *channel;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2, NULL, &channel);
+	event_get_params(data, 2, NULL, &channel);
 	printformat(server, NULL, MSGLEVEL_CRAP, IRCTXT_END_OF_WHO, channel);
-	g_free(params);
 }
 
 static void event_ban_list(IRC_SERVER_REC *server, const char *data)
@@ -143,12 +137,12 @@ static void event_ban_list(IRC_SERVER_REC *server, const char *data)
 	IRC_CHANNEL_REC *chanrec;
 	BAN_REC *banrec;
 	const char *channel;
-	char *params, *ban, *setby, *tims;
+	char *ban, *setby, *tims;
 	long secs;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 5, NULL, &channel,
+	event_get_params(data, 5, NULL, &channel,
 				  &ban, &setby, &tims);
 	secs = *tims == '\0' ? 0 :
 		(long) (time(NULL) - atol(tims));
@@ -161,19 +155,17 @@ static void event_ban_list(IRC_SERVER_REC *server, const char *data)
 		    *setby == '\0' ? IRCTXT_BANLIST : IRCTXT_BANLIST_LONG,
 		    banrec == NULL ? 0 : g_slist_index(chanrec->banlist, banrec)+1,
 		    channel, ban, setby, secs);
-
-	g_free(params);
 }
 
 static void event_eban_list(IRC_SERVER_REC *server, const char *data)
 {
 	const char *channel;
-	char *params, *ban, *setby, *tims;
+	char *ban, *setby, *tims;
 	long secs;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 5, NULL, &channel,
+	event_get_params(data, 5, NULL, &channel,
 				  &ban, &setby, &tims);
 	secs = *tims == '\0' ? 0 :
 		(long) (time(NULL) - atol(tims));
@@ -182,45 +174,39 @@ static void event_eban_list(IRC_SERVER_REC *server, const char *data)
 	printformat(server, channel, MSGLEVEL_CRAP,
 		    *setby == '\0' ? IRCTXT_EBANLIST : IRCTXT_EBANLIST_LONG,
 		    channel, ban, setby, secs);
-
-	g_free(params);
 }
 
 static void event_silence_list(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *nick, *mask;
+	char *nick, *mask;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 3, NULL, &nick, &mask);
+	event_get_params(data, 3, NULL, &nick, &mask);
 	printformat(server, NULL, MSGLEVEL_CRAP,
 		    IRCTXT_SILENCE_LINE, nick, mask);
-	g_free(params);
 }
 
 static void event_accept_list(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *accepted;
+	char *accepted;
 
 	g_return_if_fail(data != NULL);
 	g_return_if_fail(server != NULL);
 
-	params = event_get_params(data, 2 | PARAM_FLAG_GETREST,
-			NULL, &accepted);
+	event_get_params(data, 2 | PARAM_FLAG_GETREST, NULL, &accepted);
 	printformat(server, NULL, MSGLEVEL_CRAP, IRCTXT_ACCEPT_LIST, accepted);
-	g_free(params);
 }
 
 static void event_invite_list(IRC_SERVER_REC *server, const char *data)
 {
 	const char *channel;
-	char *params, *invite, *setby, *tims;
+	char *invite, *setby, *tims;
 	long secs;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 5, NULL, &channel, &invite,
-			&setby, &tims);
+	event_get_params(data, 5, NULL, &channel, &invite, &setby, &tims);
 	secs = *tims == '\0' ? 0 :
 		(long) (time(NULL) - atol(tims));
 
@@ -228,49 +214,45 @@ static void event_invite_list(IRC_SERVER_REC *server, const char *data)
 	printformat(server, channel, MSGLEVEL_CRAP,
 		    *setby == '\0' ? IRCTXT_INVITELIST : IRCTXT_INVITELIST_LONG,
 		    channel, invite, setby, secs);
-	g_free(params);
 }
 
 static void event_nick_in_use(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *nick;
+	char *nick;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2, NULL, &nick);
+	event_get_params(data, 2, NULL, &nick);
 	if (server->connected) {
 		printformat(server, NULL, MSGLEVEL_CRAP,
 			    IRCTXT_NICK_IN_USE, nick);
 	}
-
-	g_free(params);
 }
 
 static void event_topic_get(IRC_SERVER_REC *server, const char *data)
 {
 	const char *channel;
-	char *params, *topic, *recoded;
+	char *topic, *recoded;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 3, NULL, &channel, &topic);
+	event_get_params(data, 3, NULL, &channel, &topic);
 	recoded = recode_in(SERVER(server), topic, channel);
 	channel = get_visible_target(server, channel);
 	printformat(server, channel, MSGLEVEL_CRAP,
 		    IRCTXT_TOPIC, channel, recoded);
-	g_free(params);
 	g_free(recoded);
 }
 
 static void event_topic_info(IRC_SERVER_REC *server, const char *data)
 {
 	const char *channel;
-	char *params, *timestr, *bynick, *byhost, *topictime;
+	char *timestr, *bynick, *byhost, *topictime;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 4, NULL, &channel,
-				  &bynick, &topictime);
+	event_get_params(data, 4, NULL, &channel,
+			 &bynick, &topictime);
 
         timestr = my_asctime((time_t) atol(topictime));
 
@@ -282,39 +264,36 @@ static void event_topic_info(IRC_SERVER_REC *server, const char *data)
 	printformat(server, channel, MSGLEVEL_CRAP, IRCTXT_TOPIC_INFO,
 		    bynick, timestr, byhost == NULL ? "" : byhost);
 	g_free(timestr);
-	g_free(params);
 }
 
 static void event_channel_mode(IRC_SERVER_REC *server, const char *data)
 {
 	const char *channel;
-	char *params, *mode;
+	char *mode;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 3 | PARAM_FLAG_GETREST,
-				  NULL, &channel, &mode);
+	event_get_params(data, 3 | PARAM_FLAG_GETREST,
+			 NULL, &channel, &mode);
 	channel = get_visible_target(server, channel);
 	printformat(server, channel, MSGLEVEL_CRAP,
 		    IRCTXT_CHANNEL_MODE, channel, g_strchomp(mode));
-	g_free(params);
 }
 
 static void event_channel_created(IRC_SERVER_REC *server, const char *data)
 {
 	const char *channel;
-	char *params, *createtime, *timestr;
+	char *createtime, *timestr;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 3, NULL, &channel, &createtime);
+	event_get_params(data, 3, NULL, &channel, &createtime);
 
         timestr = my_asctime((time_t) atol(createtime));
 	channel = get_visible_target(server, channel);
 	printformat(server, channel, MSGLEVEL_CRAP,
 		    IRCTXT_CHANNEL_CREATED, channel, timestr);
 	g_free(timestr);
-	g_free(params);
 }
 
 static void event_nowaway(IRC_SERVER_REC *server, const char *data)
@@ -329,11 +308,11 @@ static void event_unaway(IRC_SERVER_REC *server, const char *data)
 
 static void event_away(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *nick, *awaymsg, *recoded;
+	char *nick, *awaymsg, *recoded;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 3, NULL, &nick, &awaymsg);
+	event_get_params(data, 3, NULL, &nick, &awaymsg);
 	recoded = recode_in(SERVER(server), awaymsg, nick);
 	if (!settings_get_bool("show_away_once") ||
 	    last_away_nick == NULL ||
@@ -350,56 +329,52 @@ static void event_away(IRC_SERVER_REC *server, const char *data)
 		printformat(server, nick, MSGLEVEL_CRAP,
 			    IRCTXT_NICK_AWAY, nick, recoded);
 	}
-	g_free(params);
 	g_free(recoded);
 }
 
 static void event_userhost(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *hosts;
+	char *hosts;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2, NULL, &hosts);
+	event_get_params(data, 2, NULL, &hosts);
 	printtext(server, NULL, MSGLEVEL_CRAP, "%s", hosts);
-	g_free(params);
 }
 
 static void event_sent_invite(IRC_SERVER_REC *server, const char *data)
 {
-        char *params, *nick, *channel;
+        char *nick, *channel;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 3, NULL, &nick, &channel);
+	event_get_params(data, 3, NULL, &nick, &channel);
 	printformat(server, nick, MSGLEVEL_CRAP,
 		    IRCTXT_INVITING, nick, channel);
-	g_free(params);
 }
 
 static void event_chanserv_url(IRC_SERVER_REC *server, const char *data)
 {
 	const char *channel;
-	char *params, *url;
+	char *url;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 3, NULL, &channel, &url);
+	event_get_params(data, 3, NULL, &channel, &url);
 	channel = get_visible_target(server, channel);
 	printformat(server, channel, MSGLEVEL_CRAP,
 		    IRCTXT_CHANNEL_URL, channel, url);
-	g_free(params);
 }
 
 static void event_target_unavailable(IRC_SERVER_REC *server, const char *data,
 				     const char *nick, const char *addr)
 {
 	IRC_CHANNEL_REC *chanrec;
-	char *params, *target;
+	char *target;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2, NULL, &target);
+	event_get_params(data, 2, NULL, &target);
 	if (!server_ischannel(SERVER(server), target)) {
 		/* nick unavailable */
 		printformat(server, NULL, MSGLEVEL_CRAP,
@@ -415,48 +390,43 @@ static void event_target_unavailable(IRC_SERVER_REC *server, const char *data,
 				    IRCTXT_JOINERROR_UNAVAIL, target);
 		}
 	}
-
-	g_free(params);
 }
 
 static void event_no_such_nick(IRC_SERVER_REC *server, const char *data,
 				     const char *nick, const char *addr)
 {
-	char *params, *unick;
+	char *unick;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2, NULL, &unick);
+	event_get_params(data, 2, NULL, &unick);
 	if (!g_strcmp0(unick, "*"))
 		/* more information will be in the description,
 		 * e.g. * :Target left IRC. Failed to deliver: [hi] */
 		print_event_received(server, data, nick, FALSE);
 	else
 		printformat(server, unick, MSGLEVEL_CRAP, IRCTXT_NO_SUCH_NICK, unick);
-	g_free(params);
 }
 
 static void event_no_such_channel(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *channel;
+	char *channel;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2, NULL, &channel);
+	event_get_params(data, 2, NULL, &channel);
 	printformat(server, channel, MSGLEVEL_CRAP,
 		    IRCTXT_NO_SUCH_CHANNEL, channel);
-	g_free(params);
 }
 
 static void cannot_join(IRC_SERVER_REC *server, const char *data, int format)
 {
-	char *params, *channel;
+	char *channel;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2, NULL, &channel);
+	event_get_params(data, 2, NULL, &channel);
 	printformat(server, NULL, MSGLEVEL_CRAP, format, channel);
-	g_free(params);
 }
 
 static void event_too_many_channels(IRC_SERVER_REC *server, const char *data)
@@ -467,13 +437,13 @@ static void event_too_many_channels(IRC_SERVER_REC *server, const char *data)
 static void event_duplicate_channel(IRC_SERVER_REC *server, const char *data,
 		const char *nick)
 {
-	char *params, *channel, *p;
+	char *channel, *p;
 
 	g_return_if_fail(data != NULL);
 
 	/* this new addition to ircd breaks completely with older
 	   "standards", "nick Duplicate ::!!channel ...." */
-	params = event_get_params(data, 3, NULL, NULL, &channel);
+	event_get_params(data, 3, NULL, NULL, &channel);
 	p = strchr(channel, ' ');
 	if (p != NULL) *p = '\0';
 
@@ -482,8 +452,6 @@ static void event_duplicate_channel(IRC_SERVER_REC *server, const char *data,
 			    IRCTXT_JOINERROR_DUPLICATE, channel+1);
 	} else
 		print_event_received(server, data, nick, FALSE);
-
-	g_free(params);
 }
 
 static void event_channel_is_full(IRC_SERVER_REC *server, const char *data)
@@ -520,15 +488,14 @@ static void event_477(IRC_SERVER_REC *server, const char *data,
 	 * status window. Otherwise display it in the channel window.
 	 */
 	IRC_CHANNEL_REC *chanrec;
-	char *params, *channel;
+	char *channel;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2, NULL, &channel);
+	event_get_params(data, 2, NULL, &channel);
 
 	chanrec = irc_channel_find(server, channel);
 	print_event_received(server, data, nick, chanrec == NULL || chanrec->joined);
-	g_free(params);
 }
 
 static void event_target_too_fast(IRC_SERVER_REC *server, const char *data,
@@ -539,26 +506,24 @@ static void event_target_too_fast(IRC_SERVER_REC *server, const char *data,
 	 * status window. Otherwise display it in the channel window.
 	 */
 	IRC_CHANNEL_REC *chanrec;
-	char *params, *channel;
+	char *channel;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2, NULL, &channel);
+	event_get_params(data, 2, NULL, &channel);
 
 	chanrec = irc_channel_find(server, channel);
 	print_event_received(server, data, nick, chanrec == NULL || chanrec->joined);
-	g_free(params);
 }
 
 static void event_unknown_mode(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *mode;
+	char *mode;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2, NULL, &mode);
+	event_get_params(data, 2, NULL, &mode);
 	printformat(server, NULL, MSGLEVEL_CRAP, IRCTXT_UNKNOWN_MODE, mode);
-	g_free(params);
 }
 
 static void event_numeric(IRC_SERVER_REC *server, const char *data,

--- a/src/fe-common/irc/fe-irc-channels.c
+++ b/src/fe-common/irc/fe-irc-channels.c
@@ -88,9 +88,9 @@ static void sig_event_forward(SERVER_REC *server, const char *data,
 			      const char *nick)
 {
 	IRC_CHANNEL_REC *channel;
-	char *params, *from, *to;
+	char *from, *to;
 
-	params = event_get_params(data, 3, NULL, &from, &to);
+	event_get_params(data, 3, NULL, &from, &to);
 	if (from != NULL && to != NULL && server_ischannel(server, from) && server_ischannel(server, to)) {
 		channel = irc_channel_find(server, from);
 		if (channel != NULL && irc_channel_find(server, to) == NULL) {
@@ -98,7 +98,6 @@ static void sig_event_forward(SERVER_REC *server, const char *data,
 					server->tag, to);
 		}
 	}
-	g_free(params);
 }
 
 void fe_irc_channels_init(void)

--- a/src/fe-common/irc/fe-netjoin.c
+++ b/src/fe-common/irc/fe-netjoin.c
@@ -395,7 +395,7 @@ static void msg_mode(IRC_SERVER_REC *server, const char *channel,
 		     const char *sender, const char *addr, const char *data)
 {
 	NETJOIN_REC *rec;
-	char *params, *mode, *nicks;
+	char *mode, *nicks;
 	char **nicklist, **nick, type, prefix;
 	int show;
 
@@ -403,8 +403,8 @@ static void msg_mode(IRC_SERVER_REC *server, const char *channel,
 	if (!server_ischannel(SERVER(server), channel) || addr != NULL)
 		return;
 
-	params = event_get_params(data, 2 | PARAM_FLAG_GETREST,
-				  &mode, &nicks);
+	event_get_params(data, 2 | PARAM_FLAG_GETREST,
+			 &mode, &nicks);
 
 	/* parse server mode changes - hide operator status changes and
 	   show them in the netjoin message instead as @ before the nick */
@@ -435,7 +435,6 @@ static void msg_mode(IRC_SERVER_REC *server, const char *channel,
 	if (!show) signal_stop();
 
 	g_strfreev(nicklist);
-	g_free(params);
 }
 
 static void read_settings(void)

--- a/src/fe-common/irc/fe-whois.c
+++ b/src/fe-common/irc/fe-whois.c
@@ -14,40 +14,38 @@
 
 static void event_whois(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *nick, *user, *host, *realname, *recoded;
+	char *nick, *user, *host, *realname, *recoded;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 6, NULL, &nick, &user,
-				  &host, NULL, &realname);
+	event_get_params(data, 6, NULL, &nick, &user,
+			 &host, NULL, &realname);
 	recoded = recode_in(SERVER(server), realname, nick);
 	printformat(server, nick, MSGLEVEL_CRAP,
 		    IRCTXT_WHOIS, nick, user, host, recoded);
-	g_free(params);
 	g_free(recoded);
 }
 
 static void event_whois_special(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *nick, *str;
+	char *nick, *str;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 3 | PARAM_FLAG_GETREST, NULL, &nick, &str);
+	event_get_params(data, 3 | PARAM_FLAG_GETREST, NULL, &nick, &str);
 	printformat(server, nick, MSGLEVEL_CRAP,
 		    IRCTXT_WHOIS_SPECIAL, nick, str);
-	g_free(params);
 }
 
 static void event_whois_idle(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *nick, *secstr, *signonstr, *rest, *timestr;
+	char *nick, *secstr, *signonstr, *rest, *timestr;
 	long days, hours, mins, secs;
 	time_t signon;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 5 | PARAM_FLAG_GETREST, NULL,
+	event_get_params(data, 5 | PARAM_FLAG_GETREST, NULL,
 				  &nick, &secstr, &signonstr, &rest);
 
 	secs = atol(secstr);
@@ -69,28 +67,26 @@ static void event_whois_idle(IRC_SERVER_REC *server, const char *data)
 			    nick, days, hours, mins, secs, timestr);
 		g_free(timestr);
 	}
-	g_free(params);
 }
 
 static void event_whois_server(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *nick, *whoserver, *desc;
+	char *nick, *whoserver, *desc;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 4, NULL, &nick, &whoserver, &desc);
+	event_get_params(data, 4, NULL, &nick, &whoserver, &desc);
 	printformat(server, nick, MSGLEVEL_CRAP,
 		    IRCTXT_WHOIS_SERVER, nick, whoserver, desc);
-	g_free(params);
 }
 
 static void event_whois_oper(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *nick, *type;
+	char *nick, *type;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 3, NULL, &nick, &type);
+	event_get_params(data, 3, NULL, &nick, &type);
 
 	/* Bugfix: http://bugs.irssi.org/?do=details&task_id=99
 	 * Author: Geert Hauwaerts <geert@irssi.org>
@@ -107,38 +103,34 @@ static void event_whois_oper(IRC_SERVER_REC *server, const char *data)
 
 	printformat(server, nick, MSGLEVEL_CRAP,
 		IRCTXT_WHOIS_OPER, nick, type);
-	g_free(params);
 }
 
 static void event_whois_modes(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *nick, *modes;
+	char *nick, *modes;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 3 | PARAM_FLAG_GETREST,
-			NULL, &nick, &modes);
+	event_get_params(data, 3 | PARAM_FLAG_GETREST, NULL, &nick, &modes);
 	if (!strncmp(modes, "is using modes ", 15))
 		modes += 15;
 	printformat(server, nick, MSGLEVEL_CRAP,
 		    IRCTXT_WHOIS_MODES, nick, modes);
-	g_free(params);
 }
 
 static void event_whois_realhost(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *nick, *txt_real, *txt_hostname, *hostname;
+	char *nick, *txt_real, *txt_hostname, *hostname;
 
 	g_return_if_fail(data != NULL);
 
         /* <yournick> real hostname <nick> <hostname> */
-	params = event_get_params(data, 5, NULL, &nick, &txt_real,
-				  &txt_hostname, &hostname);
+	event_get_params(data, 5, NULL, &nick, &txt_real,
+			 &txt_hostname, &hostname);
 	if (g_strcmp0(txt_real, "real") != 0 ||
 	    g_strcmp0(txt_hostname, "hostname") != 0) {
 		/* <yournick> <nick> :... from <hostname> */
-                g_free(params);
-		params = event_get_params(data, 3, NULL, &nick, &hostname);
+		event_get_params(data, 3, NULL, &nick, &hostname);
 
 		hostname = strstr(hostname, "from ");
                 if (hostname != NULL) hostname += 5;
@@ -152,42 +144,39 @@ static void event_whois_realhost(IRC_SERVER_REC *server, const char *data)
 	} else {
 		event_whois_special(server, data);
 	}
-	g_free(params);
 }
 
 static void event_whois_usermode326(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *nick, *usermode;
+	char *nick, *usermode;
 
 	g_return_if_fail(data != NULL);
 
         /* <yournick> <nick> :has oper privs: <mode> */
-	params = event_get_params(data, 3, NULL, &nick, &usermode);
+	event_get_params(data, 3, NULL, &nick, &usermode);
 	printformat(server, nick, MSGLEVEL_CRAP,
 		    IRCTXT_WHOIS_USERMODE, nick, usermode);
-        g_free(params);
 }
 
 static void event_whois_realhost327(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *nick, *hostname, *ip, *text;
+	char *nick, *hostname, *ip, *text;
 
 	g_return_if_fail(data != NULL);
 
 	/* <yournick> <hostname> <ip> :Real hostname/IP */
-	params = event_get_params(data, 5, NULL, &nick, &hostname, &ip, &text);
+	event_get_params(data, 5, NULL, &nick, &hostname, &ip, &text);
 	if (*text != '\0') {
 		printformat(server, nick, MSGLEVEL_CRAP,
 			    IRCTXT_WHOIS_REALHOST, nick, hostname, ip);
 	} else {
 		event_whois_special(server, data);
 	}
-	g_free(params);
 }
 
 static void event_whois_realhost338(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *nick, *arg1, *arg2, *arg3;
+	char *nick, *arg1, *arg2, *arg3;
 
 	g_return_if_fail(data != NULL);
 
@@ -197,7 +186,7 @@ static void event_whois_realhost338(IRC_SERVER_REC *server, const char *data)
 	 * :<server> 338 <yournick> <nick> <ip> :actually using host
 	 * (ratbox)
 	 */
-	params = event_get_params(data, 5, NULL, &nick, &arg1, &arg2, &arg3);
+	event_get_params(data, 5, NULL, &nick, &arg1, &arg2, &arg3);
 	if (*arg3 != '\0') {
 		printformat(server, nick, MSGLEVEL_CRAP,
 			    IRCTXT_WHOIS_REALHOST, nick, arg1, arg2);
@@ -207,16 +196,15 @@ static void event_whois_realhost338(IRC_SERVER_REC *server, const char *data)
 	} else {
 		event_whois_special(server, data);
 	}
-	g_free(params);
 }
 
 static void event_whois_usermode(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *txt_usermodes, *nick, *usermode;
+	char *txt_usermodes, *nick, *usermode;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 4, NULL, &txt_usermodes,
+	event_get_params(data, 4, NULL, &txt_usermodes,
 				  &nick, &usermode);
 
 	if (g_strcmp0(txt_usermodes, "usermodes") == 0) {
@@ -226,7 +214,6 @@ static void event_whois_usermode(IRC_SERVER_REC *server, const char *data)
 	} else {
 		event_whois_special(server, data);
 	}
-	g_free(params);
 }
 
 static void hide_safe_channel_id(IRC_SERVER_REC *server, char *chans)
@@ -278,11 +265,11 @@ static void hide_safe_channel_id(IRC_SERVER_REC *server, char *chans)
 
 static void event_whois_channels(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *nick, *chans, *recoded;
+	char *nick, *chans, *recoded;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 3, NULL, &nick, &chans);
+	event_get_params(data, 3, NULL, &nick, &chans);
 
 	/* sure - we COULD print the channel names as-is, but since the
 	   colors, bolds, etc. are mostly just to fool people, I think we
@@ -296,77 +283,71 @@ static void event_whois_channels(IRC_SERVER_REC *server, const char *data)
 		    IRCTXT_WHOIS_CHANNELS, nick, recoded);
 	g_free(chans);
 
-	g_free(params);
 	g_free(recoded);
 }
 
 static void event_whois_away(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *nick, *awaymsg, *recoded;
+	char *nick, *awaymsg, *recoded;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 3, NULL, &nick, &awaymsg);
+	event_get_params(data, 3, NULL, &nick, &awaymsg);
 	recoded = recode_in(SERVER(server), awaymsg, nick);
 	printformat(server, nick, MSGLEVEL_CRAP,
 		    IRCTXT_WHOIS_AWAY, nick, recoded);
-	g_free(params);
 	g_free(recoded);
 }
 
 static void event_end_of_whois(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *nick;
+	char *nick;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2, NULL, &nick);
+	event_get_params(data, 2, NULL, &nick);
 	if (server->whois_found) {
 		printformat(server, nick, MSGLEVEL_CRAP,
 			    IRCTXT_END_OF_WHOIS, nick);
 	}
-	g_free(params);
 }
 
 static void event_whois_auth(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *nick, *text;
+	char *nick, *text;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 3, NULL, &nick, &text);
+	event_get_params(data, 3, NULL, &nick, &text);
 	printformat(server, nick, MSGLEVEL_CRAP,
 		    IRCTXT_WHOIS_EXTRA, nick, text);
-	g_free(params);
 }
 
 static void event_whowas(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *nick, *user, *host, *realname, *recoded;
+	char *nick, *user, *host, *realname, *recoded;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 6, NULL, &nick, &user,
-				  &host, NULL, &realname);
+	event_get_params(data, 6, NULL, &nick, &user,
+			 &host, NULL, &realname);
 	recoded = recode_in(SERVER(server), realname, nick);
 	printformat(server, nick, MSGLEVEL_CRAP,
 		    IRCTXT_WHOWAS, nick, user, host, recoded);
-	g_free(params);
 	g_free(recoded);
 }
 
 static void event_end_of_whowas(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *nick;
+	char *nick;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2, NULL, &nick);
+	event_get_params(data, 2, NULL, &nick);
 	if (server->whowas_found) {
 		printformat(server, nick, MSGLEVEL_CRAP,
 			    IRCTXT_END_OF_WHOWAS, nick);
 	}
-	g_free(params);
 }
 
 struct whois_event_table {

--- a/src/irc/core/channel-rejoin.c
+++ b/src/irc/core/channel-rejoin.c
@@ -114,11 +114,11 @@ static int channel_rejoin(IRC_SERVER_REC *server, const char *channel)
 static void event_duplicate_channel(IRC_SERVER_REC *server, const char *data)
 {
 	CHANNEL_REC *chanrec;
-	char *params, *channel, *p;
+	char *channel, *p;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 3, NULL, NULL, &channel);
+	event_get_params(data, 3, NULL, NULL, &channel);
 	p = strchr(channel, ' ');
 	if (p != NULL) *p = '\0';
 
@@ -137,18 +137,16 @@ static void event_duplicate_channel(IRC_SERVER_REC *server, const char *data)
 			}
 		}
 	}
-
-	g_free(params);
 }
 
 static void event_target_unavailable(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *channel;
+	char *channel;
 	IRC_CHANNEL_REC *chanrec;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2, NULL, &channel);
+	event_get_params(data, 2, NULL, &channel);
 	if (server_ischannel(SERVER(server), channel)) {
 		chanrec = irc_channel_find(server, channel);
 		if (chanrec != NULL && chanrec->joined) {
@@ -162,8 +160,6 @@ static void event_target_unavailable(IRC_SERVER_REC *server, const char *data)
 			}
 		}
 	}
-
-	g_free(params);
 }
 
 /* join ok/failed - remove from rejoins list. this happens always after join

--- a/src/irc/core/channels-query.c
+++ b/src/irc/core/channels-query.c
@@ -398,11 +398,11 @@ static void event_channel_mode(IRC_SERVER_REC *server, const char *data,
 			       const char *nick)
 {
 	IRC_CHANNEL_REC *chanrec;
-	char *params, *channel, *mode;
+	char *channel, *mode;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 3 | PARAM_FLAG_GETREST,
+	event_get_params(data, 3 | PARAM_FLAG_GETREST,
 				  NULL, &channel, &mode);
 	chanrec = irc_channel_find(server, channel);
 	if (chanrec != NULL) {
@@ -414,20 +414,18 @@ static void event_channel_mode(IRC_SERVER_REC *server, const char *data,
 		parse_channel_modes(chanrec, nick, mode, FALSE);
 		channel_got_query(chanrec, CHANNEL_QUERY_MODE);
 	}
-
-	g_free(params);
 }
 
 static void event_end_of_who(IRC_SERVER_REC *server, const char *data)
 {
         SERVER_QUERY_REC *rec;
         GSList *tmp, *next;
-	char *params, *channel, **channels;
+	char *channel, **channels;
         int failed, multiple;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2, NULL, &channel);
+	event_get_params(data, 2, NULL, &channel);
 	multiple = strchr(channel, ',') != NULL;
 	channels = g_strsplit(channel, ",", -1);
 
@@ -462,24 +460,20 @@ static void event_end_of_who(IRC_SERVER_REC *server, const char *data)
 		   send them again separately */
                 query_current_error(server);
 	}
-
-        g_free(params);
 }
 
 static void event_end_of_banlist(IRC_SERVER_REC *server, const char *data)
 {
 	IRC_CHANNEL_REC *chanrec;
-	char *params, *channel;
+	char *channel;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2, NULL, &channel);
+	event_get_params(data, 2, NULL, &channel);
 	chanrec = irc_channel_find(server, channel);
 
 	if (chanrec != NULL)
 		channel_got_query(chanrec, CHANNEL_QUERY_BMODE);
-
-	g_free(params);
 }
 
 void channels_query_init(void)

--- a/src/irc/core/ctcp.c
+++ b/src/irc/core/ctcp.c
@@ -269,12 +269,12 @@ static void ctcp_reply(IRC_SERVER_REC *server, const char *data,
 static void event_privmsg(IRC_SERVER_REC *server, const char *data,
 			  const char *nick, const char *addr)
 {
-	char *params, *target, *msg;
+	char *target, *msg;
 	int len;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2, &target, &msg);
+	event_get_params(data, 2, &target, &msg);
 
 	/* handle only ctcp messages.. */
 	if (*msg == 1) {
@@ -287,18 +287,16 @@ static void event_privmsg(IRC_SERVER_REC *server, const char *data,
 		signal_emit("ctcp msg", 5, server, msg, nick, addr, target);
 		signal_stop();
 	}
-
-	g_free(params);
 }
 
 static void event_notice(IRC_SERVER_REC *server, const char *data,
 			 const char *nick, const char *addr)
 {
-	char *params, *target, *ptr, *msg;
+	char *target, *ptr, *msg;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2, &target, &msg);
+	event_get_params(data, 2, &target, &msg);
 
 	/* handle only ctcp replies */
 	if (*msg == 1) {
@@ -308,8 +306,6 @@ static void event_notice(IRC_SERVER_REC *server, const char *data,
 		signal_emit("ctcp reply", 5, server, msg, nick, addr, target);
 		signal_stop();
 	}
-
-	g_free(params);
 }
 
 static void sig_disconnected(IRC_SERVER_REC *server)

--- a/src/irc/core/irc-cap.c
+++ b/src/irc/core/irc-cap.c
@@ -83,12 +83,13 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 {
 	GSList *tmp;
 	GString *cmd;
-	char *params, *evt, *list, **caps;
+	char *evt, *list, **caps;
 	int i, caps_length, disable, avail_caps;
 
-	params = event_get_params(args, 3, NULL, &evt, &list);
-	if (params == NULL)
-		return;
+	if(args == NULL)
+	  return;
+
+	event_get_params(args, 3, NULL, &evt, &list);
 
 	/* Strip the trailing whitespaces before splitting the string, some servers send responses with
 	 * superfluous whitespaces that g_strsplit the interprets as tokens */
@@ -166,7 +167,6 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 	}
 
 	g_strfreev(caps);
-	g_free(params);
 }
 
 static void event_invalid_cap (IRC_SERVER_REC *server, const char *data, const char *from)

--- a/src/irc/core/irc-commands.c
+++ b/src/irc/core/irc-commands.c
@@ -452,11 +452,11 @@ static void event_whois(IRC_SERVER_REC *server, const char *data,
 
 static void sig_whois_try_whowas(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *nick;
+	char *nick;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2, NULL, &nick);
+	event_get_params(data, 2, NULL, &nick);
 
 	server->whowas_found = FALSE;
 	server_redirect_event(server, "whowas", 1, nick, -1, NULL,
@@ -464,8 +464,6 @@ static void sig_whois_try_whowas(IRC_SERVER_REC *server, const char *data)
 			      "event 369", "whowas event end",
 			      "event 406", "event empty", NULL);
 	irc_send_cmdv(server, "WHOWAS %s 1", nick);
-
-	g_free(params);
 }
 
 static void event_end_of_whois(IRC_SERVER_REC *server, const char *data,

--- a/src/irc/core/irc-queries.c
+++ b/src/irc/core/irc-queries.c
@@ -82,15 +82,14 @@ static void check_query_changes(IRC_SERVER_REC *server, const char *nick,
 static void event_privmsg(IRC_SERVER_REC *server, const char *data,
 			  const char *nick, const char *address)
 {
-	char *params, *target, *msg;
+	char *target, *msg;
 
 	g_return_if_fail(data != NULL);
 	if (nick == NULL)
 		return;
 
-	params = event_get_params(data, 2 | PARAM_FLAG_GETREST, &target, &msg);
+	event_get_params(data, 2 | PARAM_FLAG_GETREST, &target, &msg);
         check_query_changes(server, nick, address, target);
-	g_free(params);
 }
 
 static void ctcp_action(IRC_SERVER_REC *server, const char *msg,
@@ -104,14 +103,13 @@ static void event_nick(SERVER_REC *server, const char *data,
 		       const char *orignick)
 {
         QUERY_REC *query;
-	char *params, *nick;
+	char *nick;
 
 	query = query_find(server, orignick);
 	if (query != NULL) {
-		params = event_get_params(data, 1, &nick);
+		event_get_params(data, 1, &nick);
 		if (g_strcmp0(query->name, nick) != 0)
 			query_change_nick(query, nick);
-		g_free(params);
 	}
 }
 

--- a/src/irc/core/irc-servers.c
+++ b/src/irc/core/irc-servers.c
@@ -652,12 +652,12 @@ char *irc_server_get_channels(IRC_SERVER_REC *server)
 
 static void event_connected(IRC_SERVER_REC *server, const char *data, const char *from)
 {
-	char *params, *nick;
+	char *nick;
 	GTimeVal now;
 
 	g_return_if_fail(server != NULL);
 
-	params = event_get_params(data, 1, &nick);
+	event_get_params(data, 1, &nick);
 
 	if (g_strcmp0(server->nick, nick) != 0) {
 		/* nick changed unexpectedly .. connected via proxy, etc. */
@@ -692,16 +692,15 @@ static void event_connected(IRC_SERVER_REC *server, const char *data, const char
 	}
 
 	signal_emit("event connected", 1, server);
-	g_free(params);
 }
 
 static void event_server_info(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *ircd_version, *usermodes, *chanmodes;
+	char *ircd_version, *usermodes, *chanmodes;
 
 	g_return_if_fail(server != NULL);
 
-	params = event_get_params(data, 5, NULL, NULL, &ircd_version, &usermodes, &chanmodes);
+	event_get_params(data, 5, NULL, NULL, &ircd_version, &usermodes, &chanmodes);
 
 	/* check if server understands I and e channel modes */
 	if (strchr(chanmodes, 'I') && strchr(chanmodes, 'e'))
@@ -710,8 +709,6 @@ static void event_server_info(IRC_SERVER_REC *server, const char *data)
 	/* save server version */
 	g_free_not_null(server->version);
 	server->version = g_strdup(ircd_version);
-
-	g_free(params);
 }
 
 static void parse_chanmodes(IRC_SERVER_REC *server, const char *sptr)
@@ -841,22 +838,22 @@ static void event_end_of_motd(IRC_SERVER_REC *server, const char *data)
 
 static void event_channels_formed(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *channels;
+	char *channels;
 
 	g_return_if_fail(server != NULL);
 
-	params = event_get_params(data, 2, NULL, &channels);
+	event_get_params(data, 2, NULL, &channels);
         server->channels_formed = atoi(channels);
-	g_free(params);
 }
 
 static void event_hosthidden(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *newhost, *p, *newuserhost;
+	char *newhost, *p, *newuserhost;
 
 	g_return_if_fail(server != NULL);
 
-	params = event_get_params(data, 2, NULL, &newhost);
+	event_get_params(data, 2, NULL, &newhost);
+
 	/* do a sanity check */
 	if (!strchr(newhost, '*') && !strchr(newhost, '?') &&
 			!strchr(newhost, '!') && !strchr(newhost, '#') &&
@@ -880,7 +877,6 @@ static void event_hosthidden(IRC_SERVER_REC *server, const char *data)
 			server->userhost = newuserhost;
 		}
 	}
-	g_free(params);
 }
 
 static void event_server_banned(IRC_SERVER_REC *server, const char *data)
@@ -903,14 +899,13 @@ static void event_error(IRC_SERVER_REC *server, const char *data)
 
 static void event_ping(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *origin, *target, *str;
+	char *origin, *target, *str;
 
-	params = event_get_params(data, 2, &origin, &target);
+	event_get_params(data, 2, &origin, &target);
 	str = *target == '\0' ? g_strconcat("PONG :", origin, NULL) :
 		g_strdup_printf("PONG %s :%s", target, origin);
 	irc_send_cmd_now(server, str);
         g_free(str);
-	g_free(params);
 }
 
 static void event_empty(void)

--- a/src/irc/core/irc.c
+++ b/src/irc/core/irc.c
@@ -248,16 +248,16 @@ char *event_get_param(char **data)
 }
 
 /* Get count parameters from data */
-char *event_get_params(const char *data, int count, ...)
+void event_get_params(const char *data, int count, ...)
 {
-	char **str, *tmp, *duprec, *datad;
+	char **str, *tmp, *datad;
 	gboolean rest;
 	va_list args;
 
 	g_return_val_if_fail(data != NULL, NULL);
 
 	va_start(args, count);
-	duprec = datad = g_strdup(data);
+	datad = g_strdup(data);
 
 	rest = count & PARAM_FLAG_GETREST;
 	count = PARAM_WITHOUT_FLAGS(count);
@@ -273,8 +273,6 @@ char *event_get_params(const char *data, int count, ...)
 		if (str != NULL) *str = tmp;
 	}
 	va_end(args);
-
-	return duprec;
 }
 
 static void irc_server_event(IRC_SERVER_REC *server, const char *line,

--- a/src/irc/core/irc.c
+++ b/src/irc/core/irc.c
@@ -182,7 +182,7 @@ static char *split_nicks(const char *cmd, char **pre, char **nicks, char **post,
 void irc_send_cmd_split(IRC_SERVER_REC *server, const char *cmd,
 			int nickarg, int max_nicks)
 {
-	char *str, *pre, *post, *nicks;
+	char *pre, *post, *nicks;
 	char **nicklist, **tmp;
 	GString *nickstr;
 	int count;
@@ -190,10 +190,9 @@ void irc_send_cmd_split(IRC_SERVER_REC *server, const char *cmd,
 	g_return_if_fail(server != NULL);
 	g_return_if_fail(cmd != NULL);
 
-	str = split_nicks(cmd, &pre, &nicks, &post, nickarg);
+	split_nicks(cmd, &pre, &nicks, &post, nickarg);
 	if (nicks == NULL) {
                 /* no nicks given? */
-		g_free(str);
 		return;
 	}
 
@@ -221,8 +220,6 @@ void irc_send_cmd_split(IRC_SERVER_REC *server, const char *cmd,
 	}
 	g_strfreev(nicklist);
 	g_string_free(nickstr, TRUE);
-
-	g_free(str);
 }
 
 /* Get next parameter */

--- a/src/irc/core/irc.h
+++ b/src/irc/core/irc.h
@@ -51,7 +51,7 @@ void irc_send_cmd_full(IRC_SERVER_REC *server, const char *cmd,
 /* Get count parameters from data */
 #include "commands.h"
 char *event_get_param(char **data);
-char *event_get_params(const char *data, int count, ...);
+void event_get_params(const char *data, int count, ...);
 
 void irc_irc_init(void);
 void irc_irc_deinit(void);

--- a/src/irc/core/lag.c
+++ b/src/irc/core/lag.c
@@ -66,11 +66,11 @@ static void lag_event_pong(IRC_SERVER_REC *server, const char *data,
 
 static void sig_unknown_command(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *cmd;
+	char *cmd;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2, NULL, &cmd);
+	event_get_params(data, 2, NULL, &cmd);
 	if (g_ascii_strcasecmp(cmd, "PING") == 0) {
 		/* some servers have disabled PING command, don't bother
 		   trying alternative methods to detect lag with these
@@ -79,7 +79,6 @@ static void sig_unknown_command(IRC_SERVER_REC *server, const char *data)
 		server->lag_sent.tv_sec = 0;
                 server->lag = 0;
 	}
-	g_free(params);
 }
 
 static int sig_check_lag(void)

--- a/src/irc/core/massjoin.c
+++ b/src/irc/core/massjoin.c
@@ -35,7 +35,7 @@ static int massjoin_max_joins;
 static void event_join(IRC_SERVER_REC *server, const char *data,
 		       const char *nick, const char *address)
 {
-	char *params, *channel, *ptr;
+	char *channel, *ptr;
 	IRC_CHANNEL_REC *chanrec;
 	NICK_REC *nickrec;
 	GSList *nicks, *tmp;
@@ -47,13 +47,12 @@ static void event_join(IRC_SERVER_REC *server, const char *data,
 		return;
 	}
 
-	params = event_get_params(data, 1, &channel);
+	event_get_params(data, 1, &channel);
 	ptr = strchr(channel, 7); /* ^G does something weird.. */
 	if (ptr != NULL) *ptr = '\0';
 
 	/* find channel */
 	chanrec = irc_channel_find(server, channel);
-	g_free(params);
 	if (chanrec == NULL) return;
 
 	/* check that the nick isn't already in nicklist. seems to happen
@@ -98,7 +97,7 @@ static void event_join(IRC_SERVER_REC *server, const char *data,
 static void event_part(IRC_SERVER_REC *server, const char *data,
 		       const char *nick, const char *addr)
 {
-	char *params, *channel, *reason;
+	char *channel, *reason;
 	IRC_CHANNEL_REC *chanrec;
 	NICK_REC *nickrec;
 
@@ -109,12 +108,11 @@ static void event_part(IRC_SERVER_REC *server, const char *data,
 		return;
 	}
 
-	params = event_get_params(data, 2, &channel, &reason);
+	event_get_params(data, 2, &channel, &reason);
 
 	/* find channel */
 	chanrec = irc_channel_find(server, channel);
 	if (chanrec == NULL) {
-		g_free(params);
 		return;
 	}
 
@@ -128,7 +126,6 @@ static void event_part(IRC_SERVER_REC *server, const char *data,
 		}
 		nicklist_remove(CHANNEL(chanrec), nickrec);
 	}
-	g_free(params);
 }
 
 static void event_quit(IRC_SERVER_REC *server, const char *data,
@@ -163,17 +160,16 @@ static void event_quit(IRC_SERVER_REC *server, const char *data,
 
 static void event_kick(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *channel, *nick, *reason;
+	char *channel, *nick, *reason;
 	IRC_CHANNEL_REC *chanrec;
 	NICK_REC *nickrec;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 3, &channel, &nick, &reason);
+	event_get_params(data, 3, &channel, &nick, &reason);
 
 	if (g_ascii_strcasecmp(nick, server->nick) == 0) {
 		/* you were kicked, no need to do anything */
-		g_free(params);
 		return;
 	}
 
@@ -190,8 +186,6 @@ static void event_kick(IRC_SERVER_REC *server, const char *data)
 		}
 		nicklist_remove(CHANNEL(chanrec), nickrec);
 	}
-
-	g_free(params);
 }
 
 static void massjoin_send_hash(gpointer key, NICK_REC *nick, GSList **list)

--- a/src/irc/core/mode-lists.c
+++ b/src/irc/core/mode-lists.c
@@ -113,18 +113,17 @@ static void channel_destroyed(IRC_CHANNEL_REC *channel)
 static void event_banlist(IRC_SERVER_REC *server, const char *data)
 {
 	IRC_CHANNEL_REC *chanrec;
-	char *params, *channel, *ban, *setby, *tims;
+	char *channel, *ban, *setby, *tims;
 	time_t tim;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 5, NULL, &channel, &ban, &setby, &tims);
+	event_get_params(data, 5, NULL, &channel, &ban, &setby, &tims);
 	chanrec = irc_channel_find(server, channel);
 	if (chanrec != NULL) {
 		tim = (time_t) atol(tims);
 		banlist_add(chanrec, ban, setby, tim);
 	}
-	g_free(params);
 }
 
 void mode_lists_init(void)

--- a/src/irc/core/modes.c
+++ b/src/irc/core/modes.c
@@ -340,7 +340,7 @@ void parse_channel_modes(IRC_CHANNEL_REC *channel, const char *setby,
 {
 	IRC_SERVER_REC *server = channel->server;
         GString *newmode;
-	char *dup, *modestr, *arg, *curmode, type, *old_key;
+	char *modestr, *arg, *curmode, type, *old_key;
 	int umode;
 
 	g_return_if_fail(IS_IRC_CHANNEL(channel));
@@ -350,7 +350,7 @@ void parse_channel_modes(IRC_CHANNEL_REC *channel, const char *setby,
 	newmode = g_string_new(channel->mode);
 	old_key = update_key ? NULL : g_strdup(channel->key);
 
-	dup = modestr = g_strdup(mode);
+	modestr = g_strdup(mode);
 	curmode = cmd_get_param(&modestr);
 	while (*curmode != '\0') {
 		if (HAS_MODE_ARG(server, type, *curmode)) {
@@ -381,7 +381,6 @@ void parse_channel_modes(IRC_CHANNEL_REC *channel, const char *setby,
 
 		curmode++;
 	}
-	g_free(dup);
 
 	if (channel->key != NULL &&
 	    strchr(channel->mode, 'k') == NULL &&
@@ -416,14 +415,14 @@ char *modes_join(IRC_SERVER_REC *server, const char *old,
 		 const char *mode, int channel)
 {
 	GString *newmode;
-	char *dup, *modestr, *curmode, type;
+	char *modestr, *curmode, type;
 
         g_return_val_if_fail(mode != NULL, NULL);
 
 	type = '+';
 	newmode = g_string_new(old);
 
-	dup = modestr = g_strdup(mode);
+	modestr = g_strdup(mode);
 	curmode = cmd_get_param(&modestr);
 	while (*curmode != '\0' && *curmode != ' ') {
 		if (*curmode == '+' || *curmode == '-') {
@@ -441,7 +440,6 @@ char *modes_join(IRC_SERVER_REC *server, const char *old,
 
 		curmode++;
 	}
-	g_free(dup);
 
 	modestr = newmode->str;
 	g_string_free(newmode, FALSE);
@@ -467,25 +465,23 @@ static void parse_user_mode(IRC_SERVER_REC *server, const char *modestr)
 
 static void event_user_mode(IRC_SERVER_REC *server, const char *data)
 {
-	char *params, *nick, *mode;
+	char *nick, *mode;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 3, NULL, &nick, &mode);
+	event_get_params(data, 3, NULL, &nick, &mode);
 	parse_user_mode(server, mode);
-
-	g_free(params);
 }
 
 static void event_mode(IRC_SERVER_REC *server, const char *data,
 		       const char *nick)
 {
 	IRC_CHANNEL_REC *chanrec;
-	char *params, *channel, *mode;
+	char *channel, *mode;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2 | PARAM_FLAG_GETREST,
+	event_get_params(data, 2 | PARAM_FLAG_GETREST,
 				  &channel, &mode);
 
 	if (!server_ischannel(SERVER(server), channel)) {
@@ -497,8 +493,6 @@ static void event_mode(IRC_SERVER_REC *server, const char *data,
 		if (chanrec != NULL)
 			parse_channel_modes(chanrec, nick, mode, TRUE);
 	}
-
-	g_free(params);
 }
 
 static void event_oper(IRC_SERVER_REC *server, const char *data)
@@ -530,11 +524,11 @@ static void event_unaway(IRC_SERVER_REC *server, const char *data)
 static void sig_req_usermode_change(IRC_SERVER_REC *server, const char *data,
 				    const char *nick, const char *addr)
 {
-	char *params, *target, *mode;
+	char *target, *mode;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2 | PARAM_FLAG_GETREST,
+	event_get_params(data, 2 | PARAM_FLAG_GETREST,
 				  &target, &mode);
 	if (!server_ischannel(SERVER(server), target)) {
                 /* we requested a user mode change, save this */
@@ -542,8 +536,6 @@ static void sig_req_usermode_change(IRC_SERVER_REC *server, const char *data,
                 g_free_not_null(server->wanted_usermode);
 		server->wanted_usermode = mode;
 	}
-
-	g_free(params);
 
 	signal_emit("event mode", 4, server, data, nick, addr);
 }
@@ -596,7 +588,7 @@ void channel_set_mode(IRC_SERVER_REC *server, const char *channel,
 {
 	IRC_CHANNEL_REC *chanrec;
 	GString *tmode, *targs;
-	char *modestr, *curmode, *orig, type, prevtype;
+	char *modestr, *curmode, type, prevtype;
 	int count;
 
 	g_return_if_fail(IS_IRC_SERVER(server));
@@ -610,7 +602,7 @@ void channel_set_mode(IRC_SERVER_REC *server, const char *channel,
 	if (chanrec != NULL)
 		channel = chanrec->name;
 
-	orig = modestr = g_strdup(mode);
+	modestr = g_strdup(mode);
 
         type = '+'; prevtype = '\0';
 	curmode = cmd_get_param(&modestr);
@@ -670,7 +662,6 @@ void channel_set_mode(IRC_SERVER_REC *server, const char *channel,
 
 	g_string_free(tmode, TRUE);
 	g_string_free(targs, TRUE);
-	g_free(orig);
 }
 
 static int get_wildcard_nicks(GString *output, const char *mask,

--- a/src/irc/core/netsplit.c
+++ b/src/irc/core/netsplit.c
@@ -359,9 +359,9 @@ static void event_quit(IRC_SERVER_REC *server, const char *data,
 static void event_nick(IRC_SERVER_REC *server, const char *data)
 {
 	NETSPLIT_REC *rec;
-	char *params, *nick;
+	char *nick;
 
-	params = event_get_params(data, 1, &nick);
+	event_get_params(data, 1, &nick);
 
 	/* remove nick from split list when somebody changed
 	   nick to this one during split */
@@ -370,8 +370,6 @@ static void event_nick(IRC_SERVER_REC *server, const char *data)
 	        g_hash_table_remove(server->splits, rec->nick);
 		netsplit_destroy(server, rec);
 	}
-
-        g_free(params);
 }
 
 static void sig_disconnected(IRC_SERVER_REC *server)

--- a/src/irc/dcc/dcc-chat.c
+++ b/src/irc/dcc/dcc-chat.c
@@ -771,16 +771,15 @@ static void event_nick(IRC_SERVER_REC *server, const char *data,
 {
         QUERY_REC *query;
         CHAT_DCC_REC *dcc;
-	char *params, *nick, *tag;
+	char *nick, *tag;
 
 	g_return_if_fail(data != NULL);
 	g_return_if_fail(orignick != NULL);
 
-	params = event_get_params(data, 1, &nick);
+	event_get_params(data, 1, &nick);
 	if (g_ascii_strcasecmp(nick, orignick) == 0) {
 		/* shouldn't happen, but just to be sure irssi doesn't
 		   get into infinite loop */
-                g_free(params);
 		return;
 	}
 
@@ -803,8 +802,6 @@ static void event_nick(IRC_SERVER_REC *server, const char *data,
                         g_free(tag);
 		}
 	}
-
-	g_free(params);
 }
 
 void dcc_chat_init(void)

--- a/src/irc/dcc/dcc.c
+++ b/src/irc/dcc/dcc.c
@@ -466,12 +466,12 @@ static int dcc_timeout_func(void)
 
 static void event_no_such_nick(IRC_SERVER_REC *server, char *data)
 {
-	char *params, *nick;
+	char *nick;
 	GSList *tmp, *next;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 2, NULL, &nick);
+	event_get_params(data, 2, NULL, &nick);
 
 	/* check if we've send any dcc requests to this nick.. */
 	for (tmp = dcc_conns; tmp != NULL; tmp = next) {
@@ -482,8 +482,6 @@ static void event_no_such_nick(IRC_SERVER_REC *server, char *data)
 		    dcc->nick != NULL && g_ascii_strcasecmp(dcc->nick, nick) == 0)
 			dcc_close(dcc);
 	}
-
-	g_free(params);
 }
 
 /* SYNTAX: DCC CLOSE <type> <nick> [<file>] */

--- a/src/irc/flood/flood.c
+++ b/src/irc/flood/flood.c
@@ -239,7 +239,7 @@ static void flood_newmsg(IRC_SERVER_REC *server, int level, const char *nick,
 static void flood_privmsg(IRC_SERVER_REC *server, const char *data,
 			  const char *nick, const char *addr)
 {
-	char *params, *target, *text;
+	char *target, *text;
 	int level;
 
 	g_return_if_fail(data != NULL);
@@ -248,19 +248,17 @@ static void flood_privmsg(IRC_SERVER_REC *server, const char *data,
 	if (addr == NULL || g_ascii_strcasecmp(nick, server->nick) == 0)
 		return;
 
-	params = event_get_params(data, 2, &target, &text);
+	event_get_params(data, 2, &target, &text);
 
 	level = server_ischannel(SERVER(server), target) ? MSGLEVEL_PUBLIC : MSGLEVEL_MSGS;
 	if (addr != NULL && !ignore_check(SERVER(server), nick, addr, target, text, level))
 		flood_newmsg(server, level, nick, addr, target);
-
-	g_free(params);
 }
 
 static void flood_notice(IRC_SERVER_REC *server, const char *data,
 			 const char *nick, const char *addr)
 {
-	char *params, *target, *text;
+	char *target, *text;
 
 	g_return_if_fail(data != NULL);
 	g_return_if_fail(server != NULL);
@@ -268,11 +266,9 @@ static void flood_notice(IRC_SERVER_REC *server, const char *data,
 	if (addr == NULL || g_ascii_strcasecmp(nick, server->nick) == 0)
 		return;
 
-	params = event_get_params(data, 2, &target, &text);
+	event_get_params(data, 2, &target, &text);
 	if (!ignore_check(SERVER(server), nick, addr, target, text, MSGLEVEL_NOTICES))
 		flood_newmsg(server, MSGLEVEL_NOTICES, nick, addr, target);
-
-	g_free(params);
 }
 
 static void flood_ctcp(IRC_SERVER_REC *server, const char *data,

--- a/src/irc/notifylist/notify-ison.c
+++ b/src/irc/notifylist/notify-ison.c
@@ -285,19 +285,17 @@ static void ison_check_parts(IRC_SERVER_REC *server)
 static void event_ison(IRC_SERVER_REC *server, const char *data)
 {
 	MODULE_SERVER_REC *mserver;
-	char *params, *online;
+	char *online;
 
 	g_return_if_fail(data != NULL);
 	g_return_if_fail(server != NULL);
 
-	params = event_get_params(data, 2, NULL, &online);
+	event_get_params(data, 2, NULL, &online);
 
 	mserver = MODULE_DATA(server);
 	ison_save_users(mserver, online);
 
 	if (--mserver->ison_count > 0) {
-		/* wait for the rest of the /ISON replies */
-		g_free(params);
                 return;
 	}
 
@@ -308,8 +306,6 @@ static void event_ison(IRC_SERVER_REC *server, const char *data)
 	g_slist_foreach(mserver->ison_tempusers, (GFunc) g_free, NULL);
 	g_slist_free(mserver->ison_tempusers);
 	mserver->ison_tempusers = NULL;
-
-	g_free(params);
 }
 
 static void read_settings(void)

--- a/src/irc/notifylist/notify-whois.c
+++ b/src/irc/notifylist/notify-whois.c
@@ -32,19 +32,18 @@ static char *last_notify_nick;
 
 static void event_whois(IRC_SERVER_REC *server, const char *data)
 {
-        char *params, *nick, *user, *host, *realname;
+        char *nick, *user, *host, *realname;
 	NOTIFY_NICK_REC *nickrec;
 	NOTIFYLIST_REC *notify;
 
 	g_return_if_fail(data != NULL);
 	g_return_if_fail(server != NULL);
 
-	params = event_get_params(data, 6, NULL, &nick, &user, &host, NULL, &realname);
+	event_get_params(data, 6, NULL, &nick, &user, &host, NULL, &realname);
 
 	notify = notifylist_find(nick, server->connrec->chatnet);
 	if (notify != NULL && !mask_match(SERVER(server), notify->mask, nick, user, host)) {
 		/* user or host didn't match */
-		g_free(params);
 		return;
 	}
 
@@ -64,25 +63,22 @@ static void event_whois(IRC_SERVER_REC *server, const char *data)
 		nickrec->away = FALSE;
 		nickrec->host_ok = TRUE;
 	}
-	g_free(params);
 }
 
 static void event_whois_away(IRC_SERVER_REC *server, const char *data)
 {
 	NOTIFY_NICK_REC *nickrec;
-	char *params, *nick, *awaymsg;
+	char *nick, *awaymsg;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 3, NULL, &nick, &awaymsg);
+	event_get_params(data, 3, NULL, &nick, &awaymsg);
 
 	nickrec = notify_nick_find(server, nick);
 	if (nickrec != NULL) {
 		nickrec->awaymsg = g_strdup(awaymsg);
                 nickrec->away = TRUE;
 	}
-
-	g_free(params);
 }
 
 /* All WHOIS replies got, now announce all the changes at once. */


### PR DESCRIPTION
Hi. I could be missing something here, but I saw a bunch of variables in the code that were allocated seemingly for no reason, with a pattern similar to the following:

```C
char *foo, *bar, ...

foo = bar = g_strdup ....

/* ignore foo */

g_free(foo);
```

I removed all the instances of this that I could find, as it seemed pointless to allocate this memory and then do nothing with it.

In order to allow me to make this change in more places, I changed the event parameter decoder, ```event_get_params```,  to return void, instead of a ```char*```, as every path except one that called that function was unconditionally freeing the pointer it received without examining its value, and the only one that did check the value just compared it to NULL, which was easy to fix.

I ran the client for a bit with my changes and it didn't crash, but didn't go to any great length to ensure that my changes didn't have any unwanted side effects; I couldn't find any test cases, nor any documentation on automated testing.

Let me know if this change is a :lemon:, or how to test it better.

Thanks,
--max