### PR TITLE
Strip trailing whitespace from commands

### DIFF
--- a/src/core/commands.c
+++ b/src/core/commands.c
@@ -748,6 +748,11 @@ int cmd_get_params(const char *data, gpointer *free_me, int count, ...)
 			if (cnt == 0 && count & PARAM_FLAG_GETREST) {
 				/* get rest */
 				arg = datad;
+
+				/* strip the trailing whitespace */
+				if (count & PARAM_FLAG_STRIP_TRAILING_WS) {
+					arg = g_strchomp (arg);
+				}
 			} else {
 				arg = (count & PARAM_FLAG_NOQUOTES) ?
 					cmd_get_param(&datad) :

--- a/src/core/commands.c
+++ b/src/core/commands.c
@@ -751,7 +751,7 @@ int cmd_get_params(const char *data, gpointer *free_me, int count, ...)
 
 				/* strip the trailing whitespace */
 				if (count & PARAM_FLAG_STRIP_TRAILING_WS) {
-					arg = g_strchomp (arg);
+					arg = g_strchomp(arg);
 				}
 			} else {
 				arg = (count & PARAM_FLAG_NOQUOTES) ?

--- a/src/core/commands.h
+++ b/src/core/commands.h
@@ -152,6 +152,8 @@ int command_have_option(const char *cmd, const char *option);
 #define PARAM_FLAG_OPTCHAN 0x00010000
 /* optional channel in first argument, but don't treat "*" as current channel */
 #define PARAM_FLAG_OPTCHAN_NAME (0x00020000|PARAM_FLAG_OPTCHAN)
+/* strip the trailing whitespace */
+#define PARAM_FLAG_STRIP_TRAILING_WS 0x00040000
 
 char *cmd_get_param(char **data);
 char *cmd_get_quoted_param(char **data);

--- a/src/fe-common/core/completion.c
+++ b/src/fe-common/core/completion.c
@@ -757,7 +757,7 @@ static void cmd_completion(const char *data)
 	int len;
 
 	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_OPTIONS |
-			    PARAM_FLAG_GETREST,
+			    PARAM_FLAG_GETREST | PARAM_FLAG_STRIP_TRAILING_WS,
 			    "completion", &optlist, &key, &value))
 		return;
 

--- a/src/fe-common/core/fe-channels.c
+++ b/src/fe-common/core/fe-channels.c
@@ -122,7 +122,8 @@ static void cmd_join(const char *data, SERVER_REC *server)
 	void *free_arg;
 
 	if (!cmd_get_params(data, &free_arg, 1 | PARAM_FLAG_OPTIONS |
-			    PARAM_FLAG_UNKNOWN_OPTIONS | PARAM_FLAG_GETREST,
+			    PARAM_FLAG_UNKNOWN_OPTIONS | PARAM_FLAG_GETREST |
+			    PARAM_FLAG_STRIP_TRAILING_WS,
 			    "join", &optlist, &pdata))
 		return;
 

--- a/src/fe-common/core/fe-ignore.c
+++ b/src/fe-common/core/fe-ignore.c
@@ -127,7 +127,8 @@ static void cmd_ignore(const char *data)
 		return;
 	}
 
-	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_OPTIONS | PARAM_FLAG_GETREST,
+	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_OPTIONS | 
+			    PARAM_FLAG_GETREST | PARAM_FLAG_STRIP_TRAILING_WS,
 			    "ignore", &optlist, &mask, &levels))
 		return;
 

--- a/src/fe-common/core/fe-log.c
+++ b/src/fe-common/core/fe-log.c
@@ -87,8 +87,9 @@ static void cmd_log_open(const char *data)
 	int level;
 
 	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_GETREST |
-			    PARAM_FLAG_UNKNOWN_OPTIONS | PARAM_FLAG_OPTIONS,
-			    "log open", &optlist, &fname, &levels))
+			    PARAM_FLAG_UNKNOWN_OPTIONS | PARAM_FLAG_OPTIONS |
+			    PARAM_FLAG_STRIP_TRAILING_WS, "log open", &optlist, 
+			    &fname, &levels))
 		return;
 	if (*fname == '\0') cmd_param_error(CMDERR_NOT_ENOUGH_PARAMS);
 

