### PR TITLE
Use-after-free and other script stability fixes

### DIFF
--- a/src/fe-common/core/fe-settings.c
+++ b/src/fe-common/core/fe-settings.c
@@ -191,9 +191,9 @@ static void cmd_set(char *data)
 				/* Unpossible! */
 				break;
 			}
-			signal_emit("setup changed", 0);
 			printformat(NULL, NULL, MSGLEVEL_CLIENTCRAP, TXT_SET_TITLE, rec->section);
 			set_print(rec);
+			signal_emit("setup changed", 0);
 		} else
 			printformat(NULL, NULL, MSGLEVEL_CLIENTERROR, TXT_SET_UNKNOWN, key);
 	}

--- a/src/perl/perl-core.h
+++ b/src/perl/perl-core.h
@@ -1,6 +1,8 @@
 #ifndef __PERL_CORE_H
 #define __PERL_CORE_H
 
+#include <inttypes.h>
+
 typedef struct {
 	char *name; /* unique name */
         char *package; /* package name */
@@ -8,6 +10,17 @@ typedef struct {
         /* Script can be loaded from a file, or from some data in memory */
 	char *path; /* FILE: full path for file */
 	char *data; /* DATA: data used for the script */
+
+	/** Script destruction flag. If TRUE, the script has been
+         *  destroyed/unloaded.
+	 */
+	uint8_t destroyed;
+	/** Script signal suppression counter. If greater than zero,
+	 *  signals and commands should not be delivered to the script.e
+	 */
+	int8_t disable_signals;
+	/** PERL_SCRIPT_REC reference counter. */
+	uint8_t refcount;
 } PERL_SCRIPT_REC;
 
 extern GSList *perl_scripts;
@@ -19,9 +32,17 @@ void perl_scripts_deinit(void);
 /* Load all the scripts in the autorun/ folder */
 void perl_scripts_autorun(void);
 
-/* Load a perl script, path must be a full path. */
+/** Load a perl script, path must be a full path.
+ *  If an error occurs while loading the script, the return value is null.
+ *  Otherwise, the returned pointer has an extra reference that must be
+ *  released with perl_script_unref().
+ */
 PERL_SCRIPT_REC *perl_script_load_file(const char *path);
-/* Load a perl script from given data */
+/** Load a perl script from given data.
+ *  If an error occurs while loading the script, the return value is null.
+ *  Otherwise, the returned pointer has an extra reference that must be
+ *  released with perl_script_unref().
+ */
 PERL_SCRIPT_REC *perl_script_load_data(const char *data);
 /* Unload perl script */
 void perl_script_unload(PERL_SCRIPT_REC *script);
@@ -54,5 +75,27 @@ int perl_get_api_version(void);
 
 void perl_core_init(void);
 void perl_core_deinit(void);
+
+/** Attempts to reference a PERL_SCRIPT_REC structure, preventing it from
+ *  being freed.
+ *
+ *  Returns TRUE if a reference was taken; each reference must be released
+ *  by calling perl_script_unref().
+ *  Returns FALSE if a reference was not made (this can happen if the
+ *  if the associated script has already been destroyed.)
+ */
+
+int perl_script_ref(PERL_SCRIPT_REC *script);
+
+/** Releases a PERL_SCRIPT_REC structure, potentially allowing it to be
+ *  freed.
+ *  If @param script is NULL, this function does nothing.
+ */
+
+void perl_script_unref(PERL_SCRIPT_REC *script);
+
+/** Used to report that an error occurred while calling into a script.
+ */
+void perl_script_error(PERL_SCRIPT_REC *script, const char *error);
 
 #endif

--- a/src/perl/perl-core.h
+++ b/src/perl/perl-core.h
@@ -16,7 +16,7 @@ typedef struct {
 	 */
 	uint8_t destroyed;
 	/** Script signal suppression counter. If greater than zero,
-	 *  signals and commands should not be delivered to the script.e
+	 *  signals and commands should not be delivered to the script.
 	 */
 	int8_t disable_signals;
 	/** PERL_SCRIPT_REC reference counter. */
@@ -33,13 +33,13 @@ void perl_scripts_deinit(void);
 void perl_scripts_autorun(void);
 
 /** Load a perl script, path must be a full path.
- *  If an error occurs while loading the script, the return value is null.
+ *  If an error occurs while loading the script, the return value is NULL.
  *  Otherwise, the returned pointer has an extra reference that must be
  *  released with perl_script_unref().
  */
 PERL_SCRIPT_REC *perl_script_load_file(const char *path);
 /** Load a perl script from given data.
- *  If an error occurs while loading the script, the return value is null.
+ *  If an error occurs while loading the script, the return value is NULL.
  *  Otherwise, the returned pointer has an extra reference that must be
  *  released with perl_script_unref().
  */

--- a/src/perl/perl-fe.c
+++ b/src/perl/perl-fe.c
@@ -59,7 +59,7 @@ static void cmd_script_exec(const char *data)
 		/* not a permanent script, unload immediately */
                 perl_script_unload(script);
 	}
-
+	perl_script_unref(script);
 
 	cmd_params_free(free_arg);
 }
@@ -87,6 +87,7 @@ static void cmd_script_load(const char *data)
 				    TXT_SCRIPT_LOADED,
 				    script->name, script->path);
 		}
+		perl_script_unref(script);
 		g_free(fname);
 	}
 	cmd_params_free(free_arg);


### PR DESCRIPTION
This commit eliminates several use-after-free situations relating to
unloading scripts.

It also eliminates some segfaults stemming from recursive signals/commands.


