### PR TITLE
Clear error queue before SSL I/O operations

### DIFF
--- a/src/core/network-openssl.c
+++ b/src/core/network-openssl.c
@@ -473,6 +473,7 @@ static GIOChannel *irssi_ssl_get_iochannel(GIOChannel *handle, int port, SERVER_
 	if(!(fd = g_io_channel_unix_get_fd(handle)))
 		return NULL;
 
+	ERR_clear_error();
 	ctx = SSL_CTX_new(SSLv23_client_method());
 	if (ctx == NULL) {
 		g_error("Could not allocate memory for SSL context");
@@ -491,6 +492,7 @@ static GIOChannel *irssi_ssl_get_iochannel(GIOChannel *handle, int port, SERVER_
 		scert = convert_home(mycert);
 		if (mypkey && *mypkey)
 			spkey = convert_home(mypkey);
+		ERR_clear_error();
 		if (! SSL_CTX_use_certificate_file(ctx, scert, SSL_FILETYPE_PEM))
 			g_warning("Loading of client certificate '%s' failed: %s", mycert, ERR_reason_error_string(ERR_get_error()));
 		else if (! SSL_CTX_use_PrivateKey_file(ctx, spkey ? spkey : scert, SSL_FILETYPE_PEM))

--- a/src/core/network-openssl.c
+++ b/src/core/network-openssl.c
@@ -289,6 +289,7 @@ static GIOStatus irssi_ssl_read(GIOChannel *handle, gchar *buf, gsize len, gsize
 	const char *errstr;
 	gchar *errmsg;
 
+	ERR_clear_error();
 	ret1 = SSL_read(chan->ssl, buf, len);
 	if(ret1 <= 0)
 	{
@@ -334,6 +335,7 @@ static GIOStatus irssi_ssl_write(GIOChannel *handle, const gchar *buf, gsize len
 	const char *errstr;
 	gchar *errmsg;
 
+	ERR_clear_error();
 	ret1 = SSL_write(chan->ssl, (const char *)buf, len);
 	if(ret1 <= 0)
 	{
@@ -581,6 +583,7 @@ int irssi_ssl_handshake(GIOChannel *handle)
 	X509 *cert;
 	const char *errstr;
 
+	ERR_clear_error();
 	ret = SSL_connect(chan->ssl);
 	if (ret <= 0) {
 		err = SSL_get_error(chan->ssl, ret);


### PR DESCRIPTION
We need to clear the SSL error queue before performing SSL I/O operations. Otherwise we can see errors that are not related to the operation we error check. SSL_get_error() inspects the thread's error queue.

I read about this here: https://www.openssl.org/docs/manmaster/ssl/SSL_get_error.html where it says "The current thread's error queue must be empty before the TLS/SSL I/O operation is attempted, or SSL_get_error() will not work reliably."

How I came across this: I have a module (irssi-tcl) that itself initiates SSL connections through scripts (HTTP in the case I found). For some URLs I found that Irssi was complaining about read errors after SSL_read() and then dropping all the active SSL IRC connections. I would see "Irssi: warning SSL read error: No such file or directory". I found the condition being hit in irssi_ssl_read() was the 'SSL_ERROR_SYSCALL' one.

Unfortunately it does not always happen so it is difficult to reliably reproduce. However after applying this change I have not been able to cause it.