--- a/src/fe-common/core/fe-settings.c
+++ b/src/fe-common/core/fe-settings.c
@@ -108,7 +108,8 @@ static void cmd_set(char *data)
 	int clear, set_default;
 	SETTINGS_REC *rec;
 
-	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_GETREST | PARAM_FLAG_OPTIONS,
+	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_GETREST |
+			    PARAM_FLAG_OPTIONS | PARAM_FLAG_STRIP_TRAILING_WS,
 			    "set", &optlist, &key, &value))
 		return;
 
@@ -182,7 +183,7 @@ static void cmd_toggle(const char *data)
 	void *free_arg;
 	int type;
 
-	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_GETREST, &key, &value))
+	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_GETREST | PARAM_FLAG_STRIP_TRAILING_WS, &key, &value))
 		return;
 
 	if (*key == '\0')

--- a/src/fe-common/irc/fe-irc-commands.c
+++ b/src/fe-common/irc/fe-irc-commands.c
@@ -246,8 +246,8 @@ static void cmd_ban(const char *data, IRC_SERVER_REC *server,
 
         CMD_IRC_SERVER(server);
 
-	if (!cmd_get_params(data, &free_arg, 2 |
-			    PARAM_FLAG_OPTCHAN | PARAM_FLAG_GETREST,
+	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_OPTCHAN | 
+			    PARAM_FLAG_GETREST | PARAM_FLAG_STRIP_TRAILING_WS,
 			    item, &channel, &nicks))
 		return;
 

--- a/src/irc/core/bans.c
+++ b/src/irc/core/bans.c
@@ -184,8 +184,8 @@ static void command_set_ban(const char *data, IRC_SERVER_REC *server,
 	if (server == NULL || !server->connected || !IS_IRC_SERVER(server))
 		cmd_return_error(CMDERR_NOT_CONNECTED);
 
-	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_OPTCHAN | PARAM_FLAG_GETREST,
-			    item, &channel, &nicks)) return;
+	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_OPTCHAN | PARAM_FLAG_GETREST |
+			    PARAM_FLAG_STRIP_TRAILING_WS, item, &channel, &nicks)) return;
 	if (!server_ischannel(SERVER(server), channel)) cmd_param_error(CMDERR_NOT_JOINED);
 	if (*nicks == '\0') {
 		if (g_strcmp0(data, "*") != 0)
@@ -262,8 +262,8 @@ static void cmd_ban(const char *data, IRC_SERVER_REC *server, void *item)
 
         CMD_IRC_SERVER(server);
 
-	if (!cmd_get_params(data, &free_arg, 1 |
-			    PARAM_FLAG_OPTIONS | PARAM_FLAG_GETREST,
+	if (!cmd_get_params(data, &free_arg, 1 | PARAM_FLAG_OPTIONS | 
+			    PARAM_FLAG_GETREST | PARAM_FLAG_STRIP_TRAILING_WS,
 			    "ban", &optlist, &ban))
 		return;
 
@@ -297,8 +297,8 @@ static void cmd_unban(const char *data, IRC_SERVER_REC *server, void *item)
 
         CMD_IRC_SERVER(server);
 
-	if (!cmd_get_params(data, &free_arg, 1 |
-			    PARAM_FLAG_OPTIONS | PARAM_FLAG_GETREST,
+	if (!cmd_get_params(data, &free_arg, 1 | PARAM_FLAG_OPTIONS | 
+			    PARAM_FLAG_GETREST | PARAM_FLAG_STRIP_TRAILING_WS,
 			    "unban", &optlist, &ban))
 		return;
 

--- a/src/irc/core/irc-commands.c
+++ b/src/irc/core/irc-commands.c
@@ -267,7 +267,8 @@ static void cmd_list(const char *data, IRC_SERVER_REC *server,
         CMD_IRC_SERVER(server);
 
 	if (!cmd_get_params(data, &free_arg, 1 | PARAM_FLAG_OPTIONS |
-			    PARAM_FLAG_GETREST, "list", &optlist, &str))
+			    PARAM_FLAG_GETREST | PARAM_FLAG_STRIP_TRAILING_WS, 
+			    "list", &optlist, &str))
 		return;
 
 	if (*str == '\0' && g_hash_table_lookup(optlist, "yes") == NULL &&
@@ -288,7 +289,8 @@ static void cmd_who(const char *data, IRC_SERVER_REC *server,
 
 	CMD_IRC_SERVER(server);
 
-	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_GETREST, &channel, &rest))
+	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_GETREST | 
+			    PARAM_FLAG_STRIP_TRAILING_WS, &channel, &rest))
 		return;
 
 	if (g_strcmp0(channel, "*") == 0 || *channel == '\0') {
@@ -320,7 +322,8 @@ static void cmd_names(const char *data, IRC_SERVER_REC *server,
         CMD_IRC_SERVER(server);
 
 	if (!cmd_get_params(data, &free_arg, 1 | PARAM_FLAG_OPTIONS |
-			    PARAM_FLAG_GETREST, "names", &optlist, &channel))
+			    PARAM_FLAG_GETREST | PARAM_FLAG_STRIP_TRAILING_WS,
+			    "names", &optlist, &channel))
 		return;
 
 	if (g_strcmp0(channel, "*") == 0 || *channel == '\0') {
@@ -501,7 +504,8 @@ static void cmd_whowas(const char *data, IRC_SERVER_REC *server)
 
         CMD_IRC_SERVER(server);
 
-	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_GETREST, &nicks, &rest))
+	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_GETREST | PARAM_FLAG_STRIP_TRAILING_WS,
+			    &nicks, &rest))
 		return;
 	if (*nicks == '\0') nicks = server->nick;
 

