### PR TITLE
perl_parse needs NULL terminated parameter list.

### DIFF
--- a/src/perl/perl-core.c
+++ b/src/perl/perl-core.c
@@ -41,7 +41,7 @@ GSList *perl_scripts;
 PerlInterpreter *my_perl;
 
 static int print_script_errors;
-static char *perl_args[] = {"", "-e", "0"};
+static char *perl_args[] = {"", "-e", "0", NULL};
 
 #define IS_PERL_SCRIPT(file) \
 	(strlen(file) > 3 && g_strcmp0(file+strlen(file)-3, ".pl") == 0)
@@ -123,7 +123,7 @@ void perl_scripts_init(void)
 	my_perl = perl_alloc();
 	perl_construct(my_perl);
 
-	perl_parse(my_perl, xs_init, G_N_ELEMENTS(perl_args), perl_args, NULL);
+	perl_parse(my_perl, xs_init, G_N_ELEMENTS(perl_args)-1, perl_args, NULL);
 #if PERL_STATIC_LIBS == 1
 	perl_eval_pv("Irssi::Core::->boot_Irssi_Core(0.9);", TRUE);
 #endif


### PR DESCRIPTION
the perl_parse call needs a null-terminated parameter list, see here:
http://search.cpan.org/~xsawyerx/perl-5.25.8/pod/perlembed.pod

It says:
"Mind that argv[argc] must be NULL, same as those passed to a main function in C."

The patch adds a trailing NULL and changes the number of elements to G_N_ELEMENTS(perl_args)-1 (because it needs the number of elements *without* the NULL terminator).

If the perl_args array is not NULL terminated this will cause an out of bounds read in the perl code in S_parse_body(). This can be seen with address sanitizer, but therefore you need to compile both irssi and libperl with asan enabled.
I originally thought this is a perl bug, but as it's clearly documented it needs to be fixed in irssi.

Here's a stack trace from asan:
```
==7887==ERROR: AddressSanitizer: global-buffer-overflow on address 0x00000088b998 at pc 0x7f3d87e36d1f bp 0x7ffcc8164b80 sp 0x7ffcc8164b70
READ of size 8 at 0x00000088b998 thread T0
    #0 0x7f3d87e36d1e in S_parse_body /var/tmp/portage/dev-lang/perl-5.22.3_rc4/work/perl-5.22.3-RC4/perl.c:2131
    #1 0x7f3d87e36d1e in perl_parse /var/tmp/portage/dev-lang/perl-5.22.3_rc4/work/perl-5.22.3-RC4/perl.c:1626
    #2 0x57e18d in perl_scripts_init /tmp/irssi-1.0.0/src/perl/perl-core.c:126
    #3 0x581860 in perl_core_init /tmp/irssi-1.0.0/src/perl/perl-core.c:462
    #4 0x45a027 in textui_finish_init /tmp/irssi-1.0.0/src/fe-text/irssi.c:191
    #5 0x45a4a9 in main /tmp/irssi-1.0.0/src/fe-text/irssi.c:314
    #6 0x7f3d8648a78f in __libc_start_main (/lib64/libc.so.6+0x2078f)
    #7 0x419318 in _start (/tmp/irssi-1.0.0/src/fe-text/irssi+0x419318)

0x00000088b998 is located 0 bytes to the right of global variable 'perl_args' from 'perl-core.c' (0x88b980) of size 24
