### PR TITLE
Add multi-prefix to list of capabilities to request

### DIFF
--- a/src/irc/core/irc-servers.c
+++ b/src/irc/core/irc-servers.c
@@ -228,6 +228,8 @@ static void server_init(IRC_SERVER_REC *server)
 	if (conn->sasl_mechanism != SASL_MECHANISM_NONE)
 		cap_toggle(server, "sasl", TRUE);
 
+	cap_toggle(server, "multi-prefix", TRUE);
+
 	irc_send_cmd_now(server, "CAP LS");
 
 	if (conn->password != NULL && *conn->password != '\0') {


### PR DESCRIPTION
Turns out event_names_list() in irc-nicklist.c already handles this.

event_who() just ignores it, which is probably a good idea since some of
the irc servers I tested this with have a bug that results in sending
multiple prefixes in the NAMES reply but not in the WHO one (they were
forks of ircd-hybrid before 7.3.0)

And NAMES always happens, anyway. WHO is omitted sometimes for huge
channels.

--------------------

Absurdly easy commit, the hardest part was digging in the svn history of ircd-hybrid to figure out if they ever fixed it. Which isn't really a part of making this commit. Thanks nei for pointing out that it might already be implemented.