### PR TITLE
ensure staticlib perl works on 5.22

### DIFF
--- a/src/perl/perl-common.c
+++ b/src/perl/perl-common.c
@@ -246,10 +246,7 @@ char *perl_get_use_list(void)
 
 void irssi_callXS(void (*subaddr)(pTHX_ CV* cv), CV *cv, SV **mark)
 {
-	dSP;
-
 	PUSHMARK(mark);
-	PUTBACK;
 
 	(*subaddr)(aTHX_ cv);
 }

--- a/src/perl/perl-core.c
+++ b/src/perl/perl-core.c
@@ -125,7 +125,7 @@ void perl_scripts_init(void)
 
 	perl_parse(my_perl, xs_init, G_N_ELEMENTS(perl_args), perl_args, NULL);
 #if PERL_STATIC_LIBS == 1
-	perl_eval_pv("Irssi::Core::boot_Irssi_Core();", TRUE);
+	perl_eval_pv("Irssi::Core::->boot_Irssi_Core(0.9);", TRUE);
 #endif
 
         perl_common_start();


### PR DESCRIPTION
may nevertheless be good to get some better understanding of mark, SP (and thus ax) in the boot process. What we figured out so far is that `items` becomes -1 in the second boot process if we do not pass the required parameters (which sounds like we may be messing with the Perl stack by making some assumptions) (Could also be some part of Perl itself doing it since we boot without the required arguments)