### PR TITLE
Make use of terminal application keys configurable

### DIFF
--- a/src/fe-text/gui-readline.c
+++ b/src/fe-text/gui-readline.c
@@ -1060,6 +1060,7 @@ static void setup_changed(void)
 	paste_join_multiline = settings_get_bool("paste_join_multiline");
 	paste_use_bracketed_mode = settings_get_bool("paste_use_bracketed_mode");
 
+	term_set_appkey_mode(settings_get_bool("term_appkey_mode"));
 	/* Enable the bracketed paste mode on demand */
 	term_set_bracketed_paste_mode(paste_use_bracketed_mode);
 }
@@ -1082,6 +1083,7 @@ void gui_readline_init(void)
 	g_get_current_time(&last_keypress);
         input_listen_init(STDIN_FILENO);
 
+	settings_add_bool("lookandfeel", "term_appkey_mode", TRUE);
 	settings_add_str("history", "scroll_page_count", "/2");
 	settings_add_time("misc", "paste_detect_time", "5msecs");
 	settings_add_bool("misc", "paste_use_bracketed_mode", FALSE);

--- a/src/fe-text/term.h
+++ b/src/fe-text/term.h
@@ -94,6 +94,7 @@ void term_refresh(TERM_WINDOW *window);
 
 void term_stop(void);
 
+void term_set_appkey_mode(int enable);
 void term_set_bracketed_paste_mode(int enable);
 
 /* keyboard input handling */

--- a/src/fe-text/terminfo-core.c
+++ b/src/fe-text/terminfo-core.c
@@ -395,6 +395,12 @@ static void _ignore_parm(TERM_REC *term, int param)
 {
 }
 
+static void terminfo_set_appkey_mode(TERM_REC *term, int set)
+{
+	if (term->TI_smkx && term->TI_rmkx)
+		tput(tparm(set ? term->TI_smkx : term->TI_rmkx));
+}
+
 static void term_dec_set_bracketed_paste_mode(int enable)
 {
 	if (enable)
@@ -543,8 +549,8 @@ void terminfo_cont(TERM_REC *term)
 	if (term->TI_smcup)
 		tput(tparm(term->TI_smcup));
 
-	if (term->TI_smkx)
-		tput(tparm(term->TI_smkx));
+	if (term->appkey_enabled)
+		terminfo_set_appkey_mode(term, TRUE);
 
 	if (term->bracketed_paste_enabled)
 		term_dec_set_bracketed_paste_mode(TRUE);
@@ -566,8 +572,8 @@ void terminfo_stop(TERM_REC *term)
 	if (term->TI_rmcup)
 		tput(tparm(term->TI_rmcup));
 
-	if (term->TI_rmkx)
-		tput(tparm(term->TI_rmkx));
+	if (term->appkey_enabled)
+		terminfo_set_appkey_mode(term, FALSE);
 
         /* reset input settings */
 	terminfo_input_deinit(term);
@@ -693,6 +699,15 @@ static int term_setup(TERM_REC *term)
 	terminfo_input_init0(term);
         terminfo_cont(term);
         return 1;
+}
+
+void term_set_appkey_mode(int enable)
+{
+	if (current_term->appkey_enabled == enable)
+		return;
+
+	current_term->appkey_enabled = enable;
+	terminfo_set_appkey_mode(current_term, enable);
 }
 
 void term_set_bracketed_paste_mode(int enable)

--- a/src/fe-text/terminfo-core.h
+++ b/src/fe-text/terminfo-core.h
@@ -94,6 +94,7 @@ struct _TERM_REC {
 	const char *TI_rmkx;
 
 	/* Terminal mode states */
+	int appkey_enabled;
 	int bracketed_paste_enabled;
 };
 


### PR DESCRIPTION
adds a new setting term_appkey_mode which can enable or disable the use
of keyboard transmit (application keys) mode. Fixes #430