### PR TITLE
[WIP] Irssiproxy SSL support

### DIFF
--- a/src/irc/proxy/dump.c
+++ b/src/irc/proxy/dump.c
@@ -29,6 +29,42 @@
 #include "irc-channels.h"
 #include "irc-nicklist.h"
 #include "modes.h"
+#include "line-split.h"
+
+void proxy_send(CLIENT_REC *client, char *d, int l)
+{
+#ifdef HAVE_OPENSSL
+	if(client->listen->use_ssl) {
+		SSL_write(client->ssl, d, l);
+	} else 
+#endif
+		net_sendbuffer_send(client->handle, d, l);
+}
+
+int proxy_readline(CLIENT_REC *client, char **str)
+{
+#ifdef HAVE_OPENSSL
+	if(client->listen->use_ssl) {
+		char tmpbuf[2048];
+		int recvlen = 0;
+        
+		recvlen = SSL_read(client->ssl, tmpbuf, sizeof(tmpbuf));
+		if(recvlen > 0) {
+			return line_split(tmpbuf, recvlen, str, &client->handle->readbuffer);
+		} else {
+			int err;
+			err = SSL_get_error(client->ssl, recvlen);
+			/* READ/WRITE are not really errors, they just indicate that atm 
+			   OpenSSL is waiting for more data */
+			if(err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+				return line_split(tmpbuf, 0, str, &client->handle->readbuffer);
+			}
+			return recvlen; /* if any other error occurs, this will quit the connection */
+		}
+	} else 
+#endif
+		return net_sendbuffer_receive_line(client->handle, str, 1);
+}
 
 void proxy_outdata(CLIENT_REC *client, const char *data, ...)
 {
@@ -41,7 +77,7 @@ void proxy_outdata(CLIENT_REC *client, const char *data, ...)
 	va_start(args, data);
 
 	str = g_strdup_vprintf(data, args);
-	net_sendbuffer_send(client->handle, str, strlen(str));
+	proxy_send(client, str, strlen(str));
 	g_free(str);
 
 	va_end(args);
@@ -65,7 +101,7 @@ void proxy_outdata_all(IRC_SERVER_REC *server, const char *data, ...)
 		CLIENT_REC *rec = tmp->data;
 
 		if (rec->connected && rec->server == server)
-			net_sendbuffer_send(rec->handle, str, len);
+			proxy_send(rec, str, len);
 	}
 	g_free(str);
 

--- a/src/irc/proxy/listen.c
+++ b/src/irc/proxy/listen.c
@@ -708,7 +708,8 @@ static void read_settings(void)
 	LISTEN_REC *rec;
 	GSList *remove_listens = NULL;
 	GSList *add_listens = NULL;
-	char **ports, **tmp, *ircnet, *port, *sslfile;
+	char **ports, **tmp, *ircnet, *port;
+	char *sslfile = NULL;
 	int portnum;
 
 	remove_listens = g_slist_copy(proxy_listens);

