### PR TITLE
Network and IPv{4,6} related changes

### DIFF
--- a/docs/help/in/toggle.in
+++ b/docs/help/in/toggle.in
@@ -15,7 +15,7 @@
 
 %9Examples:%9
 
-    /TOGGLE resolve_prefer_ipv6
+    /TOGGLE resolve_reverse_lookup
     /TOGGLE channels_rejoin_unavailable ON
 
 %9See also:%9 SET

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -429,9 +429,6 @@
 	After connected to server, Irssi can automatically change your user
 	mode. You can set it with /SET usermode <mode>, default is +i.
 
-	/SET resolve_prefer_ipv6 - If ON, prefer IPv6 for hosts that
-	     have both v4 and v6 addresses.
-
  5.5 Automatic reconnecting
 
 	If you get disconnected from server, Irssi will try to reconnect

--- a/src/core/chat-commands.c
+++ b/src/core/chat-commands.c
@@ -128,10 +128,10 @@ static SERVER_CONNECT_REC *get_server_connect(const char *data, int *plus_addr,
 
         host = g_hash_table_lookup(optlist, "host");
 	if (host != NULL && *host != '\0') {
-		IPADDR ip4, ip6;
+		IPADDR ip;
 
-		if (net_gethostbyname(host, &ip4, &ip6) == 0)
-                        server_connect_own_ip_save(conn, &ip4, &ip6);
+		if (net_gethostbyname(host, &ip) == 0)
+                        server_connect_own_ip_save(conn, &ip);
 	}
 
 	cmd_params_free(free_arg);

--- a/src/core/chatnet-rec.h
+++ b/src/core/chatnet-rec.h
@@ -9,4 +9,4 @@ char *realname;
 
 char *own_host; /* address to use when connecting this server */
 char *autosendcmd; /* command to send after connecting to this ircnet */
-IPADDR *own_ip4, *own_ip6; /* resolved own_address if not NULL */
+IPADDR *own_ip; /* resolved own_address if not NULL */

--- a/src/core/net-nonblock.h
+++ b/src/core/net-nonblock.h
@@ -4,12 +4,12 @@
 #include "network.h"
 
 typedef struct {
-	IPADDR ip4, ip6; /* resolved ip addresses */
+	IPADDR ip; /* resolved ip address */
 	int error; /* error, 0 = no error, -1 = error: */
 	int errlen; /* error text length */
 	char *errorstr; /* error string - dynamically allocated, you'll
 	                   need to free() it yourself unless it's NULL */
-	char *host4, *host6; /* dito */
+	char *host; /* dito */
 } RESOLVED_IP_REC;
 
 typedef struct {

--- a/src/core/network.c
+++ b/src/core/network.c
@@ -137,35 +137,14 @@ static int sin_get_port(union sockaddr_union *so)
 /* Connect to socket */
 GIOChannel *net_connect(const char *addr, int port, IPADDR *my_ip)
 {
-	IPADDR ip4, ip6, *ip;
+	IPADDR ip;
 
 	g_return_val_if_fail(addr != NULL, NULL);
 
-	if (net_gethostbyname(addr, &ip4, &ip6) == -1)
+	if (net_gethostbyname(addr, &ip) == -1)
 		return NULL;
 
-	if (my_ip == NULL) {
-                /* prefer IPv4 addresses */
-		ip = ip4.family != 0 ? &ip4 : &ip6;
-	} else if (IPADDR_IS_V6(my_ip)) {
-                /* my_ip is IPv6 address, use it if possible */
-		if (ip6.family != 0)
-			ip = &ip6;
-		else {
-			my_ip = NULL;
-                        ip = &ip4;
-		}
-	} else {
-                /* my_ip is IPv4 address, use it if possible */
-		if (ip4.family != 0)
-			ip = &ip4;
-		else {
-			my_ip = NULL;
-                        ip = &ip6;
-		}
-	}
-
-	return net_connect_ip(ip, port, my_ip);
+	return net_connect_ip(&ip, port, my_ip);
 }
 
 /* Connect to socket with ip address */
@@ -413,82 +392,35 @@ int net_getsockname(GIOChannel *handle, IPADDR *addr, int *port)
 /* Get IP addresses for host, both IPv4 and IPv6 if possible.
    If ip->family is 0, the address wasn't found.
    Returns 0 = ok, others = error code for net_gethosterror() */
-int net_gethostbyname(const char *addr, IPADDR *ip4, IPADDR *ip6)
+int net_gethostbyname(const char *addr, IPADDR *ip)
 {
-#ifdef HAVE_IPV6
 	union sockaddr_union *so;
-	struct addrinfo hints, *ai, *ailist;
-	int ret, count_v4, count_v6, use_v4, use_v6;
-#else
-	struct hostent *hp;
-	int count;
-#endif
+	struct addrinfo hints, *ailist;
+	int ret;
 
 	g_return_val_if_fail(addr != NULL, -1);
 
-	memset(ip4, 0, sizeof(IPADDR));
-	memset(ip6, 0, sizeof(IPADDR));
+	memset(ip, 0, sizeof(IPADDR));
 
-#ifdef HAVE_IPV6
 	memset(&hints, 0, sizeof(struct addrinfo));
 	hints.ai_socktype = SOCK_STREAM;
+#ifdef HAVE_IPV6
+	hints.ai_family = AF_UNSPEC;
+#else
+	hints.ai_family = AF_INET;
+#endif
+	hints.ai_flags = (AI_V4MAPPED | AI_ADDRCONFIG);
 
 	/* save error to host_error for later use */
 	ret = getaddrinfo(addr, NULL, &hints, &ailist);
 	if (ret != 0)
 		return ret;
 
-	/* count IPs */
-        count_v4 = count_v6 = 0;
-	for (ai = ailist; ai != NULL; ai = ai->ai_next) {
-		if (ai->ai_family == AF_INET)
-			count_v4++;
-		else if (ai->ai_family == AF_INET6)
-			count_v6++;
-	}
-
-	if (count_v4 == 0 && count_v6 == 0)
-		return HOST_NOT_FOUND; /* shouldn't happen? */
-
-	/* if there are multiple addresses, return random one */
-	use_v4 = count_v4 <= 1 ? 0 : rand() % count_v4;
-	use_v6 = count_v6 <= 1 ? 0 : rand() % count_v6;
-
-	count_v4 = count_v6 = 0;
-	for (ai = ailist; ai != NULL; ai = ai->ai_next) {
-		so = (union sockaddr_union *) ai->ai_addr;
-
-		if (ai->ai_family == AF_INET) {
-			if (use_v4 == count_v4)
-				sin_get_ip(so, ip4);
-                        count_v4++;
-		} else if (ai->ai_family == AF_INET6) {
-			if (use_v6 == count_v6)
-				sin_get_ip(so, ip6);
-			count_v6++;
-		}
-	}
+	so = (const union sockaddr_union *)ailist->ai_addr;
+	sin_get_ip(so, ip);
 	freeaddrinfo(ailist);
-	return 0;
-#else
-	hp = gethostbyname(addr);
-	if (hp == NULL)
-		return h_errno;
-
-	/* count IPs */
-	count = 0;
-	while (hp->h_addr_list[count] != NULL)
-		count++;
-
-	if (count == 0)
-		return HOST_NOT_FOUND; /* shouldn't happen? */
-
-	/* if there are multiple addresses, return random one */
-	ip4->family = AF_INET;
-	memcpy(&ip4->ip, hp->h_addr_list[rand() % count], 4);
 
 	return 0;
-#endif
 }
 
 /* Get name for host, *name should be g_free()'d unless it's NULL.

--- a/src/core/network.h
+++ b/src/core/network.h
@@ -71,7 +71,7 @@ int net_transmit(GIOChannel *handle, const char *data, int len);
 /* Get IP addresses for host, both IPv4 and IPv6 if possible.
    If ip->family is 0, the address wasn't found.
    Returns 0 = ok, others = error code for net_gethosterror() */
-int net_gethostbyname(const char *addr, IPADDR *ip4, IPADDR *ip6);
+int net_gethostbyname(const char *addr, IPADDR *ip);
 /* Get name for host, *name should be g_free()'d unless it's NULL.
    Return values are the same as with net_gethostbyname() */
 int net_gethostbyaddr(IPADDR *ip, char **name);

--- a/src/core/server-connect-rec.h
+++ b/src/core/server-connect-rec.h
@@ -16,7 +16,7 @@ char *address;
 int port;
 char *chatnet;
 
-IPADDR *own_ip4, *own_ip6;
+IPADDR *own_ip;
 
 char *password;
 char *nick;

--- a/src/core/server-setup-rec.h
+++ b/src/core/server-setup-rec.h
@@ -19,7 +19,7 @@ char *ssl_capath;
 char *ssl_ciphers;
 
 char *own_host; /* address to use when connecting this server */
-IPADDR *own_ip4, *own_ip6; /* resolved own_address if not NULL */
+IPADDR *own_ip; /* resolved own_address if not NULL */
 
 time_t last_connect; /* to avoid reconnecting too fast.. */
 

--- a/src/core/servers-reconnect.c
+++ b/src/core/servers-reconnect.c
@@ -177,13 +177,9 @@ server_connect_copy_skeleton(SERVER_CONNECT_REC *src, int connect_info)
 	dest->username = g_strdup(src->username);
 	dest->realname = g_strdup(src->realname);
 
-	if (src->own_ip4 != NULL) {
-		dest->own_ip4 = g_new(IPADDR, 1);
-		memcpy(dest->own_ip4, src->own_ip4, sizeof(IPADDR));
-	}
-	if (src->own_ip6 != NULL) {
-		dest->own_ip6 = g_new(IPADDR, 1);
-		memcpy(dest->own_ip6, src->own_ip6, sizeof(IPADDR));
+	if (src->own_ip != NULL) {
+		dest->own_ip = g_new(IPADDR, 1);
+		memcpy(dest->own_ip, src->own_ip, sizeof(IPADDR));
 	}
 
 	dest->channels = g_strdup(src->channels);

--- a/src/core/servers-setup.h
+++ b/src/core/servers-setup.h
@@ -16,7 +16,7 @@ struct _SERVER_SETUP_REC {
 
 extern GSList *setupservers;
 
-extern IPADDR *source_host_ip4, *source_host_ip6; /* Resolved address */
+extern IPADDR source_host_ip; /* Resolved address */
 extern int source_host_ok; /* Use source_host_ip .. */
 
 /* Fill reconnection specific information to connection

--- a/src/core/servers.c
+++ b/src/core/servers.c
@@ -710,7 +710,6 @@ static void sig_chat_protocol_deinit(CHAT_PROTOCOL_REC *proto)
 
 void servers_init(void)
 {
-	settings_add_bool("server", "resolve_prefer_ipv6", FALSE);
 	settings_add_bool("server", "resolve_reverse_lookup", FALSE);
 	lookup_servers = servers = NULL;
 

--- a/src/core/servers.h
+++ b/src/core/servers.h
@@ -67,8 +67,7 @@ void server_connect_failed(SERVER_REC *server, const char *msg);
 void server_change_nick(SERVER_REC *server, const char *nick);
 
 /* Update own IPv4 and IPv6 records */
-void server_connect_own_ip_save(SERVER_CONNECT_REC *conn,
-				IPADDR *ip4, IPADDR *ip6);
+void server_connect_own_ip_save(SERVER_CONNECT_REC *conn, IPADDR *ip);
 
 /* `optlist' should contain only one unknown key - the server tag.
    returns NULL if there was unknown -option */

--- a/src/fe-common/core/fe-server.c
+++ b/src/fe-common/core/fe-server.c
@@ -138,7 +138,7 @@ static void cmd_server_add(const char *data)
 		if (*password != '\0') g_free_and_null(rec->password);
 		if (g_hash_table_lookup(optlist, "host")) {
 			g_free_and_null(rec->own_host);
-			rec->own_ip4 = rec->own_ip6 = NULL;
+			rec->own_ip = NULL;
 		}
 	}
 
@@ -193,7 +193,7 @@ static void cmd_server_add(const char *data)
 	value = g_hash_table_lookup(optlist, "host");
 	if (value != NULL && *value != '\0') {
 		rec->own_host = g_strdup(value);
-		rec->own_ip4 = rec->own_ip6 = NULL;
+		rec->own_ip = NULL;
 	}
 
 	signal_emit("server add fill", 2, rec, optlist);

--- a/src/fe-common/irc/fe-ircnet.c
+++ b/src/fe-common/irc/fe-ircnet.c
@@ -108,7 +108,7 @@ static void cmd_network_add(const char *data)
 		if (g_hash_table_lookup(optlist, "realname")) g_free_and_null(rec->realname);
 		if (g_hash_table_lookup(optlist, "host")) {
 			g_free_and_null(rec->own_host);
-                        rec->own_ip4 = rec->own_ip6 = NULL;
+                        rec->own_ip = NULL;
 		}
 		if (g_hash_table_lookup(optlist, "usermode")) g_free_and_null(rec->usermode);
 		if (g_hash_table_lookup(optlist, "autosendcmd")) g_free_and_null(rec->autosendcmd);
@@ -140,7 +140,7 @@ static void cmd_network_add(const char *data)
 	value = g_hash_table_lookup(optlist, "host");
 	if (value != NULL && *value != '\0') {
 		rec->own_host = g_strdup(value);
-		rec->own_ip4 = rec->own_ip6 = NULL;
+		rec->own_ip = NULL;
 	}
 
 	value = g_hash_table_lookup(optlist, "usermode");

--- a/src/irc/dcc/dcc.c
+++ b/src/irc/dcc/dcc.c
@@ -264,12 +264,12 @@ GIOChannel *dcc_connect_ip(IPADDR *ip, int port)
 	}
 
 	if (own_ip == NULL)
-		own_ip = IPADDR_IS_V6(ip) ? source_host_ip6 : source_host_ip4;
+		own_ip = &source_host_ip;
 
 	handle = net_connect_ip(ip, port, own_ip);
 	if (handle == NULL && errno == EADDRNOTAVAIL && own_ip != NULL) {
 		/* dcc_own_ip is external address */
-		own_ip = IPADDR_IS_V6(ip) ? source_host_ip6 : source_host_ip4;
+		own_ip = &source_host_ip;
 		handle = net_connect_ip(ip, port, own_ip);
 	}
 	return handle;

--- a/src/irc/proxy/listen.c
+++ b/src/irc/proxy/listen.c
@@ -585,7 +585,7 @@ static LISTEN_REC *find_listen(const char *ircnet, int port)
 static void add_listen(const char *ircnet, int port)
 {
 	LISTEN_REC *rec;
-	IPADDR ip4, ip6, *my_ip;
+	IPADDR ip, *my_ip;
 
 	if (port <= 0 || *ircnet == '\0')
 		return;
@@ -593,16 +593,13 @@ static void add_listen(const char *ircnet, int port)
 	/* bind to specific host/ip? */
 	my_ip = NULL;
 	if (*settings_get_str("irssiproxy_bind") != '\0') {
-		if (net_gethostbyname(settings_get_str("irssiproxy_bind"),
-				      &ip4, &ip6) != 0) {
+		if (net_gethostbyname(settings_get_str("irssiproxy_bind"), &ip) != 0) {
 			printtext(NULL, NULL, MSGLEVEL_CLIENTERROR,
 				  "Proxy: can not resolve '%s' - aborting",
 				  settings_get_str("irssiproxy_bind"));
 			return;
 		}
-
-		my_ip = ip6.family == 0 ? &ip4 : ip4.family == 0 ||
-			settings_get_bool("resolve_prefer_ipv6") ? &ip6 : &ip4;
+		my_ip = &ip;
 	}
 
 	rec = g_new0(LISTEN_REC, 1);


### PR DESCRIPTION
First take at fixing #190.
WORKSFORME on IPv4 networks, with and without `resolve_reverse_lookup`.