### PR TITLE
Be smart about case-matching the nicks.

### DIFF
--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -153,7 +153,7 @@ int settings_get_choice(const char *key)
 	SETTINGS_REC *rec;
 	CONFIG_NODE *node;
 	char *str;
-	int idx;
+	int index;
 
 	rec = settings_get(key, SETTING_TYPE_CHOICE);
 	if (rec == NULL) return -1;
@@ -164,8 +164,10 @@ int settings_get_choice(const char *key)
 	str = node == NULL ? rec->default_value.v_string :
 		config_node_get_str(node, key, rec->default_value.v_string);
 
-	idx = strarray_find(rec->choices, str);
-	return (idx < 0) ? rec->default_value.v_int : idx;
+	if (str == NULL || (index = strarray_find(rec->choices, str)) < 0)
+		return rec->default_value.v_int;
+
+	return index;
 }
 
 char *settings_get_print(SETTINGS_REC *rec)

--- a/src/fe-common/core/chat-completion.c
+++ b/src/fe-common/core/chat-completion.c
@@ -52,6 +52,18 @@ static int completion_auto, completion_strict;
 	last_msg_add(&((MODULE_CHANNEL_REC *) MODULE_DATA(channel))->lastmsgs, \
 		     nick, own, keep_publics_count)
 
+static int contains_uppercase(const char *s1)
+{
+	const char *ch;
+
+	for (ch = s1; *ch != '\0'; ch++) {
+		if (g_ascii_isupper(*ch))
+			return TRUE;
+	}
+
+	return FALSE;
+}
+
 static LAST_MSG_REC *last_msg_find(GSList *list, const char *nick)
 {
 	while (list != NULL) {
@@ -336,7 +348,8 @@ GList *completion_msg(SERVER_REC *win_server,
 }
 
 static void complete_from_nicklist(GList **outlist, CHANNEL_REC *channel,
-				   const char *nick, const char *suffix)
+				   const char *nick, const char *suffix,
+				   const int match_case)
 {
         MODULE_CHANNEL_REC *mchannel;
 	GSList *tmp;
@@ -352,8 +365,10 @@ static void complete_from_nicklist(GList **outlist, CHANNEL_REC *channel,
 	for (tmp = mchannel->lastmsgs; tmp != NULL; tmp = tmp->next) {
 		LAST_MSG_REC *rec = tmp->data;
 
-		if (g_ascii_strncasecmp(rec->nick, nick, len) == 0 &&
-		    glist_find_icase_string(*outlist, rec->nick) == NULL) {
+		if ((match_case? strncmp(rec->nick, nick, len)
+		     : g_ascii_strncasecmp(rec->nick, nick, len)) == 0 &&
+		    (match_case? glist_find_string(*outlist, rec->nick)
+		     : glist_find_icase_string(*outlist, rec->nick)) == NULL) {
 			str = g_strconcat(rec->nick, suffix, NULL);
 			if (completion_lowercase) ascii_strdown(str);
 			if (rec->own)
@@ -368,7 +383,8 @@ static void complete_from_nicklist(GList **outlist, CHANNEL_REC *channel,
 
 static GList *completion_nicks_nonstrict(CHANNEL_REC *channel,
 					 const char *nick,
-					 const char *suffix)
+					 const char *suffix,
+					 const int match_case)
 {
 	GSList *nicks, *tmp;
 	GList *list;
@@ -404,7 +420,8 @@ static GList *completion_nicks_nonstrict(CHANNEL_REC *channel,
                 *out = '\0';
 
 		/* add to list if 'cleaned' nick matches */
-		if (g_ascii_strncasecmp(str, nick, len) == 0) {
+		if ((match_case? strncmp(str, nick, len)
+		     : g_ascii_strncasecmp(str, nick, len)) == 0) {
 			tnick = g_strconcat(rec->nick, suffix, NULL);
 			if (completion_lowercase)
 				ascii_strdown(tnick);
@@ -428,7 +445,7 @@ static GList *completion_channel_nicks(CHANNEL_REC *channel, const char *nick,
 	GSList *nicks, *tmp;
 	GList *list;
 	char *str;
-	int len;
+	int len, match_case;
 
 	g_return_val_if_fail(channel != NULL, NULL);
 	g_return_val_if_fail(nick != NULL, NULL);
@@ -437,9 +454,11 @@ static GList *completion_channel_nicks(CHANNEL_REC *channel, const char *nick,
 	if (suffix != NULL && *suffix == '\0')
 		suffix = NULL;
 
+	match_case = contains_uppercase(nick);
+
 	/* put first the nicks who have recently said something */
 	list = NULL;
-	complete_from_nicklist(&list, channel, nick, suffix);
+	complete_from_nicklist(&list, channel, nick, suffix, match_case);
 
 	/* and add the rest of the nicks too */
 	len = strlen(nick);
@@ -447,7 +466,8 @@ static GList *completion_channel_nicks(CHANNEL_REC *channel, const char *nick,
 	for (tmp = nicks; tmp != NULL; tmp = tmp->next) {
 		NICK_REC *rec = tmp->data;
 
-		if (g_ascii_strncasecmp(rec->nick, nick, len) == 0 &&
+		if ((match_case? strncmp(rec->nick, nick, len)
+		     : g_ascii_strncasecmp(rec->nick, nick, len)) == 0 &&
 		    rec != channel->ownnick) {
 			str = g_strconcat(rec->nick, suffix, NULL);
 			if (completion_lowercase)
@@ -463,7 +483,7 @@ static GList *completion_channel_nicks(CHANNEL_REC *channel, const char *nick,
 	/* remove non alphanum chars from nick and search again in case
 	   list is still NULL ("foo<tab>" would match "_foo_" f.e.) */
 	if (!completion_strict)
-		list = g_list_concat(list, completion_nicks_nonstrict(channel, nick, suffix));
+		list = g_list_concat(list, completion_nicks_nonstrict(channel, nick, suffix, match_case));
 	return list;
 }
 


### PR DESCRIPTION
Not very sure about this, we might want to gate this behaviour under a configurable option...
Long story short, it makes the completion match the case of the user-typed prefix if it contains at least an uppercase letter, I found it quite disappointing that `Ne<tab>` didn't give `Nei` but another nick starting with a lowercase `n`.