### PR TITLE
Random fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ ltversion.m4
 lt~obsolete.m4
 pm_to_blib
 stamp-h1
+MYMETA.*
 
 docs/help/Makefile.am
 docs/help/[a-z]*

--- a/INSTALL
+++ b/INSTALL
@@ -11,7 +11,8 @@ To compile irssi you need:
 
 For most people, this should work just fine:
 
- ./autogen.sh
+ ./autogen.sh     (for people who just cloned the repository)
+ ./configure      (if this script already exists, skip ./autogen.sh)
  make
  su
  make install     (not _really_ required except for perl support)

--- a/INSTALL
+++ b/INSTALL
@@ -11,7 +11,7 @@ To compile irssi you need:
 
 For most people, this should work just fine:
 
- ./configure
+ ./autogen.sh
  make
  su
  make install     (not _really_ required except for perl support)


### PR DESCRIPTION
Made the suggested build script in `INSTALL` less confusing (`./configure` does not exist in fresh clones) and ignore `MYMETA.*` in the home directory to be consistent with ignoring `MYMETA.*` in subdirectories.