### PR TITLE
NEWS: Avoid explicitly mentioning freenode in the pinning examples

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -39,16 +39,16 @@ v1.0.0 2017-01-03  The Irssi team <staff@irssi.org>
 	  values like this: Start by downloading the certificate from a given IRC
 	  server:
 
-	      $ openssl s_client -connect chat.freenode.net:6697 < /dev/null 2>/dev/null | \
-	        openssl x509 > freenode.cert
+	      $ openssl s_client -connect irc.example.net:6697 < /dev/null 2>/dev/null | \
+	        openssl x509 > example.cert
 
 	  Find the value for -tls_pinned_cert:
 
-	      $ openssl x509 -in freenode.cert -fingerprint -sha256 -noout
+	      $ openssl x509 -in example.cert -fingerprint -sha256 -noout
 
 	  Find the value for -tls_pinned_pubkey:
 
-	      $ openssl x509 -in freenode.cert -pubkey -noout | \
+	      $ openssl x509 -in example.cert -pubkey -noout | \
 	        openssl pkey -pubin -outform der | \
 	        openssl dgst -sha256 -c | \
 	        tr a-z A-Z


### PR DESCRIPTION
They have proper certs, so using them as an example is wrong.
Particularly worse since they started using letsencrypt recently so
every server has a different cert and pubkey.

We'll figure out how to link this from the release notes later.