### PR TITLE
wip/config include

### DIFF
--- a/src/lib-config/get.c
+++ b/src/lib-config/get.c
@@ -33,6 +33,14 @@ CONFIG_NODE *config_node_find(CONFIG_NODE *parent, const char *key)
 
 		if (node->key != NULL && g_ascii_strcasecmp(node->key, key) == 0)
 			return node;
+
+		/* the primary children of an include node should also be searched */
+		if (node->type == NODE_TYPE_INCLUDE) {
+			CONFIG_INCLUDE *inc = node->value;
+			node = config_node_find(inc->rec->mainnode, key);
+			if (node)
+				return node;
+		}
 	}
 
 	return NULL;

--- a/src/lib-config/get.c
+++ b/src/lib-config/get.c
@@ -20,15 +20,15 @@
 
 #include "module.h"
 
-CONFIG_NODE *config_node_find(CONFIG_NODE *node, const char *key)
+CONFIG_NODE *config_node_find(CONFIG_NODE *parent, const char *key)
 {
 	GSList *tmp;
 
-	g_return_val_if_fail(node != NULL, NULL);
+	g_return_val_if_fail(parent != NULL, NULL);
 	g_return_val_if_fail(key != NULL, NULL);
-	g_return_val_if_fail(is_node_list(node), NULL);
+	g_return_val_if_fail(is_node_list(parent), NULL);
 
-	for (tmp = node->value; tmp != NULL; tmp = tmp->next) {
+	for (tmp = parent->value; tmp != NULL; tmp = tmp->next) {
 		CONFIG_NODE *node = tmp->data;
 
 		if (node->key != NULL && g_ascii_strcasecmp(node->key, key) == 0)

--- a/src/lib-config/iconfig.h
+++ b/src/lib-config/iconfig.h
@@ -113,7 +113,7 @@ int config_set_bool(CONFIG_REC *rec, const char *section, const char *key, int v
 
 /* Handling the configuration directly with nodes -
    useful when you need to read all values in a block/list. */
-CONFIG_NODE *config_node_find(CONFIG_NODE *node, const char *key);
+CONFIG_NODE *config_node_find(CONFIG_NODE *parent, const char *key);
 /* Find the section from node - if not found create it unless new_type is -1.
    You can also specify in new_type if it's NODE_TYPE_LIST or NODE_TYPE_BLOCK */
 CONFIG_NODE *config_node_section(CONFIG_REC *rec, CONFIG_NODE *parent, const char *key, int new_type);

--- a/src/lib-config/module.h
+++ b/src/lib-config/module.h
@@ -2,5 +2,5 @@
 #include "iconfig.h"
 
 /* private */
-int config_error(CONFIG_REC *rec, const char *msg);
+int config_error(CONFIG_REC *rec, const char *msg, ...);
 

--- a/src/lib-config/write.c
+++ b/src/lib-config/write.c
@@ -149,6 +149,18 @@ static int config_write_node(CONFIG_REC *rec, CONFIG_NODE *node, int line_feeds)
 		if (config_write_word(rec, node->value, TRUE) == -1)
 			return -1;
 		break;
+	case NODE_TYPE_INCLUDE: {
+		CONFIG_INCLUDE *inc = node->value;
+		if (config_write_str(rec, "include ") == -1)
+			return -1;
+
+		if (config_write_word(rec, inc->original_path, TRUE) == -1)
+			return -1;
+
+		config_write(inc->rec, NULL, -1);
+
+		break;
+	}
 	case NODE_TYPE_BLOCK:
 		/* key = { */
 		if (node->key != NULL) {
@@ -217,6 +229,11 @@ static int config_node_get_length(CONFIG_REC *rec, CONFIG_NODE *node)
 		/* "value, " */
 		len = 2 + strlen(node->value);
 		break;
+	case NODE_TYPE_INCLUDE: {
+		CONFIG_INCLUDE *inc = node->value;
+		len = strlen("include \"\"") + strlen(inc->rec->fname);
+		break;
+	}
 	case NODE_TYPE_BLOCK:
 	case NODE_TYPE_LIST:
 		/* "{ list }; " */


### PR DESCRIPTION
This is still a work in progress but would like some feed back and maybe some insight in to possible edge cases. It provides a way to include config files within config files, the main motivation was to be able to put the config in source control without exposing passwords.

I'm not entirely happy with how I've prevented circular includes, but it works - I keep a hash (acting as a set) of include names in the root CONFIG_REC and look up whether it's already been included. I'll think about this tomorrow.

I don't prevent two idential files with different paths from being included as there's no good portable way to do it and it doesn't provide much benefit, each file will only be included once anyway. GLib provides g_file_equal but it doesn't handle symbolic links.

Known issue - with the following set up the b alias isn't added, but the freenode server is.

config:
        include "aliases.config";
        include "servers.config";
        ...
 
aliases.config:
        aliases = {
                a = "abc;
                include "more_aliases.config";
        };
 
more_aliases.config:
        b = "def";
 
servers.config:
        servers = ( { include "server.freenode.config"; } );
 
server.freenode.config:
        address = "holmes.freenode.net";
        ...