### PR TITLE
Fix FS#905, mangled text when pasted line length exceeds 400

### DIFF
--- a/src/fe-text/gui-readline.c
+++ b/src/fe-text/gui-readline.c
@@ -237,7 +237,7 @@ static void paste_buffer_join_lines(GArray *buf)
 			last_lf = FALSE;
 			if (++line_len >= 400 && last_lf_pos != NULL) {
 				memmove(last_lf_pos+1, last_lf_pos,
-					dest - last_lf_pos);
+					(dest - last_lf_pos) * sizeof(unichar));
 				*last_lf_pos = '\n'; last_lf_pos = NULL;
 				line_len = 0;
 				dest++;


### PR DESCRIPTION
http://bugs.irssi.org/index.php?do=details&task_id=905

Not using the patch from that ticket, the issue turned out to be that
(dest - last_lf_pos) returned number of unichr, not bytes, so that's 4
times less than what the size parameter of memmove() should be.

-----

Cherry picked from #277, that one needs rebasing so that the commit doesn't appear twice in the history.