### PR TITLE
Fix glib-2.0.m4 so that $PKG_CONFIG doesn't break configure script

### DIFF
--- a/m4/glib-2.0.m4
+++ b/m4/glib-2.0.m4
@@ -43,7 +43,7 @@ AC_ARG_ENABLE(glibtest, [  --disable-glibtest      do not try to compile and run
   min_glib_version=ifelse([$1], ,2.0.0,$1)
   AC_MSG_CHECKING(for GLIB - version >= $min_glib_version)
 
-  if test x$PKG_CONFIG != xno ; then
+  if test "x$PKG_CONFIG" != xno ; then
     ## don't try to run the test against uninstalled libtool libs
     if $PKG_CONFIG --uninstalled $pkg_config_args; then
 	  echo "Will use uninstalled version of GLib found in PKG_CONFIG_PATH"


### PR DESCRIPTION
If $PKG_CONFIG contains a space, then the test may not work, so
surround with quotation mark characters. (for example,
PKG_CONFIG="pkg-config --static" breaks configure before this commit).