### PR TITLE
Don't call terminfo_cont() twice on resume

### DIFF
--- a/src/fe-text/term-terminfo.c
+++ b/src/fe-text/term-terminfo.c
@@ -611,8 +611,6 @@ void term_stop(void)
 {
 	terminfo_stop(current_term);
 	kill(getpid(), SIGTSTP);
-	terminfo_cont(current_term);
-	irssi_redraw();
 }
 
 static int input_utf8(const unsigned char *buffer, int size, unichar *result)


### PR DESCRIPTION
It was only called to push the current state onto the stack since the
terminal would be reset in the SIGCONT handler.
Fixes some weirdness when using ^Z with zsh.

Fixes #450, at least for me.