### PR TITLE
Add "GBytes *" as a possible perl signal arg

### DIFF
--- a/src/perl/get-signals.pl
+++ b/src/perl/get-signals.pl
@@ -18,6 +18,7 @@ while (<STDIN>) {
 
 	s/GList \* of ([^,]*)/glistptr_\1/g;
 	s/GSList of (\w+)s/gslist_\1/g;
+	s/GBytes \*/gbytes/g;
 
 	s/char \*[^,]*/string/g;
 	s/ulong \*[^,]*/ulongptr/g;


### PR DESCRIPTION
This allows the possibility of sending an immutable byte vector as an
argument to signals. This is helpful for upcoming changes to support
SASL scripts.