### PR TITLE
Fix #291, "/msg +#channel incorrectly shows up as Nick:@#channel"

### DIFF
--- a/src/fe-common/irc/fe-events.c
+++ b/src/fe-common/irc/fe-events.c
@@ -56,11 +56,13 @@ static void event_privmsg(IRC_SERVER_REC *server, const char *data,
 
 	if (fe_channel_is_opchannel(server, target)) {
 		/* Hybrid 6 feature, send msg to all ops in channel */
-		target = (char *)fe_channel_skip_prefix(server, target);
-		recoded = recode_in(SERVER(server), msg, target);
+		const char *cleantarget = fe_channel_skip_prefix(server, target);
+		recoded = recode_in(SERVER(server), msg, cleantarget);
+
+		/* pass the original target to the signal, with the @+ here
+		 * the other one is only needed for recode_in*/
 		signal_emit("message irc op_public", 5,
-			    server, recoded, nick, addr,
-			    get_visible_target(server, target));
+			    server, recoded, nick, addr, target);
 	} else {
 		recoded = recode_in(SERVER(server), msg, server_ischannel(SERVER(server), target) ? target : nick);
 		signal_emit(server_ischannel(SERVER(server), target) ?

--- a/src/fe-common/irc/fe-irc-channels.c
+++ b/src/fe-common/irc/fe-irc-channels.c
@@ -56,7 +56,7 @@ const char *fe_channel_skip_prefix(IRC_SERVER_REC *server, const char *target)
 
 	/* Exit early if target doesn't name a channel */
 	if (server_ischannel(SERVER(server), target) == FALSE)
-		return FALSE;
+		return target;
 
 	statusmsg = g_hash_table_lookup(server->isupport, "statusmsg");
 


### PR DESCRIPTION
Just passing the full target to the "message irc op_public" signal
handler and letting it do the cleanup.

The fe_channel_skip_prefix() call in event_privmsg() is kept because
recode_in() needs a real channel name, but

There was similar code in sig_message_own_wall(), but that one is
correct - the /wall command always sends NOTICE @#chan, so I added a
comment down there to make it clear.

------

Also including another commit, the fe_channel_skip_prefix return value fix, not 100% relevant but let's sneak that in because it was mentioned in #291 too