### PR TITLE
OpenSSL support detection and documentation fixes

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -30,10 +30,6 @@ configure options
 
   Build the irssi proxy (see startup-HOWTO).
 
-  --disable-ssl
-
-  Disable SSL support.
-
   --with-perl=[yes|no|module]
 
   Enable Perl support

--- a/configure.ac
+++ b/configure.ac
@@ -244,11 +244,6 @@ if test "x$want_socks" = "xyes"; then
 fi
 
 dnl **
-dnl ** OpenSSL checks
-dnl **
-AC_CHECK_LIB([ssl], [SSL_library_init])
-
-dnl **
 dnl ** fe-text checks
 dnl **
 
@@ -289,7 +284,21 @@ if test -z "$GLIB_LIBS"; then
   AC_ERROR([GLIB is required to build irssi.])
 fi
 
-LIBS="$LIBS $GLIB_LIBS -lssl -lcrypto"
+LIBS="$LIBS $GLIB_LIBS"
+
+dnl **
+dnl ** OpenSSL checks
+dnl **
+PKG_CHECK_MODULES([OPENSSL], [openssl], [
+	CFLAGS="$CFLAGS $OPENSSL_CFLAGS"
+	LIBS="$LIBS $OPENSSL_LIBS"
+], [
+	AC_CHECK_LIB([ssl], [SSL_library_init], [
+		LIBS="$LIBS -lssl -lcrypto"
+	], [
+		AC_MSG_ERROR([The OpenSSL library was not found])
+	])
+])
 
 dnl **
 dnl ** curses checks


### PR DESCRIPTION
This commit series improves the detection of OpenSSL through the use of pkg-config in the configure script and removes an outdated information from INSTALL.