### PR TITLE
Clean up misc.c

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -6,7 +6,7 @@
 #define IRSSI_GLOBAL_CONFIG "irssi.conf" /* config file name in /etc/ */
 #define IRSSI_HOME_CONFIG "config" /* config file name in ~/.irssi/ */
 
-#define IRSSI_ABI_VERSION 5
+#define IRSSI_ABI_VERSION 6
 
 #define DEFAULT_SERVER_ADD_PORT 6667
 

--- a/src/core/ignore.c
+++ b/src/core/ignore.c
@@ -241,7 +241,7 @@ IGNORE_REC *ignore_find_full(const char *servertag, const char *mask, const char
 		if (channels == NULL || rec->channels == NULL)
 			continue; /* other doesn't have channels */
 
-		if (strarray_length(channels) != strarray_length(rec->channels))
+		if (g_strv_length(channels) != g_strv_length(rec->channels))
 			continue; /* different amount of channels */
 
 		/* check that channels match */

--- a/src/core/log.c
+++ b/src/core/log.c
@@ -114,7 +114,7 @@ int log_start_logging(LOG_REC *log)
 		/* path may contain variables (%time, $vars),
 		   make sure the directory is created */
 		dir = g_path_get_dirname(log->real_fname);
-		mkpath(dir, log_dir_create_mode);
+		g_mkdir_with_parents(dir, log_dir_create_mode);
 		g_free(dir);
 	}
 

--- a/src/core/misc.c
+++ b/src/core/misc.c
@@ -150,20 +150,6 @@ int find_substr(const char *list, const char *item)
 	return FALSE;
 }
 
-int strarray_length(char **array)
-{
-	int len;
-
-	g_return_val_if_fail(array != NULL, 0);
-
-	len = 0;
-	while (*array) {
-		len++;
-                array++;
-	}
-        return len;
-}
-
 int strarray_find(char **array, const char *item)
 {
 	char **tmp;

--- a/src/core/misc.c
+++ b/src/core/misc.c
@@ -773,20 +773,6 @@ char *escape_string(const char *str)
 	return ret;
 }
 
-int strocpy(char *dest, const char *src, size_t dstsize)
-{
-	if (dstsize == 0)
-		return -1;
-
-	while (*src != '\0' && dstsize > 1) {
-		*dest++ = *src++;
-		dstsize--;
-	}
-
-	*dest++ = '\0';
-	return *src == '\0' ? 0 : -1;
-}
-
 int nearest_power(int num)
 {
 	int n = 1;

--- a/src/core/misc.c
+++ b/src/core/misc.c
@@ -401,22 +401,15 @@ int g_istr_cmp(gconstpointer v, gconstpointer v2)
 	return g_ascii_strcasecmp((const char *) v, (const char *) v2);
 }
 
-/* a char* hash function from ASU */
-unsigned int g_istr_hash(gconstpointer v)
+guint g_istr_hash(gconstpointer v)
 {
-	const char *s = (const char *) v;
-	unsigned int h = 0, g;
+	const signed char *p;
+	guint32 h = 5381;
 
-	while (*s != '\0') {
-		h = (h << 4) + i_toupper(*s);
-		if ((g = h & 0xf0000000UL)) {
-			h = h ^ (g >> 24);
-			h = h ^ g;
-		}
-		s++;
-	}
+	for (p = v; *p != '\0'; p++)
+		h = (h << 5) + h + g_ascii_toupper(*p);
 
-	return h /* % M */;
+	return h;
 }
 
 /* Find `mask' from `data', you can use * and ? wildcards. */

--- a/src/core/misc.c
+++ b/src/core/misc.c
@@ -407,44 +407,6 @@ int regexp_match(const char *str, const char *regexp)
 #endif
 }
 
