### PR TITLE
Fix /reconnect RECON-1 saying "Reconnection tag 1 not found"

### DIFF
--- a/src/core/servers-reconnect.c
+++ b/src/core/servers-reconnect.c
@@ -420,8 +420,8 @@ static void cmd_reconnect(const char *data, SERVER_REC *server)
 			cmd_param_error(CMDERR_NOT_CONNECTED);
                 rec = reconnects->data;
 	} else {
-		if (g_ascii_strncasecmp(data, "RECON-", 6) == 0)
-			data += 6;
+		if (g_ascii_strncasecmp(tag, "RECON-", 6) == 0)
+			tag += 6;
 
 		tagnum = atoi(tag);
 		rec = tagnum <= 0 ? NULL : reconnect_find_tag(tagnum);


### PR DESCRIPTION
Turns out it was fixing the wrong string, and trying to do `atoi("RECON-1")` instead of `atoi("1")`.

`/reconnect 1` worked, but `/reconnect RECON-1` gave that confusing error message.

----

This has been bugging me since forever, I'm surprised it doesn't have a ticket in here or in flyspray. Probably because the workaround is trivial.