### PR TITLE
Change when the autocmds are sent.

### DIFF
--- a/src/core/channels.c
+++ b/src/core/channels.c
@@ -245,9 +245,18 @@ void channel_send_autocommands(CHANNEL_REC *channel)
 	if (rec == NULL || rec->autosendcmd == NULL || !*rec->autosendcmd)
 		return;
 
-	if (rec->botmasks == NULL || !*rec->botmasks) {
-		/* just send the command. */
-		eval_special_string(rec->autosendcmd, "", channel->server, channel);
+	if (channel->wholist == FALSE) {
+		/* if the autosendcmd alone (with no -bots parameter) has been
+		 * specified then send it right after joining the channel, when
+		 * the WHO list hasn't been yet retrieved.
+		 * Depending on the value of the 'channel_max_who_sync' option
+		 * the WHO list might not be retrieved after the join event. */
+
+		if (rec->botmasks == NULL || !*rec->botmasks) {
+			/* just send the command. */
+			eval_special_string(rec->autosendcmd, "", channel->server, channel);
+		}
+
 		return;
 	}
 

--- a/src/core/channels.c
+++ b/src/core/channels.c
@@ -233,6 +233,31 @@ static int match_nick_flags(SERVER_REC *server, NICK_REC *nick, char flag)
 void channel_send_autocommands(CHANNEL_REC *channel)
 {
 	CHANNEL_SETUP_REC *rec;
+
+	g_return_if_fail(IS_CHANNEL(channel));
+
+	if (channel->session_rejoin)
+		return;
+
+	rec = channel_setup_find(channel->name, channel->server->connrec->chatnet);
+	if (rec == NULL || rec->autosendcmd == NULL || !*rec->autosendcmd)
+		return;
+
+	/* if the autosendcmd alone (with no -bots parameter) has been
+	 * specified then send it right after joining the channel, when
+	 * the WHO list hasn't been yet retrieved.
+	 * Depending on the value of the 'channel_max_who_sync' option
+	 * the WHO list might not be retrieved after the join event. */
+
+	if (rec->botmasks == NULL || !*rec->botmasks) {
+		/* just send the command. */
+		eval_special_string(rec->autosendcmd, "", channel->server, channel);
+	}
+}
+
+void channel_send_botcommands(CHANNEL_REC *channel)
+{
+	CHANNEL_SETUP_REC *rec;
 	NICK_REC *nick;
 	char **bots, **bot;
 
@@ -245,20 +270,9 @@ void channel_send_autocommands(CHANNEL_REC *channel)
 	if (rec == NULL || rec->autosendcmd == NULL || !*rec->autosendcmd)
 		return;
 
-	if (channel->wholist == FALSE) {
-		/* if the autosendcmd alone (with no -bots parameter) has been
-		 * specified then send it right after joining the channel, when
-		 * the WHO list hasn't been yet retrieved.
-		 * Depending on the value of the 'channel_max_who_sync' option
-		 * the WHO list might not be retrieved after the join event. */
-
-		if (rec->botmasks == NULL || !*rec->botmasks) {
-			/* just send the command. */
-			eval_special_string(rec->autosendcmd, "", channel->server, channel);
-		}
-
+	/* this case has already been handled by channel_send_autocommands */
+	if (rec->botmasks == NULL || !*rec->botmasks)
 		return;
-	}
 
 	/* find first available bot.. */
 	bots = g_strsplit(rec->botmasks, " ", -1);

--- a/src/core/channels.h
+++ b/src/core/channels.h
@@ -31,6 +31,7 @@ void channel_change_visible_name(CHANNEL_REC *channel, const char *name);
 
 /* Send the auto send command to channel */
 void channel_send_autocommands(CHANNEL_REC *channel);
+void channel_send_botcommands(CHANNEL_REC *channel);
 
 void channels_init(void);
 void channels_deinit(void);

--- a/src/irc/core/irc-channels-setup.c
+++ b/src/irc/core/irc-channels-setup.c
@@ -25,9 +25,11 @@
 void irc_channels_setup_init(void)
 {
 	signal_add("channel wholist", (SIGNAL_FUNC) channel_send_autocommands);
+	signal_add("channel joined", (SIGNAL_FUNC) channel_send_autocommands);
 }
 
 void irc_channels_setup_deinit(void)
 {
 	signal_remove("channel wholist", (SIGNAL_FUNC) channel_send_autocommands);
+	signal_remove("channel joined", (SIGNAL_FUNC) channel_send_autocommands);
 }

--- a/src/irc/core/irc-channels-setup.c
+++ b/src/irc/core/irc-channels-setup.c
@@ -24,12 +24,12 @@
 
 void irc_channels_setup_init(void)
 {
-	signal_add("channel wholist", (SIGNAL_FUNC) channel_send_autocommands);
+	signal_add("channel wholist", (SIGNAL_FUNC) channel_send_botcommands);
 	signal_add("channel joined", (SIGNAL_FUNC) channel_send_autocommands);
 }
 
 void irc_channels_setup_deinit(void)
 {
-	signal_remove("channel wholist", (SIGNAL_FUNC) channel_send_autocommands);
+	signal_remove("channel wholist", (SIGNAL_FUNC) channel_send_botcommands);
 	signal_remove("channel joined", (SIGNAL_FUNC) channel_send_autocommands);
 }


### PR DESCRIPTION
As per #175 if a -botcmd is specified for a given channel without a
-bots parameter then the command is sent right after joining the
channel.