### PR TITLE
Remove all WIN32 ifdefs (unifdef -UWIN32)

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -34,9 +34,6 @@
 #  include <dirent.h>
 #endif
 #include <fcntl.h>
-#ifdef WIN32
-#  include <win32-compat.h>
-#endif
 
 #include <glib.h>
 #ifdef HAVE_GMODULE

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -83,7 +83,6 @@ static void sig_reload_config(int signo)
 
 static void read_settings(void)
 {
-#ifndef WIN32
 	static int signals[] = {
 		SIGINT, SIGQUIT, SIGTERM,
 		SIGALRM, SIGUSR1, SIGUSR2
@@ -123,7 +122,6 @@ static void read_settings(void)
 		if (setrlimit(RLIMIT_CORE, &rlimit) == -1)
                         settings_set_bool("override_coredump_limit", FALSE);
 	}
-#endif
 #endif
 }
 
@@ -225,9 +223,7 @@ void core_init(void)
 	client_start_time = time(NULL);
 
 	modules_init();
-#ifndef WIN32
 	pidwait_init();
-#endif
 
 	net_disconnect_init();
 	signals_init();
@@ -303,9 +299,7 @@ void core_deinit(void)
 	signals_deinit();
 	net_disconnect_deinit();
 
-#ifndef WIN32
 	pidwait_deinit();
-#endif
 	modules_deinit();
 
 	g_free(irssi_dir);

--- a/src/core/misc.c
+++ b/src/core/misc.c
@@ -430,11 +430,7 @@ int mkpath(const char *path, int mode)
 
 		dir = g_strndup(path, (int) (p-path));
 		if (stat(dir, &statbuf) != 0) {
-#ifndef WIN32
 			if (mkdir(dir, mode) == -1)
-#else
-			if (_mkdir(dir) == -1)
-#endif
 			{
 				g_free(dir);
 				return -1;

--- a/src/core/net-disconnect.c
+++ b/src/core/net-disconnect.c
@@ -116,7 +116,6 @@ void net_disconnect_init(void)
 
 void net_disconnect_deinit(void)
 {
-#ifndef WIN32
 	NET_DISCONNECT_REC *rec;
 	time_t now, max;
 	int first, fd;
@@ -155,5 +154,4 @@ void net_disconnect_deinit(void)
 			first = 0;
 		}
 	}
-#endif
 }

