### PR TITLE
Collapse the list of nicks when possible.

### DIFF
--- a/src/core/misc.c
+++ b/src/core/misc.c
@@ -261,6 +261,23 @@ char *gslist_to_string(GSList *list, const char *delimiter)
 	return ret;
 }
 
+gboolean gslist_is_unique(GSList *list, GCompareFunc func)
+{
+	const char *prev;
+
+	if (list == NULL)
+		return TRUE;
+
+	prev = (const char *)list->data;
+
+	for (list = list->next; list != NULL; list = list->next) {
+		if (func(list->data, prev) != 0)
+			return FALSE;
+	}
+
+	return TRUE;
+}
+
 void hash_save_key(char *key, void *value, GSList **list)
 {
         *list = g_slist_append(*list, key);

--- a/src/core/misc.h
+++ b/src/core/misc.h
@@ -31,6 +31,8 @@ void *gslist_foreach_find(GSList *list, FOREACH_FIND_FUNC func, const void *data
 char *gslistptr_to_string(GSList *list, int offset, const char *delimiter);
 /* `list' contains char* */
 char *gslist_to_string(GSList *list, const char *delimiter);
+/* 'list' elements are all the same */
+gboolean gslist_is_unique(GSList *list, GCompareFunc func);
 
 GList *optlist_remove_known(const char *cmd, GHashTable *optlist);
 

--- a/src/fe-common/irc/fe-modes.c
+++ b/src/fe-common/irc/fe-modes.c
@@ -83,7 +83,10 @@ static void print_mode(MODE_REC *rec)
 
 	tmp = modes; modes = NULL;
 
-	nicks = gslist_to_string(rec->nicks, ", ");
+	if (gslist_is_unique(rec->nicks, (GCompareFunc)g_strcmp0))
+		nicks = g_strdup(rec->nicks->data);
+	else
+		nicks = gslist_to_string(rec->nicks, ", ");
 	printformat(rec->channel->server, rec->channel->visible_name,
 		    MSGLEVEL_MODES, IRCTXT_CHANMODE_CHANGE,
 		    rec->channel->visible_name, rec->mode, nicks, "");


### PR DESCRIPTION
When a single user changes the mode to a bunch of different users we
don't really have to print out the nick every time.

Partially solves #568, gives nicer messages overall
