### PR TITLE
Use GLib's regexp interface (backed by PCRE)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -144,6 +144,15 @@ AC_ARG_ENABLE(true-color,
 	fi,
 	want_truecolor=no)
 
+AC_ARG_ENABLE(gregex,
+[  --disable-gregex     Build without GRegex (fall back to regex.h)],
+	if test x$enableval = xno ; then
+		want_gregex=no
+	else
+		want_gregex=yes
+	fi,
+	want_gregex=yes)
+
 dnl **
 dnl ** just some generic stuff...
 dnl **
@@ -534,6 +543,12 @@ else
 	want_truecolor=no
 fi
 
+if test "x$want_gregex" = "xyes"; then
+	AC_DEFINE([USE_GREGEX], [], [use GRegex for regular expressions])
+else
+	want_gregex=no
+fi
+
 AH_TEMPLATE(HAVE_GMODULE)
 AH_TEMPLATE(HAVE_SOCKS_H, [misc..])
 AH_TEMPLATE(HAVE_STATIC_PERL)
@@ -648,6 +663,7 @@ echo
 
 echo "Building with 64bit DCC support .. : $offt_64bit"
 echo "Building with true color support.. : $want_truecolor"
+echo "Building with GRegex ............. : $want_gregex"
 
 echo
 echo "If there are any problems, read the INSTALL file."

--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ AC_PATH_PROG(perlpath, perl)
 AC_CHECK_HEADERS(unistd.h dirent.h sys/ioctl.h sys/resource.h)
 
 # check posix headers..
-AC_CHECK_HEADERS(sys/socket.h sys/time.h sys/utsname.h regex.h)
+AC_CHECK_HEADERS(sys/socket.h sys/time.h sys/utsname.h)
 
 AC_SYS_LARGEFILE
 

--- a/src/common.h
+++ b/src/common.h
@@ -6,7 +6,7 @@
 #define IRSSI_GLOBAL_CONFIG "irssi.conf" /* config file name in /etc/ */
 #define IRSSI_HOME_CONFIG "config" /* config file name in ~/.irssi/ */
 
-#define IRSSI_ABI_VERSION 6
+#define IRSSI_ABI_VERSION 7
 
 #define DEFAULT_SERVER_ADD_PORT 6667
 

--- a/src/core/ignore.c
+++ b/src/core/ignore.c
@@ -67,12 +67,8 @@ static int ignore_match_pattern(IGNORE_REC *rec, const char *text)
 		return FALSE;
 
 	if (rec->regexp) {
-#ifdef HAVE_REGEX_H
 		return rec->regexp_compiled &&
-			regexec(&rec->preg, text, 0, NULL, 0) == 0;
-#else
-                return FALSE;
-#endif
+		    g_regex_match(rec->preg, text, 0, NULL);
 	}
 
 	return rec->fullword ?
