### PR TITLE
Add new setting to modify behaviour of hilight_nick_matches to match anywhere in message

### DIFF
--- a/src/core/nicklist.c
+++ b/src/core/nicklist.c
@@ -577,7 +577,12 @@ int nick_match_msg_everywhere(CHANNEL_REC *channel, const char *msg, const char 
 	g_return_val_if_fail(nick != NULL, FALSE);
 	g_return_val_if_fail(msg != NULL, FALSE);
 
-	return stristr_full(msg, nick);
+	char *ret = stristr_full(msg, nick);
+
+	if (ret != NULL)
+		return TRUE;
+
+	return FALSE;
 }
 
 void nicklist_init(void)

--- a/src/core/nicklist.c
+++ b/src/core/nicklist.c
@@ -21,6 +21,7 @@
 #include "module.h"
 #include "signals.h"
 #include "misc.h"
+#include "settings.h"
 
 #include "servers.h"
 #include "channels.h"
@@ -569,6 +570,14 @@ int nick_match_msg(CHANNEL_REC *channel, const char *msg, const char *nick)
 	} else {
 		return TRUE;
 	}
+}
+
+int nick_match_msg_everywhere(CHANNEL_REC *channel, const char *msg, const char *nick)
+{
+	g_return_val_if_fail(nick != NULL, FALSE);
+	g_return_val_if_fail(msg != NULL, FALSE);
+
+	return stristr_full(msg, nick);
 }
 
 void nicklist_init(void)

--- a/src/core/nicklist.c
+++ b/src/core/nicklist.c
@@ -21,7 +21,6 @@
 #include "module.h"
 #include "signals.h"
 #include "misc.h"
-#include "settings.h"
 
 #include "servers.h"
 #include "channels.h"
@@ -577,12 +576,7 @@ int nick_match_msg_everywhere(CHANNEL_REC *channel, const char *msg, const char 
 	g_return_val_if_fail(nick != NULL, FALSE);
 	g_return_val_if_fail(msg != NULL, FALSE);
 
-	char *ret = stristr_full(msg, nick);
-
-	if (ret != NULL)
-		return TRUE;
-
-	return FALSE;
+	return stristr_full(msg, nick) != NULL;
 }
 
 void nicklist_init(void)

--- a/src/core/nicklist.h
+++ b/src/core/nicklist.h
@@ -55,6 +55,7 @@ int nicklist_compare(NICK_REC *p1, NICK_REC *p2, const char *nick_prefix);
 
 /* Check is `msg' is meant for `nick'. */
 int nick_match_msg(CHANNEL_REC *channel, const char *msg, const char *nick);
+int nick_match_msg_everywhere(CHANNEL_REC *channel, const char *msg, const char *nick);
 
 void nicklist_init(void);
 void nicklist_deinit(void);

--- a/src/fe-common/core/fe-messages.c
+++ b/src/fe-common/core/fe-messages.c
@@ -183,7 +183,9 @@ static void sig_message_public(SERVER_REC *server, const char *msg,
                 nickrec = nicklist_find(chanrec, nick);
 
 	for_me = !settings_get_bool("hilight_nick_matches") ? FALSE :
-		nick_match_msg(chanrec, msg, server->nick);
+		!settings_get_bool("hilight_nick_matches_everywhere") ?
+		nick_match_msg(chanrec, msg, server->nick) :
+		nick_match_msg_everywhere(chanrec, msg, server->nick);
 	hilight = for_me ? NULL :
 		hilight_match_nick(server, target, nick, address, MSGLEVEL_PUBLIC, msg);
 	color = (hilight == NULL) ? NULL : hilight_get_color(hilight);
@@ -694,6 +696,7 @@ void fe_messages_init(void)
 				      (GCompareFunc) g_direct_equal);
 
 	settings_add_bool("lookandfeel", "hilight_nick_matches", TRUE);
+	settings_add_bool("lookandfeel", "hilight_nick_matches_everywhere", FALSE);
 	settings_add_bool("lookandfeel", "emphasis", TRUE);
 	settings_add_bool("lookandfeel", "emphasis_replace", FALSE);
 	settings_add_bool("lookandfeel", "emphasis_multiword", FALSE);


### PR DESCRIPTION
Fix indentation

Remove unused variables that crept into the nick_match_msg_everywhere function