### PR TITLE
Make sure to make a copy of ERRSV content.

### DIFF
--- a/src/perl/common/Expando.xs
+++ b/src/perl/common/Expando.xs
@@ -85,7 +85,9 @@ static char *perl_expando_event(PerlExpando *rec, SERVER_REC *server,
 			script_unregister_expandos(script);
 		/* rec has been freed now */
 
-		signal_emit("script error", 2, script, SvPV_nolen(ERRSV));
+		char *error = g_strdup(SvPV_nolen(ERRSV));
+		signal_emit("script error", 2, script, error);
+		g_free(error);
 	} else if (retcount > 0) {
 		ret = g_strdup(POPp);
 		*free_ret = TRUE;

--- a/src/perl/textui/Statusbar.xs
+++ b/src/perl/textui/Statusbar.xs
@@ -77,7 +77,10 @@ static void perl_statusbar_event(char *function, SBAR_ITEM_REC *item,
                         /* make sure we don't get back here */
 			script_unregister_statusbars(script);
 		}
-		signal_emit("script error", 2, script, SvPV_nolen(ERRSV));
+
+		char *error = g_strdup(SvPV_nolen(ERRSV));
+		signal_emit("script error", 2, script, error);
+		g_free(error);
 	} else {
 		/* min_size and max_size can be changed, move them to SBAR_ITEM_REC */
 		hv = hvref(item_sv);


### PR DESCRIPTION
Otherwise we might end up showing an empty message.
Fixes #522.