### PR TITLE
notify-ison: Don't send ison before the connection is done

### DIFF
--- a/src/irc/notifylist/notify-ison.c
+++ b/src/irc/notifylist/notify-ison.c
@@ -80,6 +80,10 @@ static void ison_send(IRC_SERVER_REC *server, GString *cmd)
 {
 	MODULE_SERVER_REC *mserver;
 
+	if (!server->connected) {
+		return;
+	}
+
 	mserver = MODULE_DATA(server);
 	mserver->ison_count++;
 


### PR DESCRIPTION
Fixes #596 

Alternative fix to #605, this time much more boring and limited in scope.

If anything else relies on the same 120 second wait_cmd delay we can apply this same fix. Relying on the delay isn't great anyway.