### PR TITLE
Make themes' docs more consistent.

### DIFF
--- a/colorless.theme
+++ b/colorless.theme
@@ -261,8 +261,8 @@ abstracts = {
   # background for topicbar (same default)
   #sb_topic_bg = "%8";
 
-  # text at the beginning of statusbars. sb-item already puts
-  # space there,so we don't use anything by default.
+  # text at the beginning of statusbars. "sb" already puts a space there,
+  # so we don't use anything by default.
   sbstart = "";
   # text at the end of statusbars. Use space so that it's never
   # used for anything.

--- a/default.theme
+++ b/default.theme
@@ -261,8 +261,8 @@ abstracts = {
   # background for topicbar (same default)
   #sb_topic_bg = "%4";
 
-  # text at the beginning of statusbars. sb-item already puts
-  # space there,so we don't use anything by default.
+  # text at the beginning of statusbars. "sb" already puts a space there,
+  # so we don't use anything by default.
   sbstart = "";
   # text at the end of statusbars. Use space so that it's never
   # used for anything.


### PR DESCRIPTION
Mentioning "sb-item" was misleading in that there is no such template, nor any occurrence of that exact string anywhere else in the source.

In going from `sb-item` to `"sb"` I am following the pattern established in a couple of comments above:

    "msgownnick" specifies the styling …
    "ownmsgnick" specifies …