### PR TITLE
Fix the display of utf8 sequences in the gui

### DIFF
--- a/src/fe-common/core/utf8.h
+++ b/src/fe-common/core/utf8.h
@@ -8,6 +8,8 @@
 #define is_big5_hi(hi)  (0x81 <= (hi) && (hi) <= 0xFE)
 #define is_big5(hi,lo) (is_big5_hi(hi) && is_big5_lo(lo))
 
+int strlen_big5(const unsigned char *str);
+
 /* Returns width for character (0-2). */
 int mk_wcwidth(unichar c);
 

--- a/src/fe-common/core/utf8.h
+++ b/src/fe-common/core/utf8.h
@@ -8,8 +8,6 @@
 #define is_big5_hi(hi)  (0x81 <= (hi) && (hi) <= 0xFE)
 #define is_big5(hi,lo) (is_big5_hi(hi) && is_big5_lo(lo))
 
-int strlen_big5(const unsigned char *str);
-
 /* Returns width for character (0-2). */
 int mk_wcwidth(unichar c);
 

--- a/src/fe-text/gui-printtext.c
+++ b/src/fe-text/gui-printtext.c
@@ -220,16 +220,15 @@ static void sig_gui_print_text(WINDOW_REC *window, void *fgcolor,
 	get_colors(flags, &fg, &bg, &attr);
 
 	if (window == NULL) {
-                g_return_if_fail(next_xpos != -1);
+		g_return_if_fail(next_xpos != -1);
 
 		term_set_color2(root_window, attr, fg, bg);
 
 		term_move(root_window, next_xpos, next_ypos);
 		if (flags & GUI_PRINT_FLAG_CLRTOEOL)
 			term_clrtoeol(root_window);
-		term_addstr(root_window, str);
-		next_xpos += strlen(str); /* FIXME utf8 or big5 */
-                return;
+		next_xpos += term_addstr(root_window, str);
+		return;
 	}
 
 	lineinfo.level = dest == NULL ? 0 : dest->level;

--- a/src/fe-text/term-terminfo.c
+++ b/src/fe-text/term-terminfo.c
@@ -537,14 +537,14 @@ int term_addstr(TERM_WINDOW *window, const char *str)
 
 	ptr = str;
 
-	if (term_type != TERM_TYPE_BIG5) {
-	    while (*ptr != '\0') {
-		tmp = g_utf8_get_char(ptr);
-		len += unichar_isprint(tmp) ? mk_wcwidth(tmp) : 1;
-		ptr = g_utf8_next_char(ptr);
-	    }
+	if (term_type == TERM_TYPE_UTF8) {
+		while (*ptr != '\0') {
+			tmp = g_utf8_get_char(ptr);
+			len += unichar_isprint(tmp) ? mk_wcwidth(tmp) : 1;
+			ptr = g_utf8_next_char(ptr);
+		}
 	} else
-	    len = raw_len;
+		len = raw_len;
 
         term_printed_text(len);
 

--- a/src/fe-text/term-terminfo.c
+++ b/src/fe-text/term-terminfo.c
@@ -543,18 +543,8 @@ int term_addstr(TERM_WINDOW *window, const char *str)
 		len += unichar_isprint(tmp) ? mk_wcwidth(tmp) : 1;
 		ptr = g_utf8_next_char(ptr);
 	    }
-	} else {
-	    while (*ptr != '\0') {
-		if (is_big5(ptr[0], ptr[1])) {
-		    tmp = ptr[0] << 8 | ptr[1];
-		    ptr += 2;
-		} else {
-		    tmp = *ptr;
-		    ptr += 1;
-		}
-		len += (tmp > 0xff) ? 2 : 1; 
-	    }
-	}
+	} else
+	    len = raw_len;
 
         term_printed_text(len);
 

--- a/src/fe-text/term.h
+++ b/src/fe-text/term.h
@@ -83,7 +83,7 @@ void term_set_color(TERM_WINDOW *window, int col);
 void term_move(TERM_WINDOW *window, int x, int y);
 void term_addch(TERM_WINDOW *window, char chr);
 void term_add_unichar(TERM_WINDOW *window, unichar chr);
-void term_addstr(TERM_WINDOW *window, const char *str);
+int  term_addstr(TERM_WINDOW *window, const char *str);
 void term_clrtoeol(TERM_WINDOW *window);
 
 void term_move_cursor(int x, int y);


### PR DESCRIPTION
term_addstr() had a long-standing fixme that suggested it didn't
take into account the string encoding when calculating the string
length.
The BIG5 code path is untested.