### PR TITLE
fix race condition in terminal init

### DIFF
--- a/src/fe-text/terminfo-core.c
+++ b/src/fe-text/terminfo-core.c
@@ -496,7 +496,7 @@ void terminfo_setup_colors(TERM_REC *term, int force)
 	}
 }
 
-static void terminfo_input_init(TERM_REC *term)
+static void terminfo_input_init0(TERM_REC *term)
 {
 	tcgetattr(fileno(term->in), &term->old_tio);
 	memcpy(&term->tio, &term->old_tio, sizeof(term->tio));
@@ -518,8 +518,11 @@ static void terminfo_input_init(TERM_REC *term)
 	term->tio.c_cc[VSUSP] = _POSIX_VDISABLE;
 #endif
 
-        tcsetattr(fileno(term->in), TCSADRAIN, &term->tio);
+}
 
+static void terminfo_input_init(TERM_REC *term)
+{
+        tcsetattr(fileno(term->in), TCSADRAIN, &term->tio);
 }
 
 static void terminfo_input_deinit(TERM_REC *term)
@@ -673,6 +676,7 @@ static int term_setup(TERM_REC *term)
 	term->beep = term->TI_bel ? _beep : _ignore;
 
 	terminfo_setup_colors(term, FALSE);
+	terminfo_input_init0(term);
         terminfo_cont(term);
         return 1;
 }


### PR DESCRIPTION
remove the tcgetattr call to a single time on irssi load instead of
querying it each time. Fixes #450