### PR TITLE
servers-reconnect: pass unix_socket attribute to new connection

### DIFF
--- a/src/core/servers-reconnect.c
+++ b/src/core/servers-reconnect.c
@@ -190,6 +190,7 @@ server_connect_copy_skeleton(SERVER_CONNECT_REC *src, int connect_info)
 	dest->away_reason = g_strdup(src->away_reason);
 	dest->no_autojoin_channels = src->no_autojoin_channels;
 	dest->no_autosendcmd = src->no_autosendcmd;
+	dest->unix_socket = src->unix_socket;
 
 	dest->use_ssl = src->use_ssl;
 	dest->ssl_cert = g_strdup(src->ssl_cert);


### PR DESCRIPTION
Trying to /reconnect unix sockets turned them into inet.