### PR TITLE
dcc-get: close() the temp fd so we don't get ETXTBSY in ntfs mounts

### DIFF
--- a/src/irc/dcc/dcc-get.c
+++ b/src/irc/dcc/dcc-get.c
@@ -226,6 +226,8 @@ void sig_dccget_connected(GET_DCC_REC *dcc)
 		else
 			ret = fchmod(temphandle, dcc_file_create_mode);
 
+		close(temphandle);
+
 		if (ret != -1) {
 			ret = link(tempfname, dcc->file);
 
@@ -249,7 +251,6 @@ void sig_dccget_connected(GET_DCC_REC *dcc)
 
 		/* close/remove the temp file */
 		ret_errno = errno;
-		close(temphandle);
 		unlink(tempfname);
 		g_free(tempfname);
 


### PR DESCRIPTION
Patch from [debian bug 696963][1]

Fixes bug #220 and [flyspray bug 867][2]

[1]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=696963
[2]: http://bugs.irssi.org/index.php?do=details&task_id=867

-----------------

The bugs talk about ntfs and cifs mounts but it's just the windows filesystem limitation of only allowing a fd to be open by a single thing at the same time. I couldn't actually reproduce that with a local ntfs filesystem or a cifs mount from a remote ext4 partition. I'm lacking some windows here.

Either way the patch is sensible and straightforward and the original author claims it fixes the issue so i'll trust him on that.