--- a/src/irc/core/modes.c
+++ b/src/irc/core/modes.c
@@ -835,10 +835,10 @@ static void cmd_mode(const char *data, IRC_SERVER_REC *server,
 
 	if (*data == '+' || *data == '-') {
 		target = "*";
-		if (!cmd_get_params(data, &free_arg, 1 | PARAM_FLAG_GETREST, &mode))
+		if (!cmd_get_params(data, &free_arg, 1 | PARAM_FLAG_GETREST | PARAM_FLAG_STRIP_TRAILING_WS, &mode))
 			return;
 	} else {
-		if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_GETREST, &target, &mode))
+		if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_GETREST | PARAM_FLAG_STRIP_TRAILING_WS, &target, &mode))
 			return;
 	}
 

--- a/src/irc/dcc/dcc-send.c
+++ b/src/irc/dcc/dcc-send.c
@@ -174,8 +174,8 @@ static void cmd_dcc_send(const char *data, IRC_SERVER_REC *server,
 	int queue, mode, passive;
 
 	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_OPTIONS |
-			    PARAM_FLAG_GETREST, "dcc send",
-			    &optlist, &nick, &fileargs))
+			    PARAM_FLAG_GETREST | PARAM_FLAG_STRIP_TRAILING_WS, 
+			    "dcc send", &optlist, &nick, &fileargs))
 		return;
 
 	chat = item_get_dcc(item);

--- a/src/irc/dcc/dcc.c
+++ b/src/irc/dcc/dcc.c
@@ -496,8 +496,8 @@ static void cmd_dcc_close(char *data, IRC_SERVER_REC *server)
 
 	g_return_if_fail(data != NULL);
 
-	if (!cmd_get_params(data, &free_arg, 3 | PARAM_FLAG_GETREST,
-			    &typestr, &nick, &arg))
+	if (!cmd_get_params(data, &free_arg, 3 | PARAM_FLAG_GETREST |
+			    PARAM_FLAG_STRIP_TRAILING_WS, &typestr, &nick, &arg))
 		return;
 
 	if (*nick == '\0') cmd_param_error(CMDERR_NOT_ENOUGH_PARAMS);

--- a/src/irc/notifylist/notify-commands.c
+++ b/src/irc/notifylist/notify-commands.c
@@ -36,7 +36,8 @@ static void cmd_notify(gchar *data)
 
 	g_return_if_fail(data != NULL);
 
-	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_OPTIONS | PARAM_FLAG_GETREST,
+	if (!cmd_get_params(data, &free_arg,
+			    2 | PARAM_FLAG_OPTIONS | PARAM_FLAG_GETREST | PARAM_FLAG_STRIP_TRAILING_WS,
 			    "notify", &optlist, &mask, &ircnets))
 		return;
 	if (*mask == '\0') cmd_param_error(CMDERR_NOT_ENOUGH_PARAMS);


### PR DESCRIPTION
We probably need to do that for some other commands too...