### PR TITLE
Follow the XDG specification.

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -1,8 +1,6 @@
 #ifndef __COMMON_H
 #define __COMMON_H
 
-#define IRSSI_DIR_FULL "%s/.irssi" /* %s == g_get_home_dir() */
-
 #define IRSSI_GLOBAL_CONFIG "irssi.conf" /* config file name in /etc/ */
 #define IRSSI_HOME_CONFIG "config" /* config file name in ~/.irssi/ */
 

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -182,16 +182,21 @@ void core_register_options(void)
 
 void core_preinit(const char *path)
 {
-	const char *home;
 	char *str;
 	int len;
 
 	if (irssi_dir == NULL) {
-		home = g_get_home_dir();
-		if (home == NULL)
-			home = ".";
+		/* Try the XDG-compliant path first, if the config directory
+		 * exists use it instead of the one at ~/.irssi */
+		irssi_dir = g_build_filename(g_get_user_config_dir(),
+					     "irssi", NULL);
 
-		irssi_dir = g_strdup_printf(IRSSI_DIR_FULL, home);
+		if (g_file_test(irssi_dir, G_FILE_TEST_IS_DIR) == FALSE) {
+			g_free(irssi_dir);
+
+			const char *home = g_get_home_dir();
+			irssi_dir = g_build_filename(home? home: ".", ".irssi", NULL);
+		}
 	} else {
 		str = irssi_dir;
 		irssi_dir = fix_path(str);
@@ -200,8 +205,9 @@ void core_preinit(const char *path)
 		if (irssi_dir[len-1] == G_DIR_SEPARATOR)
 			irssi_dir[len-1] = '\0';
 	}
+
 	if (irssi_config_file == NULL)
-		irssi_config_file = g_strdup_printf("%s/"IRSSI_HOME_CONFIG, irssi_dir);
+		irssi_config_file = g_build_filename(irssi_dir, IRSSI_HOME_CONFIG, NULL);
 	else {
 		str = irssi_config_file;
 		irssi_config_file = fix_path(str);


### PR DESCRIPTION
We're still 100% backward-compatible.

Supersedes #51, we now default to `~/.config/irssi` if and only if it exists, otherwise `~/.irssi` is used as before.