@@ -326,26 +322,23 @@ static void ignore_remove_config(IGNORE_REC *rec)
 
 static void ignore_init_rec(IGNORE_REC *rec)
 {
-#ifdef HAVE_REGEX_H
-	char *errbuf;
-	int errcode, errbuf_len;
+	if (rec->regexp_compiled) {
+		g_regex_unref(rec->preg);
+		rec->regexp_compiled = FALSE;
+	}
 
-	if (rec->regexp_compiled) regfree(&rec->preg);
-	rec->regexp_compiled = FALSE;
 	if (rec->regexp && rec->pattern != NULL) {
-		errcode = regcomp(&rec->preg, rec->pattern,
-				REG_EXTENDED|REG_ICASE|REG_NOSUB);
-		if (errcode != 0) {
-			errbuf_len = regerror(errcode, &rec->preg, 0, 0);
-			errbuf = g_malloc(errbuf_len);
-			regerror(errcode, &rec->preg, errbuf, errbuf_len);
-			g_warning("Failed to compile regexp '%s': %s", rec->pattern, errbuf);
-			g_free(errbuf);
+		GError *re_error;
+
+		rec->preg = g_regex_new(rec->pattern, G_REGEX_CASELESS, 0, &re_error);
+
+		if (rec->preg == NULL) {
+			g_warning("Failed to compile regexp '%s': %s", rec->pattern, re_error->message);
+			g_error_free(re_error);
 		} else {
 			rec->regexp_compiled = TRUE;
 		}
 	}
-#endif
 }
 
 void ignore_add_rec(IGNORE_REC *rec)
@@ -365,9 +358,7 @@ static void ignore_destroy(IGNORE_REC *rec, int send_signal)
 	if (send_signal)
 		signal_emit("ignore destroyed", 1, rec);
 
-#ifdef HAVE_REGEX_H
-	if (rec->regexp_compiled) regfree(&rec->preg);
-#endif
+	if (rec->regexp_compiled) g_regex_unref(rec->preg);
 	if (rec->channels != NULL) g_strfreev(rec->channels);
 	g_free_not_null(rec->mask);
 	g_free_not_null(rec->servertag);

--- a/src/core/ignore.c
+++ b/src/core/ignore.c
@@ -328,7 +328,7 @@ static void ignore_init_rec(IGNORE_REC *rec)
 	if (rec->regexp && rec->pattern != NULL) {
 		GError *re_error;
 
-		rec->preg = g_regex_new(rec->pattern, G_REGEX_CASELESS, 0, &re_error);
+		rec->preg = g_regex_new(rec->pattern, G_REGEX_OPTIMIZE | G_REGEX_RAW | G_REGEX_CASELESS, 0, &re_error);
 
 		if (rec->preg == NULL) {
 			g_warning("Failed to compile regexp '%s': %s", rec->pattern, re_error->message);

--- a/src/core/ignore.c
+++ b/src/core/ignore.c
@@ -66,8 +66,10 @@ static int ignore_match_pattern(IGNORE_REC *rec, const char *text)
         if (text == NULL)
 		return FALSE;
 
-	if (rec->regexp)
-		return rec->preg && g_regex_match(rec->preg, text, 0, NULL);
+	if (rec->regexp) {
+		return rec->preg != NULL &&
+			g_regex_match(rec->preg, text, 0, NULL);
+	}
 
 	return rec->fullword ?
 		stristr_full(text, rec->pattern) != NULL :

--- a/src/core/ignore.c
+++ b/src/core/ignore.c
@@ -66,10 +66,8 @@ static int ignore_match_pattern(IGNORE_REC *rec, const char *text)
         if (text == NULL)
 		return FALSE;
 
-	if (rec->regexp) {
-		return rec->regexp_compiled &&
-		    g_regex_match(rec->preg, text, 0, NULL);
-	}
+	if (rec->regexp)
+		return rec->preg && g_regex_match(rec->preg, text, 0, NULL);
 
 	return rec->fullword ?
 		stristr_full(text, rec->pattern) != NULL :
@@ -322,10 +320,8 @@ static void ignore_remove_config(IGNORE_REC *rec)
 
 static void ignore_init_rec(IGNORE_REC *rec)
 {
-	if (rec->regexp_compiled) {
+	if (rec->preg != NULL)
 		g_regex_unref(rec->preg);
-		rec->regexp_compiled = FALSE;
-	}
 
 	if (rec->regexp && rec->pattern != NULL) {
 		GError *re_error;
@@ -335,8 +331,6 @@ static void ignore_init_rec(IGNORE_REC *rec)
 		if (rec->preg == NULL) {
 			g_warning("Failed to compile regexp '%s': %s", rec->pattern, re_error->message);
 			g_error_free(re_error);
-		} else {
-			rec->regexp_compiled = TRUE;
 		}
 	}
 }
@@ -358,7 +352,7 @@ static void ignore_destroy(IGNORE_REC *rec, int send_signal)
 	if (send_signal)
 		signal_emit("ignore destroyed", 1, rec);
 
-	if (rec->regexp_compiled) g_regex_unref(rec->preg);
+	if (rec->preg != NULL) g_regex_unref(rec->preg);
 	if (rec->channels != NULL) g_strfreev(rec->channels);
 	g_free_not_null(rec->mask);
 	g_free_not_null(rec->servertag);

--- a/src/core/ignore.h
+++ b/src/core/ignore.h
@@ -1,10 +1,6 @@
 #ifndef __IGNORE_H
 #define __IGNORE_H
 
-#ifdef HAVE_REGEX_H
-#  include <regex.h>
-#endif
-
 typedef struct _IGNORE_REC IGNORE_REC;
 
 struct _IGNORE_REC {
@@ -20,10 +16,8 @@ struct _IGNORE_REC {
 	unsigned int regexp:1;
 	unsigned int fullword:1;
 	unsigned int replies:1; /* ignore replies to nick in channel */
-#ifdef HAVE_REGEX_H
 	unsigned int regexp_compiled:1; /* should always be TRUE, unless regexp is invalid */
-	regex_t preg;
-#endif
+	GRegex *preg;
 };
 
 extern GSList *ignores;

--- a/src/core/ignore.h
+++ b/src/core/ignore.h
@@ -1,6 +1,10 @@
 #ifndef __IGNORE_H
 #define __IGNORE_H
 
+#ifndef USE_GREGEX
+#  include <regex.h>
+#endif
+
 typedef struct _IGNORE_REC IGNORE_REC;
 
 struct _IGNORE_REC {
@@ -16,7 +20,12 @@ struct _IGNORE_REC {
 	unsigned int regexp:1;
 	unsigned int fullword:1;
 	unsigned int replies:1; /* ignore replies to nick in channel */
+#ifdef USE_GREGEX
 	GRegex *preg;
+#else
+	unsigned int regexp_compiled:1; /* should always be TRUE, unless regexp is invalid */
+	regex_t preg;
+#endif
 };
 
 extern GSList *ignores;

--- a/src/core/ignore.h
+++ b/src/core/ignore.h
@@ -16,7 +16,6 @@ struct _IGNORE_REC {
 	unsigned int regexp:1;
 	unsigned int fullword:1;
 	unsigned int replies:1; /* ignore replies to nick in channel */
-	unsigned int regexp_compiled:1; /* should always be TRUE, unless regexp is invalid */
 	GRegex *preg;
 };
 

--- a/src/core/misc.c
+++ b/src/core/misc.c
@@ -22,10 +22,6 @@
 #include "misc.h"
 #include "commands.h"
 
-#ifdef HAVE_REGEX_H
-#  include <regex.h>
-#endif
-
 typedef struct {
 	int condition;
 	GInputFunction function;

--- a/src/core/misc.c
+++ b/src/core/misc.c
@@ -22,6 +22,10 @@
 #include "misc.h"
 #include "commands.h"
 
+#ifndef USE_GREGEX
+#  include <regex.h>
+#endif
+
 typedef struct {
 	int condition;
 	GInputFunction function;

--- a/src/fe-common/core/fe-ignore.c
+++ b/src/fe-common/core/fe-ignore.c
@@ -58,8 +58,13 @@ static void ignore_print(int index, IGNORE_REC *rec)
 		g_string_append(options, "-regexp ");
 		if (rec->pattern == NULL)
 			g_string_append(options, "[INVALID! -pattern missing] ");
+#ifdef USE_GREGEX
 		else if (rec->preg == NULL)
 			g_string_append(options, "[INVALID!] ");
+#else
+		else if (!rec->regexp_compiled)
+			g_string_append(options, "[INVALID!] ");
+#endif
 	}
 	if (rec->fullword) g_string_append(options, "-full ");
 	if (rec->replies) g_string_append(options, "-replies ");

--- a/src/fe-common/core/fe-ignore.c
+++ b/src/fe-common/core/fe-ignore.c
@@ -58,10 +58,8 @@ static void ignore_print(int index, IGNORE_REC *rec)
 		g_string_append(options, "-regexp ");
 		if (rec->pattern == NULL)
 			g_string_append(options, "[INVALID! -pattern missing] ");
-#ifdef HAVE_REGEX_H
 		else if (!rec->regexp_compiled)
 			g_string_append(options, "[INVALID!] ");
-#endif
 	}
 	if (rec->fullword) g_string_append(options, "-full ");
 	if (rec->replies) g_string_append(options, "-replies ");

--- a/src/fe-common/core/fe-ignore.c
+++ b/src/fe-common/core/fe-ignore.c
@@ -58,7 +58,7 @@ static void ignore_print(int index, IGNORE_REC *rec)
 		g_string_append(options, "-regexp ");
 		if (rec->pattern == NULL)
 			g_string_append(options, "[INVALID! -pattern missing] ");
-		else if (!rec->regexp_compiled)
+		else if (rec->preg == NULL)
 			g_string_append(options, "[INVALID!] ");
 	}
 	if (rec->fullword) g_string_append(options, "-full ");

--- a/src/fe-common/core/hilight-text.c
+++ b/src/fe-common/core/hilight-text.c
@@ -101,7 +101,7 @@ static void hilight_destroy(HILIGHT_REC *rec)
 {
 	g_return_if_fail(rec != NULL);
 
-	if (rec->regexp_compiled) g_regex_unref(rec->preg);
+	if (rec->preg != NULL) g_regex_unref(rec->preg);
 	if (rec->channels != NULL) g_strfreev(rec->channels);
 	g_free_not_null(rec->color);
 	g_free_not_null(rec->act_color);
@@ -118,15 +118,10 @@ static void hilights_destroy_all(void)
 
 static void hilight_init_rec(HILIGHT_REC *rec)
 {
-	if (rec->regexp_compiled) {
+	if (rec->preg != NULL)
 		g_regex_unref(rec->preg);
-		rec->regexp_compiled = FALSE;
-	}
 
 	rec->preg = g_regex_new(rec->text, G_REGEX_CASELESS, 0, NULL);
-
-	if (rec->preg != NULL)
-		rec->regexp_compiled = TRUE;
 }
 
 void hilight_create(HILIGHT_REC *rec)
@@ -201,7 +196,7 @@ static int hilight_match_text(HILIGHT_REC *rec, const char *text,
 	if (rec->regexp) {
 		GMatchInfo *match;
 
-		if (rec->regexp_compiled) {
+		if (rec->preg != NULL) {
 			g_regex_match (rec->preg, text, 0, &match);
 
 			if (g_match_info_matches(match)) {
@@ -504,7 +499,7 @@ static void hilight_print(int index, HILIGHT_REC *rec)
 	if (rec->case_sensitive) g_string_append(options, "-matchcase ");
 	if (rec->regexp) {
 		g_string_append(options, "-regexp ");
-		if (!rec->regexp_compiled)
+		if (rec->preg == NULL)
 			g_string_append(options, "[INVALID!] ");
 	}
 

--- a/src/fe-common/core/hilight-text.h
+++ b/src/fe-common/core/hilight-text.h
@@ -20,7 +20,6 @@ struct _HILIGHT_REC {
 	unsigned int fullword:1; /* match `text' only for full words */
 	unsigned int regexp:1; /* `text' is a regular expression */
 	unsigned int case_sensitive:1;/* `text' must match case */
-	unsigned int regexp_compiled:1; /* should always be TRUE, unless regexp is invalid */
 	GRegex *preg;
 	char *servertag;
 };

--- a/src/fe-common/core/hilight-text.h
+++ b/src/fe-common/core/hilight-text.h
@@ -1,6 +1,10 @@
 #ifndef __HILIGHT_TEXT_H
 #define __HILIGHT_TEXT_H
 
+#ifndef USE_GREGEX
+#  include <regex.h>
+#endif
+
 #include "formats.h"
 
 struct _HILIGHT_REC {
@@ -20,7 +24,12 @@ struct _HILIGHT_REC {
 	unsigned int fullword:1; /* match `text' only for full words */
 	unsigned int regexp:1; /* `text' is a regular expression */
 	unsigned int case_sensitive:1;/* `text' must match case */
+#ifdef USE_GREGEX
 	GRegex *preg;
+#else
+	unsigned int regexp_compiled:1; /* should always be TRUE, unless regexp is invalid */
+	regex_t preg;
+#endif
 	char *servertag;
 };
 

--- a/src/fe-common/core/hilight-text.h
+++ b/src/fe-common/core/hilight-text.h
@@ -1,10 +1,6 @@
 #ifndef __HILIGHT_TEXT_H
 #define __HILIGHT_TEXT_H
 
-#ifdef HAVE_REGEX_H
-#  include <regex.h>
-#endif
-
 #include "formats.h"
 
 struct _HILIGHT_REC {
@@ -24,10 +20,8 @@ struct _HILIGHT_REC {
 	unsigned int fullword:1; /* match `text' only for full words */
 	unsigned int regexp:1; /* `text' is a regular expression */
 	unsigned int case_sensitive:1;/* `text' must match case */
-#ifdef HAVE_REGEX_H
 	unsigned int regexp_compiled:1; /* should always be TRUE, unless regexp is invalid */
-	regex_t preg;
-#endif
+	GRegex *preg;
 	char *servertag;
 };
 

--- a/src/fe-text/textbuffer.c
+++ b/src/fe-text/textbuffer.c
@@ -543,6 +543,8 @@ GList *textbuffer_find_text(TEXT_BUFFER_REC *buffer, LINE_REC *startline,
 	g_return_val_if_fail(buffer != NULL, NULL);
 	g_return_val_if_fail(text != NULL, NULL);
 
+	preg = NULL;
+
 	if (regexp) {
 		preg = g_regex_new(text, (case_sensitive ? 0 : G_REGEX_CASELESS), 0, NULL);
 

--- a/src/fe-text/textbuffer.c
+++ b/src/fe-text/textbuffer.c
@@ -27,10 +27,6 @@
 
 #include "textbuffer.h"
 
-#ifdef HAVE_REGEX_H
-#  include <regex.h>
-#endif
-
 #define TEXT_CHUNK_USABLE_SIZE (LINE_TEXT_CHUNK_SIZE-2-(int)sizeof(char*))
 
 TEXT_BUFFER_REC *textbuffer_create(void)
@@ -537,9 +533,7 @@ GList *textbuffer_find_text(TEXT_BUFFER_REC *buffer, LINE_REC *startline,
 			    int before, int after,
 			    int regexp, int fullword, int case_sensitive)
 {
-#ifdef HAVE_REGEX_H
-	regex_t preg;
-#endif
+	GRegex *preg;
         LINE_REC *line, *pre_line;
 	GList *matches;
 	GString *str;
@@ -550,14 +544,10 @@ GList *textbuffer_find_text(TEXT_BUFFER_REC *buffer, LINE_REC *startline,
 	g_return_val_if_fail(text != NULL, NULL);
 
 	if (regexp) {
-#ifdef HAVE_REGEX_H
-		int flags = REG_EXTENDED | REG_NOSUB |
-			(case_sensitive ? 0 : REG_ICASE);
-		if (regcomp(&preg, text, flags) != 0)
+		preg = g_regex_new(text, (case_sensitive ? 0 : G_REGEX_CASELESS), 0, NULL);
+
+		if (preg == NULL)
 			return NULL;
-#else
-		return NULL;
-#endif
 	}
 
 	matches = NULL; match_after = 0;
@@ -577,12 +567,11 @@ GList *textbuffer_find_text(TEXT_BUFFER_REC *buffer, LINE_REC *startline,
 		if (*text != '\0') {
 			textbuffer_line2text(line, FALSE, str);
 
-			if (line_matched)
-			line_matched =
-#ifdef HAVE_REGEX_H
-			regexp ? regexec(&preg, str->str, 0, NULL, 0) == 0 :
-#endif
-			match_func(str->str, text) != NULL;
+			if (line_matched) {
+				line_matched = regexp ? 
+				    g_regex_match(preg, str->str, 0, NULL) :
+				    match_func(str->str, text) != NULL;
+			}
 		}
 
 		if (line_matched) {
@@ -610,9 +599,9 @@ GList *textbuffer_find_text(TEXT_BUFFER_REC *buffer, LINE_REC *startline,
 				matches = g_list_append(matches, NULL);
 		}
 	}
-#ifdef HAVE_REGEX_H
-	if (regexp) regfree(&preg);
-#endif
+
+	if (regexp)
+		g_regex_unref(preg);
         g_string_free(str, TRUE);
 	return matches;
 }

--- a/src/fe-text/textbuffer.c
+++ b/src/fe-text/textbuffer.c
@@ -570,7 +570,7 @@ GList *textbuffer_find_text(TEXT_BUFFER_REC *buffer, LINE_REC *startline,
 			textbuffer_line2text(line, FALSE, str);
 
 			if (line_matched) {
-				line_matched = regexp ? 
+				line_matched = regexp ?
 				    g_regex_match(preg, str->str, 0, NULL) :
 				    match_func(str->str, text) != NULL;
 			}

--- a/src/fe-text/textbuffer.c
+++ b/src/fe-text/textbuffer.c
@@ -546,7 +546,7 @@ GList *textbuffer_find_text(TEXT_BUFFER_REC *buffer, LINE_REC *startline,
 	preg = NULL;
 
 	if (regexp) {
-		preg = g_regex_new(text, (case_sensitive ? 0 : G_REGEX_CASELESS), 0, NULL);
+		preg = g_regex_new(text, G_REGEX_RAW | (case_sensitive ? 0 : G_REGEX_CASELESS), 0, NULL);
 
 		if (preg == NULL)
 			return NULL;
@@ -602,7 +602,7 @@ GList *textbuffer_find_text(TEXT_BUFFER_REC *buffer, LINE_REC *startline,
 		}
 	}
 
-	if (regexp)
+	if (preg != NULL)
 		g_regex_unref(preg);
         g_string_free(str, TRUE);
 	return matches;


### PR DESCRIPTION
Pros:
- Uniform syntax between systems (as brought up by @wilhelmy)
- More people are familiar with the syntax used by PCRE
- Faster (?)
- More robust utf8 support

Cons:
- People may need to update their regexps
- We need to make sure to feed utf8 encoded strings

This proposal is up for discussion :balloon: 

---

@ailin-nemui
I would really like to see some test cases wrt. UTF8 and with and without the raw flags and some thoughts about how to go best about this (compile 2 regexen and match them depending on utf state?) there is also some secret unicode command flag in pcre iirc, does this apply?