-/* Create the directory and all it's parent directories */
-int mkpath(const char *path, int mode)
-{
-	struct stat statbuf;
-	const char *p;
-	char *dir;
-
-	g_return_val_if_fail(path != NULL, -1);
-
-	p = g_path_skip_root((char *) path);
-	if (p == NULL) {
-		/* not a full path, maybe not what we wanted
-		   but continue anyway.. */
-                p = path;
-	}
-	for (;;) {
-		if (*p != G_DIR_SEPARATOR && *p != '\0') {
-			p++;
-			continue;
-		}
-
-		dir = g_strndup(path, (int) (p-path));
-		if (stat(dir, &statbuf) != 0) {
-			if (mkdir(dir, mode) == -1)
-			{
-				g_free(dir);
-				return -1;
-			}
-		}
-		g_free(dir);
-
-		if (*p++ == '\0')
-			break;
-	}
-
-	return 0;
-}
-
 /* convert ~/ to $HOME */
 char *convert_home(const char *path)
 {

--- a/src/core/misc.c
+++ b/src/core/misc.c
@@ -20,6 +20,7 @@
 
 #include "module.h"
 #include "misc.h"
+#include "commands.h"
 
 #ifdef HAVE_REGEX_H
 #  include <regex.h>
@@ -265,14 +266,23 @@ void hash_save_key(char *key, void *value, GSList **list)
         *list = g_slist_append(*list, key);
 }
 
-/* save all keys in hash table to linked list - you shouldn't remove any
-   items while using this list, use g_slist_free() after you're done with it */
-GSList *hashtable_get_keys(GHashTable *hash)
+/* remove all the options from the optlist hash table that are valid for the
+ * command cmd */
+GList *optlist_remove_known(const char *cmd, GHashTable *optlist)
 {
-	GSList *list;
+	GList *list, *tmp, *next;
 
-	list = NULL;
-	g_hash_table_foreach(hash, (GHFunc) hash_save_key, &list);
+	list = g_hash_table_get_keys(optlist);
+	if (cmd != NULL && list != NULL) {
+		for (tmp = list; tmp != NULL; tmp = next) {
+			char *option = tmp->data;
+			next = tmp->next;
+
+			if (command_have_option(cmd, option))
+				list = g_list_remove(list, option);
+		}
+	}
+
 	return list;
 }
 

--- a/src/core/misc.c
+++ b/src/core/misc.c
@@ -375,24 +375,6 @@ char *stristr_full(const char *data, const char *key)
         return strstr_full_case(data, key, TRUE);
 }
 
