### PR TITLE
make /knockout use /unban to remove bans

### DIFF
--- a/src/irc/core/irc-commands.c
+++ b/src/irc/core/irc-commands.c
@@ -749,7 +749,7 @@ static void knockout_timeout_server(IRC_SERVER_REC *server)
 		next = tmp->next;
 		if (rec->unban_time <= now) {
 			/* timeout, unban. */
-			ban_remove(rec->channel, rec->ban);
+			signal_emit("command unban", 3, rec->ban, server, rec->channel);
 			knockout_destroy(server, rec);
 		}
 	}


### PR DESCRIPTION
/knockout uses /ban to set bans but calls ban_remove() directly to
remove them. This commit makes it use /unban instead. This allows
scripts that hook ban/unban to work automatically with /knockout.