--- a/src/irc/proxy/listen.c
+++ b/src/irc/proxy/listen.c
@@ -648,14 +648,14 @@ static void add_listen(const char *ircnet, int port, char *sslcert)
 
 	if(sslcert != NULL) {
 		rec->use_ssl = TRUE;
-		rec->ssl_method = SSLv3_server_method(); /* let's start with 3 */
-		rec->ssl_ctx = SSL_CTX_new(rec->ssl_method);
+		rec->ssl_ctx = SSL_CTX_new(SSLv23_server_method());
 		if(rec->ssl_ctx == NULL) {
 			printtext(NULL, NULL, MSGLEVEL_CLIENTERROR,
 			  "Proxy: Error setting up SSL Context for port %d failed.",
 			  rec->port);
 			goto error;
 		}
+		SSL_CTX_set_options(rec->ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
 
 		if(SSL_CTX_use_certificate_file(rec->ssl_ctx, sslcert, SSL_FILETYPE_PEM) <= 0) {
 			printtext(NULL, NULL, MSGLEVEL_CLIENTERROR, "Proxy: Error loading certificate.");

--- a/src/irc/proxy/module.h
+++ b/src/irc/proxy/module.h
@@ -24,3 +24,6 @@ void proxy_outdata_all(IRC_SERVER_REC *server, const char *data, ...);
 void proxy_outserver(CLIENT_REC *client, const char *data, ...);
 void proxy_outserver_all(IRC_SERVER_REC *server, const char *data, ...);
 void proxy_outserver_all_except(CLIENT_REC *client, const char *data, ...);
+
+void proxy_send(CLIENT_REC *client, char *d, int l);
+int proxy_readline(CLIENT_REC *client, char **str);

--- a/src/irc/proxy/proxy.c
+++ b/src/irc/proxy/proxy.c
@@ -78,6 +78,11 @@ void irc_proxy_init(void)
 	settings_add_str("irssiproxy", "irssiproxy_bind", "");
 	settings_add_bool("irssiproxy", "irssiproxy", TRUE);
 
+#ifdef HAVE_OPENSSL
+	SSL_load_error_strings();
+	OpenSSL_add_ssl_algorithms();
+#endif
+
 	if (*settings_get_str("irssiproxy_password") == '\0') {
 		/* no password - bad idea! */
 		signal_emit("gui dialog", 2, "warning",
@@ -87,9 +92,16 @@ void irc_proxy_init(void)
 	}
 	if (*settings_get_str("irssiproxy_ports") == '\0') {
 		signal_emit("gui dialog", 2, "warning",
-			    "No proxy ports specified. Use /SET "
+			    "No proxy ports specified. Use /set "
+#ifdef HAVE_OPENSSL
+			    "irssiproxy_ports <ircnet>=<port> <ircnet2>=<port2>:<sslcert> "
+			    "... to set them. You can add :filename.pem to secure the proxy with SSL."
+			    " (Should contain a cert and key in PEM format)");
+#else
 			    "irssiproxy_ports <ircnet>=<port> <ircnet2>=<port2> "
 			    "... to set them.");
+#endif
+
 	}
 
 	command_bind("irssiproxy", NULL, (SIGNAL_FUNC) cmd_irssiproxy);
@@ -101,7 +113,7 @@ void irc_proxy_init(void)
 		proxy_listen_init();
 	}
 	settings_check();
-        module_register("proxy", "irc");
+	module_register("proxy", "irc");
 }
 
 void irc_proxy_deinit(void)

--- a/src/irc/proxy/proxy.c
+++ b/src/irc/proxy/proxy.c
@@ -78,10 +78,8 @@ void irc_proxy_init(void)
 	settings_add_str("irssiproxy", "irssiproxy_bind", "");
 	settings_add_bool("irssiproxy", "irssiproxy", TRUE);
 
-#ifdef HAVE_OPENSSL
 	SSL_load_error_strings();
 	OpenSSL_add_ssl_algorithms();
-#endif
 
 	if (*settings_get_str("irssiproxy_password") == '\0') {
 		/* no password - bad idea! */
@@ -93,14 +91,9 @@ void irc_proxy_init(void)
 	if (*settings_get_str("irssiproxy_ports") == '\0') {
 		signal_emit("gui dialog", 2, "warning",
 			    "No proxy ports specified. Use /set "
-#ifdef HAVE_OPENSSL
 			    "irssiproxy_ports <ircnet>=<port> <ircnet2>=<port2>:<sslcert> "
 			    "... to set them. You can add :filename.pem to secure the proxy with SSL."
 			    " (Should contain a cert and key in PEM format)");
-#else
-			    "irssiproxy_ports <ircnet>=<port> <ircnet2>=<port2> "
-			    "... to set them.");
-#endif
 
 	}
 

--- a/src/irc/proxy/proxy.h
+++ b/src/irc/proxy/proxy.h
@@ -7,6 +7,15 @@
 #include "irc.h"
 #include "irc-servers.h"
 
+#ifdef HAVE_OPENSSL
+#include <openssl/rsa.h>
+#include <openssl/crypto.h>
+#include <openssl/x509.h>
+#include <openssl/pem.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#endif
+
 typedef struct {
 	int port;
 	char *ircnet;
@@ -15,6 +24,11 @@ typedef struct {
 	GIOChannel *handle;
 
 	GSList *clients;
+#ifdef HAVE_OPENSSL
+	unsigned int use_ssl;
+	SSL_CTX *ssl_ctx;
+	SSL_METHOD *ssl_method;
+#endif
 } LISTEN_REC;
 
 typedef struct {
@@ -29,6 +43,9 @@ typedef struct {
 	unsigned int user_sent:1;
 	unsigned int connected:1;
 	unsigned int want_ctcp:1;
+#ifdef HAVE_OPENSSL
+	SSL *ssl;
+#endif
 } CLIENT_REC;
 
 #endif

--- a/src/irc/proxy/proxy.h
+++ b/src/irc/proxy/proxy.h
@@ -24,7 +24,6 @@ typedef struct {
 	GSList *clients;
 	unsigned int use_ssl;
 	SSL_CTX *ssl_ctx;
-	SSL_METHOD *ssl_method;
 } LISTEN_REC;
 
 typedef struct {

--- a/src/irc/proxy/proxy.h
+++ b/src/irc/proxy/proxy.h
@@ -7,14 +7,12 @@
 #include "irc.h"
 #include "irc-servers.h"
 
-#ifdef HAVE_OPENSSL
 #include <openssl/rsa.h>
 #include <openssl/crypto.h>
 #include <openssl/x509.h>
 #include <openssl/pem.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
-#endif
 
 typedef struct {
 	int port;
@@ -24,11 +22,9 @@ typedef struct {
 	GIOChannel *handle;
 
 	GSList *clients;
-#ifdef HAVE_OPENSSL
 	unsigned int use_ssl;
 	SSL_CTX *ssl_ctx;
 	SSL_METHOD *ssl_method;
-#endif
 } LISTEN_REC;
 
 typedef struct {
@@ -43,9 +39,7 @@ typedef struct {
 	unsigned int user_sent:1;
 	unsigned int connected:1;
 	unsigned int want_ctcp:1;
-#ifdef HAVE_OPENSSL
 	SSL *ssl;
-#endif
 } CLIENT_REC;
 
 #endif


### PR DESCRIPTION
Based off a patch from "Christian Sachs", http://bugs.irssi.org/index.php?do=details&task_id=645

I'd like to credit the first commit properly, but couldn't find an email address.

Quoting the ticket:

>I've created this patch (on SVN/r5021) which adds SSL encryption to irssiproxy. (The proxy then acts as a SSL server, the client used to connect to it will need to support SSL.)
>It's been tested on Linux and Mac OS X. Unless someone stumbles upon bugs I've missed, maybe the patch could be merged.
>I know that adding a small wrapper might not be the most elegant solution, but taking a look at the existing irssi SSL code makes it appear pretty client centric;
>I assumed it might be more adequate to add this by changing the proxy code alone, not the basic network code.

[...]

>It's enabled by compiling irssi SSL enabled; encryption then needs a server certificate and can be enabled network-wise.
>One can switch SSL on by adding `:/path/to/certkey.pem` to the `irssiproxy_ports` setting.
>e.g. `/set irssiproxy_ports QuakeNet=7777:/home/user/.irssi/servercert.pem`
>The certificate/key file must contain both cert&key, and be in PEM format. If one is familiar with PKI, obviously a proper cert can be used.
>For basic security, a simple cert/key can be made using the following command: `openssl req -new -x509 -nodes -newkey rsa:2048 -keyout yourcert.pem -out yourcert.pem -days 365`
>(Obviously checking the cert for trustability must be disabled in this case on the client side.)


I just rebased, applied a bunch of style fixes, removed all the openssl ifdefs, simplified code slightly, and fixed the blatantly wrong usage of `SSLv3_server_method()`. Thanks openssl! So intuitive.

Just adding it here to not forget about it (most of this stuff is from a few months ago), and to review it some more.

Not ~~significantly~~ tested, not even significantly reviewed by myself either. The fixes I applied are all low hanging fruit.

Review comment from coekie:

>It seems strange to me that the path to the certificate is per network, and not just one global setting though. Is there really a use for having different certificates for different proxy ports; or only having ssl enabled for some of them?