--- a/src/core/net-nonblock.c
+++ b/src/core/net-nonblock.c
@@ -77,14 +77,11 @@ int net_gethostbyname_nonblock(const char *addr, GIOChannel *pipe,
 {
 	RESOLVED_IP_REC rec;
 	const char *errorstr;
-#ifndef WIN32
 	int pid;
-#endif
 	int len;
 
 	g_return_val_if_fail(addr != NULL, FALSE);
 
-#ifndef WIN32
 	pid = fork();
 	if (pid > 0) {
 		/* parent */
@@ -97,7 +94,6 @@ int net_gethostbyname_nonblock(const char *addr, GIOChannel *pipe,
 		g_warning("net_connect_thread(): fork() failed! "
 			  "Using blocking resolving");
 	}
-#endif
 
 	/* child */
 	srand(time(NULL));
@@ -138,10 +134,8 @@ int net_gethostbyname_nonblock(const char *addr, GIOChannel *pipe,
 		}
 	}
 
-#ifndef WIN32
 	if (pid == 0)
 		_exit(99);
-#endif
 
 	/* we used blocking lookup */
 	return 0;
@@ -157,9 +151,7 @@ int net_gethostbyname_return(GIOChannel *pipe, RESOLVED_IP_REC *rec)
 	rec->host4 = NULL;
 	rec->host6 = NULL;
 
-#ifndef WIN32
 	fcntl(g_io_channel_unix_get_fd(pipe), F_SETFL, O_NONBLOCK);
-#endif
 
 	/* get ip+error */
 	if (g_io_channel_read_block(pipe, rec, sizeof(*rec)) == -1) {
@@ -201,9 +193,7 @@ void net_disconnect_nonblock(int pid)
 {
 	g_return_if_fail(pid > 0);
 
-#ifndef WIN32
 	kill(pid, SIGKILL);
-#endif
 }
 
 static void simple_init(SIMPLE_THREAD_REC *rec, GIOChannel *handle)

--- a/src/core/net-sendbuffer.c
+++ b/src/core/net-sendbuffer.c
@@ -160,13 +160,9 @@ void net_sendbuffer_flush(NET_SENDBUF_REC *rec)
 
         /* set the socket blocking while doing this */
 	handle = g_io_channel_unix_get_fd(rec->handle);
-#ifndef WIN32
 	fcntl(handle, F_SETFL, 0);
-#endif
 	while (!buffer_send(rec)) ;
-#ifndef WIN32
 	fcntl(handle, F_SETFL, O_NONBLOCK);
-#endif
 }
 
 /* Returns the socket handle */

--- a/src/core/network.c
+++ b/src/core/network.c
@@ -45,11 +45,7 @@ union sockaddr_union {
 GIOChannel *g_io_channel_new(int handle)
 {
 	GIOChannel *chan;
-#ifdef WIN32
-	chan = g_io_channel_win32_new_socket(handle);
-#else
 	chan = g_io_channel_unix_new(handle);
-#endif
 	g_io_channel_set_encoding(chan, NULL, NULL);
 	g_io_channel_set_buffered(chan, FALSE);
 	return chan;
@@ -188,9 +184,7 @@ GIOChannel *net_connect_ip(IPADDR *ip, int port, IPADDR *my_ip)
 		return NULL;
 
 	/* set socket options */
-#ifndef WIN32
 	fcntl(handle, F_SETFL, O_NONBLOCK);
-#endif
 	setsockopt(handle, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
 	setsockopt(handle, SOL_SOCKET, SO_KEEPALIVE, &opt, sizeof(opt));
 
@@ -211,11 +205,7 @@ GIOChannel *net_connect_ip(IPADDR *ip, int port, IPADDR *my_ip)
 	sin_set_port(&so, port);
 	ret = connect(handle, &so.sa, SIZEOF_SOCKADDR(so));
 
-#ifndef WIN32
 	if (ret < 0 && errno != EINPROGRESS)
-#else
-	if (ret < 0 && WSAGetLastError() != WSAEWOULDBLOCK)
-#endif
 	{
 		int old_errno = errno;
 		close(handle);
@@ -238,9 +228,7 @@ GIOChannel *net_connect_unix(const char *path)
 		return NULL;
 
 	/* set socket options */
-#ifndef WIN32
 	fcntl(handle, F_SETFL, O_NONBLOCK);
-#endif
 
 	/* connect */
 	memset(&sa, 0, sizeof(sa));
@@ -297,9 +285,7 @@ GIOChannel *net_listen(IPADDR *my_ip, int *port)
 		return NULL;
 
 	/* set socket options */
-#ifndef WIN32
 	fcntl(handle, F_SETFL, O_NONBLOCK);
-#endif
 	setsockopt(handle, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
 	setsockopt(handle, SOL_SOCKET, SO_KEEPALIVE, &opt, sizeof(opt));
 
@@ -342,9 +328,7 @@ GIOChannel *net_accept(GIOChannel *handle, IPADDR *addr, int *port)
 	if (addr != NULL) sin_get_ip(&so, addr);
 	if (port != NULL) *port = sin_get_port(&so);
 
-#ifndef WIN32
 	fcntl(ret, F_SETFL, O_NONBLOCK);
-#endif
 	return g_io_channel_new(ret);
 }
 

--- a/src/core/network.h
+++ b/src/core/network.h
@@ -6,12 +6,10 @@
 #endif
 
 #include <sys/types.h>
-#ifndef WIN32
 #  include <sys/socket.h>
 #  include <netinet/in.h>
 #  include <netdb.h>
 #  include <arpa/inet.h>
-#endif
 
 #ifndef AF_INET6
 #  ifdef PF_INET6

--- a/src/fe-common/core/fe-common-core.c
+++ b/src/fe-common/core/fe-common-core.c
@@ -168,9 +168,7 @@ void fe_common_core_init(void)
 	keyboard_init();
 	printtext_init();
 	formats_init();
-#ifndef WIN32
         fe_exec_init();
-#endif
         fe_expandos_init();
 	fe_help_init();
 	fe_ignore_init();
@@ -211,9 +209,7 @@ void fe_common_core_deinit(void)
 	keyboard_deinit();
 	printtext_deinit();
 	formats_deinit();
-#ifndef WIN32
         fe_exec_deinit();
-#endif
         fe_expandos_deinit();
 	fe_help_deinit();
 	fe_ignore_deinit();

--- a/src/fe-text/irssi.c
+++ b/src/fe-text/irssi.c
@@ -271,20 +271,6 @@ static void check_files(void)
 	}
 }
 
-#ifdef WIN32
-static void winsock_init(void)
-{
-	WORD wVersionRequested;
-	WSADATA wsaData;
-
-	wVersionRequested = MAKEWORD(2, 2);
-
-	if (WSAStartup(wVersionRequested, &wsaData) != 0) {
-		printf("Error initializing winsock\n");
-		exit(1);
-	}
-}
-#endif
 
 int main(int argc, char **argv)
 {
@@ -315,9 +301,6 @@ int main(int argc, char **argv)
 
 	check_files();
 
-#ifdef WIN32
-        winsock_init();
-#endif
 #ifdef HAVE_SOCKS
 	SOCKSinit(argv[0]);
 #endif


### PR DESCRIPTION
Just use cygwin.

This looks like it wasn't enough to do anything useful, and I don't think anyone cares about supporting win32 the hard way.