### PR TITLE
improved cutbuffer handling

### DIFF
--- a/src/fe-text/gui-entry.c
+++ b/src/fe-text/gui-entry.c
@@ -32,6 +32,8 @@
 #undef i_tolower
 #undef i_isalnum
 
+#define KILL_RING_MAX 10
+
 static unichar i_toupper(unichar c)
 {
 	if (term_type == TERM_TYPE_UTF8)
@@ -82,10 +84,21 @@ GUI_ENTRY_REC *gui_entry_create(int xpos, int ypos, int width, int utf8)
 
 void gui_entry_destroy(GUI_ENTRY_REC *entry)
 {
+	GSList *tmp;
+
         g_return_if_fail(entry != NULL);
 
 	if (active_entry == entry)
 		gui_entry_set_active(NULL);
+
+	for (tmp = entry->kill_ring; tmp != NULL; tmp = tmp->next) {
+		GUI_ENTRY_CUTBUFFER_REC *rec = tmp->data;
+		if (rec != NULL) {
+			g_free(rec->cutbuffer);
+			g_free(rec);
+		}
+	}
+	g_slist_free(entry->kill_ring);
 
         g_free(entry->text);
 	g_free(entry->prompt);
@@ -546,20 +559,40 @@ char *gui_entry_get_cutbuffer(GUI_ENTRY_REC *entry)
 
 	g_return_val_if_fail(entry != NULL, NULL);
 
-	if (entry->cutbuffer == NULL)
+	if (entry->kill_ring == NULL || entry->kill_ring->data == NULL)
+		return NULL;
+
+	GUI_ENTRY_CUTBUFFER_REC *tmp = entry->kill_ring->data;
+
+	if (tmp->cutbuffer == NULL)
                 return NULL;
 
 	if (entry->utf8)
-		buf = g_ucs4_to_utf8(entry->cutbuffer, -1, NULL, NULL, NULL);
+		buf = g_ucs4_to_utf8(tmp->cutbuffer, -1, NULL, NULL, NULL);
 	else {
-		buf = g_malloc(entry->cutbuffer_len*6 + 1);
+		buf = g_malloc(tmp->cutbuffer_len*6 + 1);
 		if (term_type == TERM_TYPE_BIG5)
-			unichars_to_big5(entry->cutbuffer, buf);
+			unichars_to_big5(tmp->cutbuffer, buf);
 		else
-			for (i = 0; i <= entry->cutbuffer_len; i++)
-				buf[i] = entry->cutbuffer[i];
+			for (i = 0; i <= tmp->cutbuffer_len; i++)
+				buf[i] = tmp->cutbuffer[i];
 	}
 	return buf;
+}
+
+char *gui_entry_get_next_cutbuffer(GUI_ENTRY_REC *entry)
+{
+	g_return_val_if_fail(entry != NULL, NULL);
+
+	if (entry->kill_ring == NULL)
+		return NULL;
+
+	GUI_ENTRY_CUTBUFFER_REC *tmp = entry->kill_ring->data;
+
+	entry->kill_ring = g_slist_remove(entry->kill_ring, tmp);
+	entry->kill_ring = g_slist_append(entry->kill_ring, tmp);
+
+	return gui_entry_get_cutbuffer(entry);
 }
 
 void gui_entry_erase_to(GUI_ENTRY_REC *entry, int pos, CUTBUFFER_UPDATE_OP update_cutbuffer)
@@ -573,6 +606,40 @@ void gui_entry_erase_to(GUI_ENTRY_REC *entry, int pos, CUTBUFFER_UPDATE_OP updat
 	gui_entry_erase(entry, size, update_cutbuffer);
 }
 
+static GUI_ENTRY_CUTBUFFER_REC *get_cutbuffer_rec(GUI_ENTRY_REC *entry, CUTBUFFER_UPDATE_OP update_cutbuffer)
+{
+	GUI_ENTRY_CUTBUFFER_REC *tmp = NULL;
+
+	g_return_val_if_fail(entry != NULL, NULL);
+
+	if (entry->kill_ring == NULL) {
+		/* no kill ring exists */
+		entry->kill_ring = g_slist_prepend(entry->kill_ring, (void *)NULL);
+	} else {
+		tmp = entry->kill_ring->data;
+
+		if (tmp != NULL && tmp->cutbuffer_len > 0
+		    && (!entry->previous_append_next_kill
+			|| update_cutbuffer == CUTBUFFER_UPDATE_REPLACE)) {
+			/* a cutbuffer exists and should be replaced */
+			entry->kill_ring = g_slist_prepend(entry->kill_ring, (void *)NULL);
+		}
+	}
+
+	if (g_slist_length(entry->kill_ring) > KILL_RING_MAX) {
+		GUI_ENTRY_CUTBUFFER_REC *rec = g_slist_last(entry->kill_ring)->data;
+		entry->kill_ring = g_slist_remove(entry->kill_ring, rec);
+		if (rec != NULL) g_free(rec->cutbuffer);
+		g_free(rec);
+	}
+
+	if (entry->kill_ring->data == NULL) {
+		entry->kill_ring->data = g_new0(GUI_ENTRY_CUTBUFFER_REC, 1);
+	}
+
+	return entry->kill_ring->data;
+}
+
 void gui_entry_erase(GUI_ENTRY_REC *entry, int size, CUTBUFFER_UPDATE_OP update_cutbuffer)
 {
 	size_t w = 0;
@@ -582,51 +649,59 @@ void gui_entry_erase(GUI_ENTRY_REC *entry, int size, CUTBUFFER_UPDATE_OP update_
 	if (size == 0 || entry->pos < size)
 		return;
 
-	if (update_cutbuffer != CUTBUFFER_UPDATE_NOOP
-	    && entry->cutbuffer_len == 0) {
-		update_cutbuffer = CUTBUFFER_UPDATE_REPLACE;
-	}
-	int cutbuffer_new_size = entry->cutbuffer_len + size;
-	unichar *tmpcutbuffer = entry->cutbuffer;
-	switch (update_cutbuffer) {
-		case CUTBUFFER_UPDATE_APPEND:
-			entry->cutbuffer = g_new(unichar, cutbuffer_new_size+1);
-			memcpy(entry->cutbuffer, tmpcutbuffer,
-					entry->cutbuffer_len * sizeof(unichar));
-			memcpy(entry->cutbuffer + entry->cutbuffer_len * sizeof(unichar),
-					entry->text + entry->pos - size, size * sizeof(unichar));
+	if (update_cutbuffer != CUTBUFFER_UPDATE_NOOP) {
+		int cutbuffer_new_size;
+		unichar *tmpcutbuffer;
+		GUI_ENTRY_CUTBUFFER_REC *tmp = get_cutbuffer_rec(entry, update_cutbuffer);
 
-			entry->cutbuffer_len = cutbuffer_new_size;
-			entry->cutbuffer[cutbuffer_new_size] = '\0';
-			g_free(tmpcutbuffer);
-			break;
+		if (tmp->cutbuffer_len == 0) {
+			update_cutbuffer = CUTBUFFER_UPDATE_REPLACE;
+		}
 
-		case CUTBUFFER_UPDATE_PREPEND:
-			entry->cutbuffer = g_new(unichar, cutbuffer_new_size+1);
-			memcpy(entry->cutbuffer, entry->text + entry->pos - size,
-					size * sizeof(unichar));
-			memcpy(entry->cutbuffer + size, tmpcutbuffer,
-					entry->cutbuffer_len * sizeof(unichar));
+		cutbuffer_new_size = tmp->cutbuffer_len + size;
+		tmpcutbuffer = tmp->cutbuffer;
+		entry->append_next_kill = TRUE;
+		switch (update_cutbuffer) {
+			case CUTBUFFER_UPDATE_APPEND:
+				tmp->cutbuffer = g_new(unichar, cutbuffer_new_size+1);
+				memcpy(tmp->cutbuffer, tmpcutbuffer,
+				       tmp->cutbuffer_len * sizeof(unichar));
+				memcpy(tmp->cutbuffer + tmp->cutbuffer_len * sizeof(unichar),
+				       entry->text + entry->pos - size, size * sizeof(unichar));
 
-			entry->cutbuffer_len = cutbuffer_new_size;
-			entry->cutbuffer[cutbuffer_new_size] = '\0';
-			g_free(tmpcutbuffer);
-			break;
+				tmp->cutbuffer_len = cutbuffer_new_size;
+				tmp->cutbuffer[cutbuffer_new_size] = '\0';
+				g_free(tmpcutbuffer);
+				break;
 
-		case CUTBUFFER_UPDATE_REPLACE:
-			/* put erased text to cutbuffer */
-			if (entry->cutbuffer_len < size) {
-				g_free(entry->cutbuffer);
-				entry->cutbuffer = g_new(unichar, size+1);
-			}
+			case CUTBUFFER_UPDATE_PREPEND:
+				tmp->cutbuffer = g_new(unichar, cutbuffer_new_size+1);
+				memcpy(tmp->cutbuffer, entry->text + entry->pos - size,
+				       size * sizeof(unichar));
+				memcpy(tmp->cutbuffer + size, tmpcutbuffer,
+				       tmp->cutbuffer_len * sizeof(unichar));
 
-			entry->cutbuffer_len = size;
-			entry->cutbuffer[size] = '\0';
-			memcpy(entry->cutbuffer, entry->text + entry->pos - size, size * sizeof(unichar));
-			break;
+				tmp->cutbuffer_len = cutbuffer_new_size;
+				tmp->cutbuffer[cutbuffer_new_size] = '\0';
+				g_free(tmpcutbuffer);
+				break;
 
-		case CUTBUFFER_UPDATE_NOOP:
-			break;
+			case CUTBUFFER_UPDATE_REPLACE:
+				/* put erased text to cutbuffer */
+				if (tmp->cutbuffer_len < size) {
+					g_free(tmp->cutbuffer);
+					tmp->cutbuffer = g_new(unichar, size+1);
+				}
+
+				tmp->cutbuffer_len = size;
+				tmp->cutbuffer[size] = '\0';
+				memcpy(tmp->cutbuffer, entry->text + entry->pos - size, size * sizeof(unichar));
+				break;
+
+			case CUTBUFFER_UPDATE_NOOP:
+				/* cannot happen, handled in "if" */
+				break;
+		}
 	}
 
 	if (entry->utf8)
@@ -686,10 +761,10 @@ void gui_entry_erase_word(GUI_ENTRY_REC *entry, int to_space, CUTBUFFER_UPDATE_O
 	}
 	if (to > 0) to++;
 
-	gui_entry_erase(entry, entry->pos-to, CUTBUFFER_UPDATE_REPLACE);
+	gui_entry_erase(entry, entry->pos-to, cutbuffer_op);
 }
 
-void gui_entry_erase_next_word(GUI_ENTRY_REC *entry, int to_space)
+void gui_entry_erase_next_word(GUI_ENTRY_REC *entry, int to_space, CUTBUFFER_UPDATE_OP cutbuffer_op)
 {
 	int to, size;
 
@@ -712,7 +787,7 @@ void gui_entry_erase_next_word(GUI_ENTRY_REC *entry, int to_space)
 
         size = to-entry->pos;
 	entry->pos = to;
-        gui_entry_erase(entry, size, CUTBUFFER_UPDATE_REPLACE);
+        gui_entry_erase(entry, size, cutbuffer_op);
 }
 
 void gui_entry_transpose_chars(GUI_ENTRY_REC *entry)

--- a/src/fe-text/gui-entry.h
+++ b/src/fe-text/gui-entry.h
@@ -2,11 +2,15 @@
 #define __GUI_ENTRY_H
 
 typedef struct {
+        int cutbuffer_len;
+	unichar *cutbuffer;
+} GUI_ENTRY_CUTBUFFER_REC;
+
+typedef struct {
 	int text_len, text_alloc; /* as shorts, not chars */
 	unichar *text;
 
-        int cutbuffer_len;
-	unichar *cutbuffer;
+	GSList *kill_ring;
 
         /* all as shorts, not chars */
 	int xpos, ypos, width; /* entry position in screen */
@@ -18,6 +22,10 @@ typedef struct {
 
 	int redraw_needed_from;
 	unsigned int utf8:1;
+
+	unsigned int previous_append_next_kill:1;
+	unsigned int append_next_kill:1;
+	unsigned int yank_preceded:1;
 } GUI_ENTRY_REC;
 
 typedef enum {
@@ -47,11 +55,12 @@ void gui_entry_insert_text(GUI_ENTRY_REC *entry, const char *str);
 void gui_entry_insert_char(GUI_ENTRY_REC *entry, unichar chr);
 
 char *gui_entry_get_cutbuffer(GUI_ENTRY_REC *entry);
+char *gui_entry_get_next_cutbuffer(GUI_ENTRY_REC *entry);
 void gui_entry_erase_to(GUI_ENTRY_REC *entry, int pos, CUTBUFFER_UPDATE_OP update_cutbuffer);
 void gui_entry_erase(GUI_ENTRY_REC *entry, int size, CUTBUFFER_UPDATE_OP update_cutbuffer);
 void gui_entry_erase_cell(GUI_ENTRY_REC *entry);
 void gui_entry_erase_word(GUI_ENTRY_REC *entry, int to_space, CUTBUFFER_UPDATE_OP cutbuffer_op);
-void gui_entry_erase_next_word(GUI_ENTRY_REC *entry, int to_space);
+void gui_entry_erase_next_word(GUI_ENTRY_REC *entry, int to_space, CUTBUFFER_UPDATE_OP cutbuffer_op);
 
 void gui_entry_transpose_chars(GUI_ENTRY_REC *entry);
 void gui_entry_transpose_words(GUI_ENTRY_REC *entry);


### PR DESCRIPTION
This adds cutbuffer handling building on the work of toddpratt. It adds two new keys which you can bind in /bind: yank_next_cutbuffer and append_next_kill. Consecutive kills are appended to the current cutbuffer