### PR TITLE
Replace spaces with tabs

### DIFF
--- a/src/core/chat-commands.c
+++ b/src/core/chat-commands.c
@@ -117,8 +117,8 @@ static SERVER_CONNECT_REC *get_server_connect(const char *data, int *plus_addr,
 	if (g_hash_table_lookup(optlist, "!") != NULL)
 		conn->no_autojoin_channels = TRUE;
 
-    if (g_hash_table_lookup(optlist, "noautosendcmd") != NULL)
-        conn->no_autosendcmd = TRUE;
+	if (g_hash_table_lookup(optlist, "noautosendcmd") != NULL)
+		conn->no_autosendcmd = TRUE;
 
 	if (g_hash_table_lookup(optlist, "noproxy") != NULL)
                 g_free_and_null(conn->proxy);


### PR DESCRIPTION
Fix a new gcc6 warning.
```
  CC       chat-commands.o
chat-commands.c: In function ‘get_server_connect’:
chat-commands.c:123:2: warning: statement is indented as if it were guarded by... [-Wmisleading-indentation]
  if (g_hash_table_lookup(optlist, "noproxy") != NULL)
  ^~
chat-commands.c:120:5: note: ...this ‘if’ clause, but it is not
     if (g_hash_table_lookup(optlist, "noautosendcmd") != NULL)
     ^~
  CC       chat-protocols.o
```