### PR TITLE
Process the nick changes in queries before the PRIVMSG is handled.

### DIFF
--- a/src/fe-common/irc/fe-irc-queries.c
+++ b/src/fe-common/irc/fe-irc-queries.c
@@ -78,6 +78,13 @@ static void event_privmsg(SERVER_REC *server, const char *data,
 			if (!server_has_nick(server, query->name))
 				query_change_nick(query, nick);
 		}
+	} else {
+		/* process the changes to the query structure now, before the
+		 * privmsg is dispatched. */
+		if (g_strcmp0(query->name, nick) != 0)
+			query_change_nick(query, nick);
+		if (address != NULL && g_strcmp0(query->address, address) != 0)
+			query_change_address(query, address);
 	}
 }
 

--- a/src/irc/core/irc-queries.c
+++ b/src/irc/core/irc-queries.c
@@ -79,20 +79,6 @@ static void check_query_changes(IRC_SERVER_REC *server, const char *nick,
 	}
 }
 
-static void event_privmsg(IRC_SERVER_REC *server, const char *data,
-			  const char *nick, const char *address)
-{
-	char *params, *target, *msg;
-
-	g_return_if_fail(data != NULL);
-	if (nick == NULL)
-		return;
-
-	params = event_get_params(data, 2 | PARAM_FLAG_GETREST, &target, &msg);
-        check_query_changes(server, nick, address, target);
-	g_free(params);
-}
-
 static void ctcp_action(IRC_SERVER_REC *server, const char *msg,
 			const char *nick, const char *address,
 			const char *target)
@@ -117,14 +103,12 @@ static void event_nick(SERVER_REC *server, const char *data,
 
 void irc_queries_init(void)
 {
-	signal_add_last("event privmsg", (SIGNAL_FUNC) event_privmsg);
 	signal_add_last("ctcp action", (SIGNAL_FUNC) ctcp_action);
 	signal_add("event nick", (SIGNAL_FUNC) event_nick);
 }
 
 void irc_queries_deinit(void)
 {
-	signal_remove("event privmsg", (SIGNAL_FUNC) event_privmsg);
 	signal_remove("ctcp action", (SIGNAL_FUNC) ctcp_action);
 	signal_remove("event nick", (SIGNAL_FUNC) event_nick);
 }


### PR DESCRIPTION
The `event privmsg` handler in `irc-queries.c` kicks in too late and renames the query so the privmsg ends up in the wrong window.
Tested with a local ratbox instance, had a lengthy conversation between me and myself over two irssi instances.
PS: We might need something for the `CTCP` too.