### PR TITLE
Add .gitattributes to ensure all shell scripts have LF as eol-style.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# On Windows, some Git clients may normalize all text files' line-endings to
+# CRLF, which causes obscure errors when running shell scripts.
+*.sh	eol=lf


### PR DESCRIPTION
Some Git clients on Windows may use CRLF otherwise, which effectively prevents running such scripts.