### PR TITLE
Serialize the 'name' attribute of the CHANNEL_REC.

### DIFF
--- a/src/fe-common/core/windows-layout.c
+++ b/src/fe-common/core/windows-layout.c
@@ -168,12 +168,12 @@ static void sig_layout_save_item(WINDOW_REC *window, WI_ITEM_REC *item,
 		chat_protocol_find_id(item->chat_type);
 	if (proto != NULL)
 		iconfig_node_set_str(subnode, "chat_type", proto->name);
-	iconfig_node_set_str(subnode, "name", item->visible_name);
+	iconfig_node_set_str(subnode, "name", item->name);
 
 	if (item->server != NULL) {
 		iconfig_node_set_str(subnode, "tag", item->server->tag);
 		if (IS_CHANNEL(item)) {
-			rec = window_bind_add(window, item->server->tag, item->visible_name);
+			rec = window_bind_add(window, item->server->tag, item->name);
 			if (rec != NULL)
 				rec->sticky = TRUE;
 		}


### PR DESCRIPTION
This way the code doing the serialization in 'sig_layout_save_item' is
now symmetric with the loading code loading the data in
'sig_layout_restore'.