### PR TITLE
more perl inheritance warning fixes

### DIFF
--- a/src/perl/common/Irssi.pm
+++ b/src/perl/common/Irssi.pm
@@ -159,6 +159,7 @@ if (!in_irssi()) {
 
   @Irssi::Channel::ISA = qw(Irssi::Windowitem);
   @Irssi::Query::ISA = qw(Irssi::Windowitem);
+  @Irssi::Chatnet::ISA = qw();
   @Irssi::Nick::ISA = qw();
 
   Irssi::init();


### PR DESCRIPTION
Fixes `Can't locate package Irssi::Chatnet for @Irssi::Silc::Chatnet::ISA` etc.