### PR TITLE
Check for socket() in libnetwork for Haiku

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -158,7 +158,7 @@ case "$host_os" in
 esac
 
 
-AC_SEARCH_LIBS([socket], [socket])
+AC_SEARCH_LIBS([socket], [network socket])
 
 AC_SEARCH_LIBS([inet_addr], [nsl])
 


### PR DESCRIPTION
Since the time of #106 it seems the ncurses checks have been dropped, so this is all that's left from the required changed to build on Haiku.