### PR TITLE
net_gethosterror: Handle EAI_SYSTEM ("System error") properly

### DIFF
--- a/src/core/network.c
+++ b/src/core/network.c
@@ -510,7 +510,11 @@ const char *net_gethosterror(int error)
 {
 	g_return_val_if_fail(error != 0, NULL);
 
-	return gai_strerror(error);
+	if (error == EAI_SYSTEM) {
+		return strerror(errno);
+	} else {
+		return gai_strerror(error);
+	}
 }
 
 /* return TRUE if host lookup failed because it didn't exist (ie. not


### PR DESCRIPTION
That error code means "check errno". A few users got it and we never
figured out what happened - it usually fixed itself after restarting
something - so hopefully with this we'll have more information the next
time.