### PR TITLE
make irssi --with-perl build with separate object directory

### DIFF
--- a/src/perl/common/Makefile.PL.in
+++ b/src/perl/common/Makefile.PL.in
@@ -1,4 +1,4 @@
-use ExtUtils::MakeMaker;our $AM_DEFAULT_VERBOSITY='@AM_DEFAULT_VERBOSITY@';require "../Makefile_silent.pm";
+use ExtUtils::MakeMaker;our $AM_DEFAULT_VERBOSITY='@AM_DEFAULT_VERBOSITY@';require "@top_srcdir@/src/perl/Makefile_silent.pm";
 
 WriteMakefile('NAME' => 'Irssi',
               'LIBS' => '',

--- a/src/perl/irc/Makefile.PL.in
+++ b/src/perl/irc/Makefile.PL.in
@@ -1,4 +1,4 @@
-use ExtUtils::MakeMaker;our $AM_DEFAULT_VERBOSITY='@AM_DEFAULT_VERBOSITY@';require "../Makefile_silent.pm";
+use ExtUtils::MakeMaker;our $AM_DEFAULT_VERBOSITY='@AM_DEFAULT_VERBOSITY@';require "@top_srcdir@/src/perl/Makefile_silent.pm";
 
 WriteMakefile('NAME' => 'Irssi::Irc',
               'LIBS' => '',

--- a/src/perl/textui/Makefile.PL.in
+++ b/src/perl/textui/Makefile.PL.in
@@ -1,4 +1,4 @@
-use ExtUtils::MakeMaker;our $AM_DEFAULT_VERBOSITY='@AM_DEFAULT_VERBOSITY@';require "../Makefile_silent.pm";
+use ExtUtils::MakeMaker;our $AM_DEFAULT_VERBOSITY='@AM_DEFAULT_VERBOSITY@';require "@top_srcdir@/src/perl/Makefile_silent.pm";
 
 WriteMakefile('NAME' => 'Irssi::TextUI',
               'LIBS' => '',

--- a/src/perl/ui/Makefile.PL.in
+++ b/src/perl/ui/Makefile.PL.in
@@ -1,4 +1,4 @@
-use ExtUtils::MakeMaker;our $AM_DEFAULT_VERBOSITY='@AM_DEFAULT_VERBOSITY@';require "../Makefile_silent.pm";
+use ExtUtils::MakeMaker;our $AM_DEFAULT_VERBOSITY='@AM_DEFAULT_VERBOSITY@';require "@top_srcdir@/src/perl/Makefile_silent.pm";
 
 WriteMakefile('NAME' => 'Irssi::UI',
               'LIBS' => '',


### PR DESCRIPTION
irssi 1.0.0 will not build if Perl is enabled and a separate object code directory is used. The problem is a relative path to an internal Perl dependency in four `Makefile.PL.in` files. This commit fixes the problem by making these paths absolute using `@top_srcdir@`.