### PR TITLE
Use the locale's preferred date format for daychange notifications.

### DIFF
--- a/src/fe-common/core/module-formats.c
+++ b/src/fe-common/core/module-formats.c
@@ -31,7 +31,7 @@ FORMAT_REC fecommon_core_formats[] = {
 	{ "line_start_irssi", "{line_start}{hilight Irssi:} ", 0 },
         { "timestamp", "{timestamp $Z} ", 0 },
 	{ "servertag", "[$0] ", 1, { 0 } },
-	{ "daychange", "Day changed to %%d %%b %%Y", 0 },
+	{ "daychange", "Day changed to %%x", 0 },
 	{ "talking_with", "You are now talking with {nick $0}", 1, { 0 } },
 	{ "refnum_too_low", "Window number must be greater than 1", 0 },
 	{ "error_server_sticky", "Window's server is sticky and it cannot be changed without -unsticky option", 0 },

--- a/src/fe-text/irssi.c
+++ b/src/fe-text/irssi.c
@@ -310,7 +310,7 @@ int main(int argc, char **argv)
 	   before this call.
 
 	   locales aren't actually used for anything else than autodetection
-	   of UTF-8 currently..
+	   of UTF-8 and date formatting at daychange currently..
 
 	   furthermore to get the users's charset with g_get_charset() properly
 	   you have to call setlocale(LC_ALL, "") */


### PR DESCRIPTION
Locale data was already used for formatting dates, but the result is more or less awkward, depending on language.
This commit will change the formatting of the "Day changed to ..." line even for English.

On the other hand, if it is undesirable to change the date format for English, perhaps the date shouldn't obey locale in the first place.
Note that the additional comment to `irssi.c` is already true whether or not this PR is merged or not.