### PR TITLE
support storing and replaying the monospace attribute in textbuffer

### DIFF
--- a/src/fe-text/textbuffer-view.c
+++ b/src/fe-text/textbuffer-view.c
@@ -146,6 +146,9 @@ static void update_cmd_color(unsigned char cmd, int *color)
 	case LINE_CMD_ITALIC:
 		*color ^= ATTR_ITALIC;
 		break;
+	case LINE_CMD_MONOSPACE:
+		/* ignored */
+		break;
 	case LINE_CMD_COLOR0:
 		*color &= BGATTR;
 		*color &= ~ATTR_FGCOLOR24;

--- a/src/fe-text/textbuffer.c
+++ b/src/fe-text/textbuffer.c
@@ -326,6 +326,10 @@ void textbuffer_line_add_colors(TEXT_BUFFER_REC *buffer, LINE_REC **line,
 		data[pos++] = 0;
 		data[pos++] = LINE_CMD_ITALIC;
 	}
+	if ((flags & GUI_PRINT_FLAG_MONOSPACE) != (buffer->last_flags & GUI_PRINT_FLAG_MONOSPACE)) {
+		data[pos++] = 0;
+		data[pos++] = LINE_CMD_MONOSPACE;
+	}
 	if (flags & GUI_PRINT_FLAG_INDENT) {
 		data[pos++] = 0;
 		data[pos++] = LINE_CMD_INDENT;
@@ -508,6 +512,10 @@ void textbuffer_line2text(LINE_REC *line, int coloring, GString *str)
 		case LINE_CMD_ITALIC:
 			g_string_append_printf(str, "\004%c",
 					  FORMAT_STYLE_ITALIC);
+			break;
+		case LINE_CMD_MONOSPACE:
+			g_string_append_printf(str, "\004%c",
+					  FORMAT_STYLE_MONOSPACE);
 			break;
 		case LINE_CMD_COLOR0:
 			g_string_append_printf(str, "\004%c%c",

--- a/src/fe-text/textbuffer.h
+++ b/src/fe-text/textbuffer.h
@@ -18,6 +18,7 @@ enum {
 	LINE_CMD_BLINK,		/* enable/disable blink */
 	LINE_CMD_BOLD,		/* enable/disable bold */
 	LINE_CMD_ITALIC,	/* enable/disable italic */
+	LINE_CMD_MONOSPACE,	/* enable/disable monospace (gui only) */
 	LINE_COLOR_EXT,		/* extended color */
 	LINE_COLOR_EXT_BG,	/* extended bg */
 #ifdef TERM_TRUECOLOR


### PR DESCRIPTION
I want to support this formatting command (%#) also in terminal, even if it doesn't do anything. objections?