### PR TITLE
terminfo-core: Don't send smkx/rmkx

### DIFF
--- a/src/fe-text/terminfo-core.c
+++ b/src/fe-text/terminfo-core.c
@@ -532,9 +532,6 @@ void terminfo_cont(TERM_REC *term)
 	if (term->TI_smcup)
 		tput(tparm(term->TI_smcup));
 
-	if (term->TI_smkx)
-		tput(tparm(term->TI_smkx));
-
         terminfo_input_init(term);
 }
 
@@ -548,9 +545,6 @@ void terminfo_stop(TERM_REC *term)
 	/* stop cup-mode */
 	if (term->TI_rmcup)
 		tput(tparm(term->TI_rmcup));
-
-	if (term->TI_rmkx)
-		tput(tparm(term->TI_rmkx));
 
         /* reset input settings */
 	terminfo_input_deinit(term);


### PR DESCRIPTION
Partially reverts b5b73cb.

Partially, because the commit is mostly unrelated whitespace changes, but also because I left the TI_smkx and TI_rmkx caps in there, to reconsider later.

-----

Fixes #430.

As the branch name says, this is the lazy solution to the problem. We're a bit tight on time and the not-lazy one might break more than it fixes.

(Also, I personally use st and don't even have that kind of backspace/del behavior. I must have "accidentally" fixed it by editing the config file)

If someone cares we should make this a setting, but that's after the bugfix release.