### PR TITLE
Revert "Removed the obsolete SQUERY and SERVLIST commands"

### DIFF
--- a/docs/help/in/list.in
+++ b/docs/help/in/list.in
@@ -25,10 +25,10 @@
 %9Remarks:%9
 
     Not all networks support server-side filtering and may provide a network
-    service instead; on IRCnet, you may use the ALIS service:
+    service or service bot instead; on IRCnet, you may use the List service:
 
-    /QUOTE SQUERY ALIS :HELP
+    /SQUERY List HELP
     /MSG ALIS HELP
 
-%9See also:%9 QUOTE, STATS, WHOIS
+%9See also:%9 STATS, SQUERY, WHOIS
 

--- a/docs/help/in/servlist.in
+++ b/docs/help/in/servlist.in
@@ -1,0 +1,23 @@
+
+%9Syntax:%9
+
+@SYNTAX:servlist@
+
+%9Parameters:%9
+
+    <mask> limits the output to the services which names matches
+           the mask.
+    <type> limits the output to the services of the specified type.
+
+%9Description:%9
+
+    List the network services currently present on the
+    IRC network.
+
+%9Examples:%9
+
+    /SERVLIST *@javairc.*
+    /SERVLIST * 0xD000
+
+%9See also:%9 SQUERY
+

--- a/docs/help/in/squery.in
+++ b/docs/help/in/squery.in
@@ -1,0 +1,16 @@
+
+%9Syntax:%9
+
+@SYNTAX:squery@
+
+%9Parameters:%9
+
+    <service> - Service nickname or full hostmask of service to query.
+    <message> - Message to send to the service.
+
+%9Description:%9
+
+    /SQUERY sends a query to the specified service.
+
+%9See also:%9 SERVLIST, LIST, MSG
+

--- a/src/irc/core/irc-commands.c
+++ b/src/irc/core/irc-commands.c
@@ -1018,11 +1018,15 @@ void irc_commands_init(void)
 	command_bind_irc("trace", NULL, (SIGNAL_FUNC) command_self);
 	/* SYNTAX: VERSION [<server>|<nick>] */
 	command_bind_irc("version", NULL, (SIGNAL_FUNC) command_self);
+	/* SYNTAX: SERVLIST [<mask> [<type>]] */
+	command_bind_irc("servlist", NULL, (SIGNAL_FUNC) command_self);
 	/* SYNTAX: SILENCE [[+|-]<nick!user@host>]
 	           SILENCE [<nick>] */
 	command_bind_irc("silence", NULL, (SIGNAL_FUNC) command_self);
 	command_bind_irc("unsilence", NULL, (SIGNAL_FUNC) cmd_unsilence);
 	command_bind_irc("sconnect", NULL, (SIGNAL_FUNC) cmd_sconnect);
+	/* SYNTAX: SQUERY <service> [<message>] */
+	command_bind_irc("squery", NULL, (SIGNAL_FUNC) command_2self);
 	/* SYNTAX: DIE */
 	command_bind_irc("die", NULL, (SIGNAL_FUNC) command_self);
 	/* SYNTAX: HASH */
@@ -1091,9 +1095,11 @@ void irc_commands_deinit(void)
 	command_unbind("time", (SIGNAL_FUNC) command_self);
 	command_unbind("trace", (SIGNAL_FUNC) command_self);
 	command_unbind("version", (SIGNAL_FUNC) command_self);
+	command_unbind("servlist", (SIGNAL_FUNC) command_self);
 	command_unbind("silence", (SIGNAL_FUNC) command_self);
 	command_unbind("unsilence", (SIGNAL_FUNC) cmd_unsilence);
 	command_unbind("sconnect", (SIGNAL_FUNC) cmd_sconnect);
+	command_unbind("squery", (SIGNAL_FUNC) command_2self);
 	command_unbind("die", (SIGNAL_FUNC) command_self);
 	command_unbind("hash", (SIGNAL_FUNC) command_self);
 	command_unbind("oper", (SIGNAL_FUNC) cmd_oper);


### PR DESCRIPTION
This reverts commit 4beebe3238dda96efd4c3a0a6f6002ad5afc96e7.