### PR TITLE
Drop centos 5 support, bump glib requirement to 2.16

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -261,7 +261,7 @@ for try in 1 2; do
     echo "*** trying without -lgmodule"
     glib_modules=
   fi
-  AM_PATH_GLIB_2_0(2.6.0,,, $glib_modules)
+  AM_PATH_GLIB_2_0(2.16.0,,, $glib_modules)
   if test "$GLIB_LIBS"; then
     if test $glib_modules = gmodule; then
       AC_DEFINE(HAVE_GMODULE)

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -1,5 +1,3 @@
-docdir = $(datadir)/doc/irssi
-
 man_MANS = \
 	irssi.1
 

--- a/src/common.h
+++ b/src/common.h
@@ -43,19 +43,6 @@
 #  include <gmodule.h>
 #endif
 
-#if !GLIB_CHECK_VERSION(2,10,0)
-#define g_slice_alloc(size)      g_malloc(size)
-#define g_slice_alloc0(size)     g_malloc0(size)
-#define g_slice_free1(size, mem) g_free(mem)
-#define g_slice_new(type)        g_new(type, 1)
-#define g_slice_new0(type)       g_new0(type, 1)
-#define g_slice_free(type, mem)  g_free(mem)
-#endif
-
-#if !GLIB_CHECK_VERSION(2,16,0)
-#define g_strcmp0(a, b) (!a ? -(a != b) : (!b ? (a != b) : strcmp(a, b)))
-#endif
-
 #if defined (UOFF_T_INT)
 typedef unsigned int uoff_t;
 #elif defined (UOFF_T_LONG)

--- a/src/fe-common/core/fe-common-core.c
+++ b/src/fe-common/core/fe-common-core.c
@@ -450,18 +450,7 @@ void fe_common_core_finish_init(void)
 	signal_add_first("setup changed", (SIGNAL_FUNC) sig_setup_changed);
 
         /* _after_ windows are created.. */
-#if GLIB_CHECK_VERSION(2,6,0)
 	g_log_set_default_handler((GLogFunc) glog_func, NULL);
-#else
-	g_log_set_handler(G_LOG_DOMAIN,
-			  (GLogLevelFlags) (G_LOG_LEVEL_CRITICAL |
-					    G_LOG_LEVEL_WARNING),
-			  (GLogFunc) glog_func, NULL);
-	g_log_set_handler("GLib",
-			  (GLogLevelFlags) (G_LOG_LEVEL_CRITICAL |
-					    G_LOG_LEVEL_WARNING),
-			  (GLogFunc) glog_func, NULL); /* send glib errors to the same place */
-#endif
 
 	if (setup_changed)
                 signal_emit("setup changed", 0);


### PR DESCRIPTION
Applies #232 again, fixes #230 

------

**Revert "Revert "Bug fix - docdir is ignored during installation.""**

This reverts commit d222c11.

------

**Bump glib2 requirement from 2.6 to 2.16**

This drops support for rhel/centos 5 (18 months left of its 10 year
support cycle)

Keeps support for debian 5.0 (lenny) and ubuntu 8.04 LTS, both of
which are unsupported, so bumping up to glib 2.24 wouldn't be a problem,
but it's not needed atm.

------

**Drop some glib version checks that are not needed anymore**

The g_strcmp0 fallback in particular was broken since it was used in a
few places as a GCompareFunc, and macros don't work that way.

Yes, that one was my fault, but nobody complained :D

------