### PR TITLE
completion: Fix crash when the complist provided by a script has nulls

### DIFF
--- a/src/fe-common/core/completion.c
+++ b/src/fe-common/core/completion.c
@@ -217,6 +217,11 @@ char *word_complete(WINDOW_REC *window, const char *line, int *pos, int erase, i
 		want_space = TRUE;
 		signal_emit("complete word", 5, &complist, window, word, linestart, &want_space);
 		last_want_space = want_space;
+
+		if (complist != NULL) {
+			/* Remove all nulls (from the signal) before doing further processing */
+			complist = g_list_remove_all(g_list_first(complist), NULL);
+		}
 	}
 
 	g_free(linestart);


### PR DESCRIPTION
Can be reproduced with aspell_complete.pl 1.00 by setting an invalid
dictionary with "/set spell_dict a"