### PR TITLE
Use the expanded filename when picking the awaylog

### DIFF
--- a/src/fe-common/core/fe-log.c
+++ b/src/fe-common/core/fe-log.c
@@ -617,7 +617,7 @@ static void sig_window_item_remove(WINDOW_REC *window, WI_ITEM_REC *item)
 static void sig_log_locked(LOG_REC *log)
 {
 	printformat(NULL, NULL, MSGLEVEL_CLIENTERROR,
-		    TXT_LOG_LOCKED, log->fname);
+		    TXT_LOG_LOCKED, log->real_fname);
 }
 
 static void sig_log_create_failed(LOG_REC *log)
@@ -657,11 +657,11 @@ static void sig_awaylog_show(LOG_REC *log, gpointer pmsgs, gpointer pfilepos)
 	filepos = GPOINTER_TO_INT(pfilepos);
 
 	if (msgs == 0)
-		printformat(NULL, NULL, MSGLEVEL_CLIENTNOTICE, TXT_LOG_NO_AWAY_MSGS, log->fname);
+		printformat(NULL, NULL, MSGLEVEL_CLIENTNOTICE, TXT_LOG_NO_AWAY_MSGS, log->real_fname);
 	else {
-		printformat(NULL, NULL, MSGLEVEL_CLIENTNOTICE, TXT_LOG_AWAY_MSGS, log->fname, msgs);
+		printformat(NULL, NULL, MSGLEVEL_CLIENTNOTICE, TXT_LOG_AWAY_MSGS, log->real_fname, msgs);
 
-                str = g_strdup_printf("\"%s\" %d", log->fname, filepos);
+                str = g_strdup_printf("\"%s\" %d", log->real_fname, filepos);
 		signal_emit("command cat", 1, str);
 		g_free(str);
 	}


### PR DESCRIPTION
This fixes a long-standing bug where 'fname' was being feed to cat
instead of 'real_fname', causing it to quit with a 'No such file or directory'
error.

[FS#377](http://bugs.irssi.org/index.php?do=details&task_id=377)