### PR TITLE
SASL: handle fragmentation

### DIFF
--- a/src/irc/core/irc-servers.c
+++ b/src/irc/core/irc-servers.c
@@ -444,6 +444,8 @@ static void sig_disconnected(IRC_SERVER_REC *server)
 	gslist_free_full(server->cap_queue, (GDestroyNotify) g_free);
 	server->cap_queue = NULL;
 
+	g_free_and_null(server->sasl_buffer);
+
 	/* these are dynamically allocated only if isupport was sent */
 	g_hash_table_foreach(server->isupport,
 			     (GHFunc) isupport_destroy_hash, server);

--- a/src/irc/core/irc-servers.h
+++ b/src/irc/core/irc-servers.h
@@ -78,7 +78,8 @@ struct _IRC_SERVER_REC {
 	GSList *cap_queue;     /* A list of caps to request on connection */ 
 	int cap_complete:1;    /* We've done the initial CAP negotiation */
 
-	guint sasl_timeout; /* Holds the source id of the running timeout */
+	GString *sasl_buffer; /* Buffer used to reassemble a fragmented SASL payload */
+	guint sasl_timeout;   /* Holds the source id of the running timeout */
 
 	/* Command sending queue */
 	int cmdcount; /* number of commands in `cmdqueue'. Can be more than


### PR DESCRIPTION
The IRCv3 SASL extension says that AUTHENTICATION payloads of exactly
400 bytes in length indicate that the message is fragmented and will
continue in a subsequent message. Handle the reassembly and splitting of
these messages so that we are compliant with the specification.