### PR TITLE
Add SUPPRESS_PRINTF_FALLBACK

### DIFF
--- a/src/fe-common/core/printtext.c
+++ b/src/fe-common/core/printtext.c
@@ -446,7 +446,9 @@ static void sig_print_text(TEXT_DEST_REC *dest, const char *text)
 
 	if (dest->window == NULL) {
                 str = strip_codes(text);
+#ifndef SUPPRESS_PRINTF_FALLBACK
 		printf("NO WINDOWS: %s\n", str);
+#endif
                 g_free(str);
                 return;
 	}


### PR DESCRIPTION
There are some cases (such as fuzzing with fe-fuzz) where suppressing
printf output may be desirable.