### PR TITLE
enforce check that chatnets are nodelists to handle invalid config

### DIFF
--- a/src/core/chatnets.c
+++ b/src/core/chatnets.c
@@ -132,7 +132,7 @@ static void chatnet_read(CONFIG_NODE *node)
 	CHATNET_REC *rec;
         char *type;
 
-	if (node == NULL || node->key == NULL)
+	if (node == NULL || node->key == NULL || !is_node_list(node))
 		return;
 
 	type = config_node_get_str(node, "type", NULL);


### PR DESCRIPTION
Closes #563 

Please review. I decided to just avoid parsing the chatnet if its node is not a nodelist.
