### PR TITLE
Fix for segfault when a 'script error' handler dies

### DIFF
--- a/src/perl/perl-core.h
+++ b/src/perl/perl-core.h
@@ -8,6 +8,10 @@ typedef struct {
         /* Script can be loaded from a file, or from some data in memory */
 	char *path; /* FILE: full path for file */
 	char *data; /* DATA: data used for the script */
+
+	/* internal bookkeeping */
+	char script_error_status; /* script error status */
+	char disable_signals; /* don't deliver signals to this script */
 } PERL_SCRIPT_REC;
 
 extern GSList *perl_scripts;
@@ -54,5 +58,10 @@ int perl_get_api_version(void);
 
 void perl_core_init(void);
 void perl_core_deinit(void);
+
+/* Reports script errors.
+ * Upon return, @param script may have been (and probably was) freed.
+ */
+void perl_report_script_error(PERL_SCRIPT_REC *script, const char *error);
 
 #endif

--- a/src/perl/perl-signals.c
+++ b/src/perl/perl-signals.c
@@ -304,7 +304,7 @@ static void perl_call_signal(PERL_SCRIPT_REC *script, SV *func,
 
 	if (SvTRUE(ERRSV)) {
 		char *error = g_strdup(SvPV_nolen(ERRSV));
-		signal_emit("script error", 2, script, error);
+		perl_report_script_error(script, error);
                 g_free(error);
                 rec = NULL;
 	}
@@ -360,6 +360,8 @@ static void sig_func(const void *p1, const void *p2,
 	args[3] = p4; args[4] = p5; args[5] = p6;
 
 	rec = signal_get_user_data();
+	if (rec->script->disable_signals)
+		return;
 	perl_call_signal(rec->script, rec->func, signal_get_emitted_id(), args);
 }
 

--- a/src/perl/perl-sources.c
+++ b/src/perl/perl-sources.c
@@ -82,7 +82,7 @@ static int perl_source_event(PERL_SOURCE_REC *rec)
 
 	if (SvTRUE(ERRSV)) {
                 char *error = g_strdup(SvPV_nolen(ERRSV));
-		signal_emit("script error", 2, rec->script, error);
+		perl_report_script_error(rec->script, error);
                 g_free(error);
 	}
 


### PR DESCRIPTION
I have put together a well and true fix for #101. (I saw the comment in perl.txt and took it as a challenge :grin:) Not sure if it's the best solution, but it does work.

The fix is relatively straightforward and only touches four source files.
It adds two fields to `PERL_SCRIPT_REC`: `script_error_status` and `disable_signals`.

The overhead is negligible for the common case (i.e. when scripts aren't experiencing errors.)

`script_error_status` serves two purposes:
1. It is used to detect nested `script error` signals for the same script.  Barring certain *very* unlikely situations, such a situation indicates that a script's own `script error` handler has died.
2. It serves as a crude reference count on the script, to prevent both use-after-free errors and memory leaks.

`disable_signals` has only one purpose: To prevent `script error` signals from being delivered to a script.  It actually does more than that -- it prevents *any* signals from being delivered to the script.  I don't consider this much of a problem; unless the user has some *very* fancy scripts loaded, the only signal that would ever be delivered to a script with this flag set is `script error`.

For example, here's what it looks like on my screen when I run a variation of the example command from #101:

````
/script exec sub fail { print(__PACKAGE__ . "::fail('$_[1]')"); die 'goodbye, cruel world'; }; Irssi::signal_add('script error', 'fail'); die 'hasta la vista'

22:07 Irssi::Script::data1::fail('hasta la vista at (eval 317) line 1.
22:07 ')
22:07 -!- Irssi: Error in script data1:
22:07 goodbye, cruel world at (eval 317) line 1.
22:07
````

This is what happens behind the scenes:
1. A script error occurs (the `die 'hasta la vista'`)
2. `perl_report_script_error` (a new function) sets the script's `script_error_status` to `SES_ERROR`, then emits a `script error` signal.
3. The script's error handler prints the message about 'fail' being called (the first two output lines)
4. A second script error occurs (the `die 'goodbye, cruel world'`)
5. `perl_report_script_error` sees that we're already handling a script error.
    1. The `script error` signal that was emitted in step 2 is stopped
    2. The script's `disable_signals` flag is set to `TRUE`.
    3. A new `script error` signal is raised.  Note that our script will not receive that notification, because we shut its signals off.
    4. The sig_script_error handler in perl-fe.c displays the error notification (the last three output lines)
    5. The sig_script_error handler in perl-core.c unloads the script, but does *not* delete the `PERL_SCRIPT_REC` structure.  Instead, it sets the script's `script_error_status` to `SES_DESTROY`.
    6. The `script error` signal_emit call from step 2 completes and control is returned to `perl_report_script_error`.
6. `perl_report_script_error` sees that the script's `script_error_status` is now `SES_DESTROY`, and frees the `PERL_SCRIPT_REC` structure.
