### PR TITLE
Don't print 'day changed' messages until something happens

### DIFF
--- a/src/fe-common/core/fe-windows.c
+++ b/src/fe-common/core/fe-windows.c
@@ -575,7 +575,7 @@ static void sig_server_disconnected(SERVER_REC *server)
 	}
 }
 
-static void window_print_daychange(WINDOW_REC *window, struct tm *tm)
+void window_print_daychange(WINDOW_REC *window, struct tm *tm)
 {
         THEME_REC *theme;
         TEXT_DEST_REC dest;
@@ -664,9 +664,9 @@ static void sig_print_text(void)
 	daycheck = 2;
 	signal_remove("print text", (SIGNAL_FUNC) sig_print_text);
 
-	/* day changed, print notice about it to every window */
+	/* day changed, notify every window */
 	for (tmp = windows; tmp != NULL; tmp = tmp->next)
-		window_print_daychange(tmp->data, tm);
+		((WINDOW_REC *)(tmp->data))->daychanged = 1;
 }
 
 static int sig_check_daychange(void)

--- a/src/fe-common/core/fe-windows.h
+++ b/src/fe-common/core/fe-windows.h
@@ -35,6 +35,7 @@ struct _WINDOW_REC {
 	unsigned int immortal:1;
 	unsigned int sticky_refnum:1;
 	unsigned int destroying:1;
+	unsigned int daychanged:1;
 
 	/* window-specific command line history */
 	HISTORY_REC *history;
@@ -82,6 +83,7 @@ WINDOW_REC *window_find_item(SERVER_REC *server, const char *name);
 int window_refnum_prev(int refnum, int wrap);
 int window_refnum_next(int refnum, int wrap);
 int windows_refnum_last(void);
+void window_print_daychange(WINDOW_REC *window, struct tm *tm);
 
 int window_refnum_cmp(WINDOW_REC *w1, WINDOW_REC *w2);
 GSList *windows_get_sorted(void);

--- a/src/fe-common/core/printtext.c
+++ b/src/fe-common/core/printtext.c
@@ -167,9 +167,18 @@ static void print_line(TEXT_DEST_REC *dest, const char *text)
 {
         THEME_REC *theme;
 	char *str, *tmp, *stripped;
+	time_t t;
+	struct tm *tm;
 
 	g_return_if_fail(dest != NULL);
 	g_return_if_fail(text != NULL);
+
+	if(dest->window->daychanged) {
+		dest->window->daychanged = 0;
+		t = time(NULL);
+		tm = localtime(&t);
+		window_print_daychange(dest->window, tm);
+	}
 
         theme = window_get_theme(dest->window);
 	tmp = format_get_level_tag(theme, dest);


### PR DESCRIPTION
I usually have hundreds of windows open, most are private messages. This
patch prevents them from all showing up as having unread things in the
window list, and also prevents long series of just 'day changed to'
messages in the more idle queries.

I didn't see how to do this from a script, hence another patch to irssi.