### PR TITLE
Minimal message-tags handling - just skip the @ part

### DIFF
--- a/src/irc/core/irc.c
+++ b/src/irc/core/irc.c
@@ -318,7 +318,16 @@ static char *irc_parse_prefix(char *line, char **nick, char **address)
 
 	*nick = *address = NULL;
 
-	/* :<nick> [["!" <user>] "@" <host>] SPACE */
+	/* [@tags] :<nick> [["!" <user>] "@" <host>] SPACE */
+
+	if (*line == '@') {
+		while (*line != '\0' && *line != ' ')
+			line++;
+		if (*line == ' ') {
+			*line++ = '\0';
+			while (*line == ' ') line++;
+		}
+	}
 
 	if (*line != ':')
 		return line;


### PR DESCRIPTION
This adds support for the ircv3.2 message-tags wire format without
actually parsing any of the tags or adding any interface to process them
(other than the 'server incoming' signal).

The API for this stuff can be decided later.

-----

"""Formal proof of correctness""":

![](http://dump.dequis.org/R-PfW.png)

AFL test case: http://dump.dequis.org/JxPOI.txt

Dirty bitlbee patch to send tags in every line: http://dump.dequis.org/A5dME.txt