### PR TITLE
Quote the filename when dcc requests are auto accepted.

### DIFF
--- a/src/core/misc.c
+++ b/src/core/misc.c
@@ -724,18 +724,20 @@ int expand_escape(const char **data)
 	}
 }
 
-/* Escape all '"', "'" and '\' chars with '\' */
-char *escape_string(const char *str)
+/* Escape all the characters in `what' with a backslash */
+char *escape_string(const char *str, const char *what)
 {
-	char *ret, *p;
+	const char *p;
+	char *ret;
 
-	p = ret = g_malloc(strlen(str)*2+1);
-	while (*str != '\0') {
-		if (*str == '"' || *str == '\'' || *str == '\\')
-			*p++ = '\\';
-		*p++ = *str++;
+	ret = g_malloc(strlen(str) * 2 + 1);
+	for (p = str; *p != '\0'; p++, ret++) {
+		if (strchr(what, *p) != NULL) {
+			*ret++ = '\\';
+		}
+		*ret = *p;
 	}
-	*p = '\0';
+	*ret = '\0';
 
 	return ret;
 }

--- a/src/core/misc.h
+++ b/src/core/misc.h
@@ -88,8 +88,8 @@ char *stristr_full(const char *data, const char *key);
 char *ascii_strup(char *str);
 char *ascii_strdown(char *str);
 
-/* Escape all '"', "'" and '\' chars with '\' */
-char *escape_string(const char *str);
+/* Escape all the characters in `what' with a backslash */
+char *escape_string(const char *str, const char *what);
 
 /* convert all low-ascii (<32) to ^<A..> combinations */
 char *show_lowascii(const char *str);

--- a/src/fe-common/core/chat-completion.c
+++ b/src/fe-common/core/chat-completion.c
@@ -1113,7 +1113,7 @@ static void event_text(const char *data, SERVER_REC *server, WI_ITEM_REC *item)
 	/* the nick is quoted in case it contains '-' character. also
 	   spaces should work too now :) The nick is also escaped in case
 	   it contains '\' characters */
-	target = escape_string(window_item_get_target(item));
+	target = escape_string(window_item_get_target(item), "\"'\\");
 	str = g_strdup_printf(IS_CHANNEL(item) ? "-channel \"%s\" %s" :
 			      IS_QUERY(item) ? "-nick \"%s\" %s" : "%s %s",
 			      target, line);

--- a/src/irc/dcc/dcc-autoget.c
+++ b/src/irc/dcc/dcc-autoget.c
@@ -70,7 +70,7 @@ static void sig_dcc_request(GET_DCC_REC *dcc, const char *nickaddr)
 	file = dcc_get_download_path(dcc->arg);
 	str = g_strdup_printf(settings_get_bool("dcc_autoresume") &&
 			      stat(file, &statbuf) == 0 ?
-			      "RESUME %s %s" : "GET %s %s",
+			      "RESUME %s \"%s\"" : "GET %s \"%s\"",
 			      dcc->nick, dcc->arg);
 	signal_emit("command dcc", 2, str, dcc->server);
         g_free(file);

--- a/src/irc/dcc/dcc-autoget.c
+++ b/src/irc/dcc/dcc-autoget.c
@@ -23,6 +23,7 @@
 #include "masks.h"
 #include "settings.h"
 #include "servers.h"
+#include "misc.h"
 
 #include "dcc-get.h"
 
@@ -30,7 +31,7 @@ static void sig_dcc_request(GET_DCC_REC *dcc, const char *nickaddr)
 {
         struct stat statbuf;
 	const char *masks;
-        char *str, *file;
+        char *str, *file, *esc_arg;
         int max_size;
 
         if (!IS_DCC_GET(dcc)) return;
@@ -68,11 +69,14 @@ static void sig_dcc_request(GET_DCC_REC *dcc, const char *nickaddr)
 
 	/* ok. but do we want/need to resume? */
 	file = dcc_get_download_path(dcc->arg);
+	/* we have to escape the quotes as the whole file name gets quoted */
+	esc_arg = escape_string(dcc->arg, "\"");
 	str = g_strdup_printf(settings_get_bool("dcc_autoresume") &&
 			      stat(file, &statbuf) == 0 ?
 			      "RESUME %s \"%s\"" : "GET %s \"%s\"",
-			      dcc->nick, dcc->arg);
+			      dcc->nick, esc_arg);
 	signal_emit("command dcc", 2, str, dcc->server);
+	g_free(esc_arg);
         g_free(file);
 	g_free(str);
 }


### PR DESCRIPTION
PR #453 forces the user to quote the filenames given to /DCC commands
when they contain spaces but the autoget functionality didn't get
updated so the filename was always passed without quotes.

Closes #656.