### PR TITLE
Makefile.am: Add default-config.h and default-theme.h to CLEANFILES

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,7 @@ ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
 # create default-config.h
 BUILT_SOURCES = default-config.h default-theme.h irssi-version.h
+CLEANFILES = default-config.h default-theme.h
 
 @MAINTAINER_MODE_TRUE@.PHONY: irssi-version.h
 


### PR DESCRIPTION
Fixes issues when building from other directories when the source tree was already configured before, as found in the comments of PR #375