### PR TITLE
fix SASL EXTERNAL

### DIFF
--- a/src/irc/core/sasl.c
+++ b/src/irc/core/sasl.c
@@ -145,7 +145,7 @@ static void sasl_step(IRC_SERVER_REC *server, const char *data, const char *from
 
 		case SASL_MECHANISM_EXTERNAL:
 			/* Empty response */
-			irc_send_cmdv(server, "+");
+			irc_send_cmdv(server, "AUTHENTICATE +");
 			break;
 	}
 


### PR DESCRIPTION
First commit makes the authentication actually _work_ rather than hanging on "You have not registered".

<del>Second commit adds authzid support, similar to how it is implemented in PLAIN</del>.

[As tradition goes,](https://github.com/irssi/irssi/commit/b8d3301d34f383f039071214872570385de1bb59) the latter is untested as of now.