### PR TITLE
Properly check the command arguments in tail place.

### DIFF
--- a/src/core/commands.c
+++ b/src/core/commands.c
@@ -567,13 +567,14 @@ static int get_cmd_options(char **data, int ignore_unknown,
 
 	option = NULL; pos = -1;
 	for (;;) {
-		if (**data == '-') {
+		if (**data == '\0' || **data == '-') {
 			if (option != NULL && *optlist[pos] == '+') {
 				/* required argument missing! */
                                 *data = optlist[pos] + 1;
 				return CMDERR_OPTION_ARG_MISSING;
 			}
-
+		}
+		if (**data == '-') {
 			(*data)++;
 			if (**data == '-' && (*data)[1] == ' ') {
 				/* -- option means end of options even


### PR DESCRIPTION
A command requiring an argument and given in tail position would not
raise an error but silently set the value to the empty string ''.

Spotted by trying to figure out what #651 is about.