### PR TITLE
Avoiding to compile portions of statements and expressions with preprocessor conditionals.

### DIFF
--- a/src/core/misc.c
+++ b/src/core/misc.c
@@ -431,11 +431,11 @@ int mkpath(const char *path, int mode)
 		dir = g_strndup(path, (int) (p-path));
 		if (stat(dir, &statbuf) != 0) {
 #ifndef WIN32
-			if (mkdir(dir, mode) == -1)
+            gboolean failed = (mkdir(dir, mode) == -1);
 #else
-			if (_mkdir(dir) == -1)
+            gboolean failed = (_mkdir(dir) == -1);
 #endif
-			{
+			if (failed) {
 				g_free(dir);
 				return -1;
 			}

--- a/src/core/network.c
+++ b/src/core/network.c
@@ -212,11 +212,11 @@ GIOChannel *net_connect_ip(IPADDR *ip, int port, IPADDR *my_ip)
 	ret = connect(handle, &so.sa, SIZEOF_SOCKADDR(so));
 
 #ifndef WIN32
-	if (ret < 0 && errno != EINPROGRESS)
+    gboolean failed = (ret < 0 && errno != EINPROGRESS);
 #else
-	if (ret < 0 && WSAGetLastError() != WSAEWOULDBLOCK)
+    gboolean failed = (ret < 0 && WSAGetLastError() != WSAEWOULDBLOCK);
 #endif
-	{
+	if (failed) {
 		int old_errno = errno;
 		close(handle);
 		errno = old_errno;

--- a/src/fe-text/term-curses.c
+++ b/src/fe-text/term-curses.c
@@ -398,10 +398,11 @@ void term_gets(GArray *buffer, int *line_count)
 
 	for (;;) {
 #ifdef WIDEC_CURSES
-		if (get_wch(&key) == ERR)
+        gboolean failed = (get_wch(&key) == ERR);
 #else
-		if ((key = getch()) == ERR)
+        gboolean failed = ((key = getch()) == ERR);
 #endif
+        if (failed)
 			break;
 #ifdef KEY_RESIZE
 		if (key == KEY_RESIZE)


### PR DESCRIPTION
Removing conditional directives that split up parts of statements, which might influence code understanding, maintainability and error-proneness negatively, as suggested by code style guidelines from the Linux Kernel, practitioners and researchers.

- https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
- https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

More than 80% of developers prefer to avoid this kind of preprocessor conditionals according to an online survey with 202 developers from 24 C open-source projects.

- http://www.cs.cmu.edu/~ckaestne/pdf/ecoop15.pdf 