### PR TITLE
fix nick class hierarchy

### DIFF
--- a/src/perl/common/Irssi.pm
+++ b/src/perl/common/Irssi.pm
@@ -159,6 +159,7 @@ if (!in_irssi()) {
 
   @Irssi::Channel::ISA = qw(Irssi::Windowitem);
   @Irssi::Query::ISA = qw(Irssi::Windowitem);
+  @Irssi::Nick::ISA = qw();
 
   Irssi::init();
 


### PR DESCRIPTION
Fixes #271 (Can't locate package Irssi::Nick)