-int regexp_match(const char *str, const char *regexp)
-{
-#ifdef HAVE_REGEX_H
-	regex_t preg;
-	int ret;
-
-	if (regcomp(&preg, regexp, REG_EXTENDED|REG_ICASE|REG_NOSUB) != 0)
-                return 0;
-
-	ret = regexec(&preg, str, 0, NULL, 0);
-	regfree(&preg);
-
-	return ret == 0;
-#else
-	return FALSE;
-#endif
-}
-
 /* convert ~/ to $HOME */
 char *convert_home(const char *path)
 {

--- a/src/core/misc.c
+++ b/src/core/misc.c
@@ -515,15 +515,11 @@ int dec2octal(int decimal)
 /* string -> uoff_t */
 uoff_t str_to_uofft(const char *str)
 {
-	uoff_t ret;
-
-	ret = 0;
-	while (*str != '\0') {
-		ret = ret*10 + (*str - '0');
-		str++;
-	}
-
-	return ret;
+#ifdef UOFF_T_LONG_LONG
+	return (uoff_t)strtoull(str, NULL, 10);
+#else
+	return (uoff_t)strtoul(str, NULL, 10);
+#endif
 }
 
 /* convert all low-ascii (<32) to ^<A..> combinations */

--- a/src/core/misc.h
+++ b/src/core/misc.h
@@ -36,9 +36,6 @@ char *gslist_to_string(GSList *list, const char *delimiter);
    items while using this list, use g_slist_free() after you're done with it */
 GSList *hashtable_get_keys(GHashTable *hash);
 
-/* easy way to check if regexp matches */
-int regexp_match(const char *str, const char *regexp);
-
 /* convert ~/ to $HOME */
 char *convert_home(const char *path);
 

--- a/src/core/misc.h
+++ b/src/core/misc.h
@@ -102,8 +102,6 @@ char *show_lowascii(const char *str);
 /* replace all `from' chars in string to `to' chars. returns `str' */
 char *replace_chars(char *str, char from, char to);
 
-/* return how many items `array' has */
-int strarray_length(char **array);
 /* return index of `item' in `array' or -1 if not found */
 int strarray_find(char **array, const char *item);
 

--- a/src/core/misc.h
+++ b/src/core/misc.h
@@ -32,9 +32,7 @@ char *gslistptr_to_string(GSList *list, int offset, const char *delimiter);
 /* `list' contains char* */
 char *gslist_to_string(GSList *list, const char *delimiter);
 
-/* save all keys in hash table to linked list - you shouldn't remove any
-   items while using this list, use g_slist_free() after you're done with it */
-GSList *hashtable_get_keys(GHashTable *hash);
+GList *optlist_remove_known(const char *cmd, GHashTable *optlist);
 
 /* convert ~/ to $HOME */
 char *convert_home(const char *path);

--- a/src/core/misc.h
+++ b/src/core/misc.h
@@ -83,9 +83,6 @@ int parse_size(const char *size, int *bytes);
    Stop when `end_char' is found from string. */
 int is_numeric(const char *str, char end_char);
 
-/* Like strlcpy(), but return -1 if buffer was overflown, 0 if not. */
-int strocpy(char *dest, const char *src, size_t dstsize);
-
 /* strstr() with case-ignoring */
 char *stristr(const char *data, const char *key);
 

--- a/src/core/misc.h
+++ b/src/core/misc.h
@@ -39,8 +39,6 @@ GSList *hashtable_get_keys(GHashTable *hash);
 /* easy way to check if regexp matches */
 int regexp_match(const char *str, const char *regexp);
 
-/* Create the directory and all it's parent directories */
-int mkpath(const char *path, int mode);
 /* convert ~/ to $HOME */
 char *convert_home(const char *path);
 

--- a/src/core/network.h
+++ b/src/core/network.h
@@ -37,7 +37,7 @@ GIOChannel *g_io_channel_new(int handle);
 int net_ip_compare(IPADDR *ip1, IPADDR *ip2);
 
 /* Connect to socket */
-GIOChannel *net_connect(const char *addr, int port, IPADDR *my_ip);
+GIOChannel *net_connect(const char *addr, int port, IPADDR *my_ip) G_GNUC_DEPRECATED;
 /* Connect to socket with ip address and SSL*/
 GIOChannel *net_connect_ip_ssl(IPADDR *ip, int port, IPADDR *my_ip, SERVER_REC *server);
 int irssi_ssl_handshake(GIOChannel *handle);

--- a/src/core/rawlog.c
+++ b/src/core/rawlog.c
@@ -157,6 +157,11 @@ void rawlog_save(RAWLOG_REC *rawlog, const char *fname)
 	f = open(path, O_WRONLY | O_APPEND | O_CREAT, log_file_create_mode);
 	g_free(path);
 
+	if (f < 0) {
+		g_warning("rawlog open() failed: %s", strerror(errno));
+		return;
+	}
+
 	rawlog_dump(rawlog, f);
 	close(f);
 }

--- a/src/core/rawlog.c
+++ b/src/core/rawlog.c
@@ -150,7 +150,7 @@ void rawlog_save(RAWLOG_REC *rawlog, const char *fname)
 	int f;
 
         dir = g_path_get_dirname(fname);
-        mkpath(dir, log_dir_create_mode);
+        g_mkdir_with_parents(dir, log_dir_create_mode);
         g_free(dir);
 
 	path = convert_home(fname);

--- a/src/core/servers.c
+++ b/src/core/servers.c
@@ -684,21 +684,11 @@ SERVER_REC *cmd_options_get_server(const char *cmd,
 				   SERVER_REC *defserver)
 {
 	SERVER_REC *server;
-	GSList *list, *tmp, *next;
+	GList *list;
 
 	/* get all the options, then remove the known ones. there should
 	   be only one left - the server tag. */
-	list = hashtable_get_keys(optlist);
-	if (cmd != NULL) {
-		for (tmp = list; tmp != NULL; tmp = next) {
-			char *option = tmp->data;
-			next = tmp->next;
-
-			if (command_have_option(cmd, option))
-				list = g_slist_remove(list, option);
-		}
-	}
-
+	list = optlist_remove_known(cmd, optlist);
 	if (list == NULL)
 		return defserver;
 
@@ -713,7 +703,7 @@ SERVER_REC *cmd_options_get_server(const char *cmd,
 		server = NULL;
 	}
 
-	g_slist_free(list);
+	g_list_free(list);
 	return server;
 }
 

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -683,7 +683,7 @@ static void init_configfile(void)
 
 	if (stat(get_irssi_dir(), &statbuf) != 0) {
 		/* ~/.irssi not found, create it. */
-		if (mkpath(get_irssi_dir(), 0700) != 0) {
+		if (g_mkdir_with_parents(get_irssi_dir(), 0700) != 0) {
 			g_error("Couldn't create %s directory", get_irssi_dir());
 		}
 	} else if (!S_ISDIR(statbuf.st_mode)) {

--- a/src/core/special-vars.c
+++ b/src/core/special-vars.c
@@ -44,7 +44,7 @@ static char *get_argument(char **cmd, char **arglist)
 	arg = 0;
 	max = -1;
 
-	argcount = arglist == NULL ? 0 : strarray_length(arglist);
+	argcount = arglist == NULL ? 0 : g_strv_length(arglist);
 
 	if (**cmd == '*') {
 		/* get all arguments */

--- a/src/fe-common/core/fe-exec.c
+++ b/src/fe-common/core/fe-exec.c
@@ -237,22 +237,13 @@ static int signal_name_to_id(const char *name)
 static int cmd_options_get_signal(const char *cmd,
 				  GHashTable *optlist)
 {
-	GSList *list, *tmp, *next;
+	GList *list;
 	char *signame;
         int signum;
 
 	/* get all the options, then remove the known ones. there should
 	   be only one left - the signal */
-	list = hashtable_get_keys(optlist);
-	if (cmd != NULL) {
-		for (tmp = list; tmp != NULL; tmp = next) {
-			char *option = tmp->data;
-			next = tmp->next;
-
-			if (command_have_option(cmd, option))
-				list = g_slist_remove(list, option);
-		}
-	}
+	list = optlist_remove_known(cmd, optlist);
 
 	if (list == NULL)
 		return -1;
@@ -272,7 +263,7 @@ static int cmd_options_get_signal(const char *cmd,
                 return -2;
 	}
 
-	g_slist_free(list);
+	g_list_free(list);
 	return signum;
 }
 

--- a/src/fe-common/core/fe-log.c
+++ b/src/fe-common/core/fe-log.c
@@ -453,7 +453,7 @@ static void autolog_open(SERVER_REC *server, const char *server_tag,
 		log_item_add(log, LOG_ITEM_TARGET, target, server_tag);
 
 		dir = g_path_get_dirname(log->real_fname);
-		mkpath(dir, log_dir_create_mode);
+		g_mkdir_with_parents(dir, log_dir_create_mode);
 		g_free(dir);
 
 		log->temp = TRUE;

--- a/src/fe-common/core/hilight-text.c
+++ b/src/fe-common/core/hilight-text.c
@@ -178,7 +178,7 @@ static HILIGHT_REC *hilight_find(const char *text, char **channels)
 		if (channels == NULL || rec->channels == NULL)
 			continue; /* other doesn't have channels */
 
-		if (strarray_length(channels) != strarray_length(rec->channels))
+		if (g_strv_length(channels) != g_strv_length(rec->channels))
 			continue; /* different amount of channels */
 
 		/* check that channels match */

--- a/src/fe-text/lastlog.c
+++ b/src/fe-text/lastlog.c
@@ -39,21 +39,10 @@
    Returns -1 if unknown option was given. */
 int cmd_options_get_level(const char *cmd, GHashTable *optlist)
 {
-	GSList *list, *tmp, *next;
+	GList *list;
         int level, retlevel;
 
-	/* get all the options, then remove the known ones. there should
-	   be only one left - the server tag. */
-	list = hashtable_get_keys(optlist);
-	if (cmd != NULL) {
-		for (tmp = list; tmp != NULL; tmp = next) {
-			char *option = tmp->data;
-			next = tmp->next;
-
-			if (command_have_option(cmd, option))
-				list = g_slist_remove(list, option);
-		}
-	}
+	list = optlist_remove_known(cmd, optlist);
 
         retlevel = 0;
 	while (list != NULL) {
@@ -68,7 +57,7 @@ int cmd_options_get_level(const char *cmd, GHashTable *optlist)
 		}
 
 		retlevel |= level;
-                list = g_slist_remove(list, list->data);
+                list = g_list_remove(list, list->data);
 	}
 
 	return retlevel;

--- a/src/irc/core/irc-nicklist.c
+++ b/src/irc/core/irc-nicklist.c
@@ -48,7 +48,7 @@ NICK_REC *irc_nicklist_insert(IRC_CHANNEL_REC *channel, const char *nick,
 	rec->send_massjoin = send_massjoin;
 
 	if (prefixes != NULL) {
-		strocpy(rec->prefixes, prefixes, sizeof(rec->prefixes));
+		g_strlcpy(rec->prefixes, prefixes, sizeof(rec->prefixes));
 	}
 
 	nicklist_insert(CHANNEL(channel), rec);

--- a/src/irc/core/irc-servers.c
+++ b/src/irc/core/irc-servers.c
@@ -212,7 +212,6 @@ static void server_init(IRC_SERVER_REC *server)
 {
 	IRC_SERVER_CONNECT_REC *conn;
 	char *address, *ptr, *username, *cmd;
-	GTimeVal now;
 
 	g_return_if_fail(server != NULL);
 
@@ -287,9 +286,8 @@ static void server_init(IRC_SERVER_REC *server)
 
 	/* prevent the queue from sending too early, we have a max cut off of 120 secs */
 	/* this will reset to 1 sec after we get the 001 event */
-	g_get_current_time(&now);
-	memcpy(&((IRC_SERVER_REC *)server)->wait_cmd, &now, sizeof(GTimeVal));
-	((IRC_SERVER_REC *)server)->wait_cmd.tv_sec += 120;
+	g_get_current_time(&server->wait_cmd);
+	g_time_val_add(&server->wait_cmd, 120 * G_USEC_PER_SEC);
 }
 
 SERVER_REC *irc_server_init_connect(SERVER_CONNECT_REC *conn)
@@ -535,7 +533,7 @@ void irc_server_send_data(IRC_SERVER_REC *server, const char *data, int len)
 		server->wait_cmd.tv_sec = 0;
 	else {
 		memcpy(&server->wait_cmd, &server->last_cmd, sizeof(GTimeVal));
-		server->wait_cmd.tv_sec += 2 + len/100;
+		g_time_val_add(&server->wait_cmd, (2 + len/100) * G_USEC_PER_SEC);
 	}
 }
 
@@ -695,7 +693,6 @@ char *irc_server_get_channels(IRC_SERVER_REC *server)
 static void event_connected(IRC_SERVER_REC *server, const char *data, const char *from)
 {
 	char *params, *nick;
-	GTimeVal now;
 
 	g_return_if_fail(server != NULL);
 
@@ -718,8 +715,7 @@ static void event_connected(IRC_SERVER_REC *server, const char *data, const char
 	server->real_connect_time = time(NULL);
 
 	/* let the queue send now that we are identified */
-	g_get_current_time(&now);
-	memcpy(&server->wait_cmd, &now, sizeof(GTimeVal));
+	g_get_current_time(&server->wait_cmd);
 
 	if (server->connrec->usermode != NULL) {
 		/* Send the user mode, before the autosendcmd.

--- a/src/irc/dcc/dcc-chat.c
+++ b/src/irc/dcc/dcc-chat.c
@@ -619,7 +619,7 @@ static void ctcp_msg_dcc_chat(IRC_SERVER_REC *server, const char *data,
         /* CHAT <unused> <address> <port> */
 	/* CHAT <unused> <address> 0 <id> (DCC CHAT passive protocol) */
 	params = g_strsplit(data, " ", -1);
-	paramcount = strarray_length(params);
+	paramcount = g_strv_length(params);
 
 	if (paramcount < 3) {
 		g_strfreev(params);

--- a/src/irc/dcc/dcc-get.c
+++ b/src/irc/dcc/dcc-get.c
@@ -423,7 +423,7 @@ static void ctcp_msg_dcc_send(IRC_SERVER_REC *server, const char *data,
 	/* SEND <file name> <address> <port> <size> [...] */
 	/* SEND <file name> <address> 0 <size> <id> (DCC SEND passive protocol) */
 	params = g_strsplit(data, " ", -1);
-	paramcount = strarray_length(params);
+	paramcount = g_strv_length(params);
 
 	if (paramcount < 4) {
 		signal_emit("dcc error ctcp", 5, "SEND", data,

--- a/src/irc/dcc/dcc-get.c
+++ b/src/irc/dcc/dcc-get.c
@@ -473,8 +473,8 @@ static void ctcp_msg_dcc_send(IRC_SERVER_REC *server, const char *data,
 				net_ip2host(&temp_dcc->addr, temp_dcc->addrstr);
 			else {
 				/* with IPv6, show it to us as it was sent */
-				strocpy(temp_dcc->addrstr, address,
-					sizeof(temp_dcc->addrstr));
+				g_strlcpy(temp_dcc->addrstr, address,
+					  sizeof(temp_dcc->addrstr));
 			}
 
 			/* This new signal is added to let us invoke
@@ -508,7 +508,7 @@ static void ctcp_msg_dcc_send(IRC_SERVER_REC *server, const char *data,
 		net_ip2host(&dcc->addr, dcc->addrstr);
 	else {
 		/* with IPv6, show it to us as it was sent */
-		strocpy(dcc->addrstr, address, sizeof(dcc->addrstr));
+		g_strlcpy(dcc->addrstr, address, sizeof(dcc->addrstr));
 	}
 	dcc->port = port;
 	dcc->size = size;

--- a/src/irc/dcc/dcc-resume.c
+++ b/src/irc/dcc/dcc-resume.c
@@ -88,7 +88,7 @@ static int dcc_ctcp_resume_parse(int type, const char *data, const char *nick,
 	/* RESUME|ACCEPT <file name> <port> <size> */
 	/* RESUME|ACCEPT <file name> 0 <size> <id> (passive protocol) */
 	params = g_strsplit(data, " ", -1);
-	paramcount = strarray_length(params);
+	paramcount = g_strv_length(params);
 
 	if (paramcount < 3)
 		return 0;

--- a/src/irc/dcc/dcc-server.c
+++ b/src/irc/dcc/dcc-server.c
@@ -245,7 +245,7 @@ static void dcc_server_msg(SERVER_DCC_REC *dcc, const char *msg)
 
 			/* 120 clientnickname filesize filename */
 			params = g_strsplit(msg, " ", -1);
-			paramcount = strarray_length(params);
+			paramcount = g_strv_length(params);
 
 			if (paramcount < 3) {
 				g_strfreev(params);


### PR DESCRIPTION
The weekend's approaching, feel free to review this and/or pick some of the suggestions below:

- [x] `find_substr` could be replaced by something less hairy and simple
- [ ] `gslist_find_{,icase}_string` could be implemented in terms of `g_slist_find_custom`
- [ ] Same as above for `gslist_foreach_find`
- [ ] `stristr` can be replaced with the nonstandard but portable `strcasestr`
- [ ] `strstr_full_case` could be implemented in terms of the above or via a regexp
- [ ] `convert_home` should support the more generic `~USERNAME/` format
- [x] `g_istr_hash` could use the `djb` hash function (the same used by the case-sensitive version)
- [ ] `match_wildcards` sounds like something that a regexp could do just fine
- [ ] `str_to_uofft` doesn't care about overflowing nor about errors