### PR TITLE
Set the default STATUSMSG to @ instead of @+ if it's missing

### DIFF
--- a/src/fe-common/irc/fe-irc-channels.c
+++ b/src/fe-common/irc/fe-irc-channels.c
@@ -41,7 +41,7 @@ int fe_channel_is_opchannel(IRC_SERVER_REC *server, const char *target)
 
 	statusmsg = g_hash_table_lookup(server->isupport, "statusmsg");
 	if (statusmsg == NULL)
-		statusmsg = "@+";
+		statusmsg = "@";
 
 	return strchr(statusmsg, *target) != NULL;
 }
@@ -61,12 +61,9 @@ const char *fe_channel_skip_prefix(IRC_SERVER_REC *server, const char *target)
 	statusmsg = g_hash_table_lookup(server->isupport, "statusmsg");
 
 	/* Hack: for bahamut 1.4 which sends neither STATUSMSG nor
-	 * WALLCHOPS in 005, accept @#chan and @+#chan (but not +#chan) */
-	if (statusmsg == NULL && *target != '@')
-		return target;
-
+	 * WALLCHOPS in 005 */
 	if (statusmsg == NULL)
-		statusmsg = "@+";
+		statusmsg = "@";
 
 	/* Strip the leading statusmsg prefixes */
 	while (strchr(statusmsg, *target) != NULL) {

--- a/src/irc/core/irc-servers.c
+++ b/src/irc/core/irc-servers.c
@@ -89,8 +89,10 @@ static int ischannel_func(SERVER_REC *server, const char *data)
 		chantypes = "#&!+"; /* normal, local, secure, modeless */
 
 	statusmsg = g_hash_table_lookup(irc_server->isupport, "statusmsg");
-	if (statusmsg != NULL)
-		data += strspn(data, statusmsg);
+	if (statusmsg == NULL)
+		statusmsg = "@";
+
+	data += strspn(data, statusmsg);
 
 	/* strchr(3) considers the trailing NUL as part of the string, make sure
 	 * we didn't advance too much. */


### PR DESCRIPTION
This fixes two issues:

- IRCNet doesn't have STATUSMSG, but it supports +channels, and including + in the default value meant processing those incorrectly

- The "bahamut hack", for old servers that support but don't advertise STATUSMSG, didn't work since ischannel_func doesn't use the default.

The choice of @ intentionally leaves out support for other STATUSMSG (for example, AzzurraNet's bahamut 1.4 fork seemed to support + and % in any order, contradicting the comment in the code).

I think this is a decent tradeoff, given how those servers are uncommon and relying on +# or %# is even less common than @#.

Fixes #531