### PR TITLE
Fix slow startup with glib 2.49.3

### DIFF
--- a/src/fe-text/irssi.c
+++ b/src/fe-text/irssi.c
@@ -318,21 +318,21 @@ int main(int argc, char **argv)
 	   can call our dirty-checker after each iteration */
 	while (!quitting) {
 		if (reload_config) {
-                        /* SIGHUP received, do /RELOAD */
+			/* SIGHUP received, do /RELOAD */
 			reload_config = FALSE;
-                        signal_emit("command reload", 1, "");
+			signal_emit("command reload", 1, "");
 		}
 
 		dirty_check();
 
 		term_refresh_freeze();
 		g_main_iteration(TRUE);
-                term_refresh_thaw();
+		term_refresh_thaw();
 	}
 
 	g_main_destroy(main_loop);
 	textui_deinit();
 
-        session_upgrade(); /* if we /UPGRADEd, start the new process */
+	session_upgrade(); /* if we /UPGRADEd, start the new process */
 	return 0;
 }

--- a/src/fe-text/irssi.c
+++ b/src/fe-text/irssi.c
@@ -317,10 +317,6 @@ int main(int argc, char **argv)
 	/* Does the same as g_main_run(main_loop), except we
 	   can call our dirty-checker after each iteration */
 	while (!quitting) {
-		term_refresh_freeze();
-		g_main_iteration(TRUE);
-                term_refresh_thaw();
-
 		if (reload_config) {
                         /* SIGHUP received, do /RELOAD */
 			reload_config = FALSE;
@@ -328,6 +324,10 @@ int main(int argc, char **argv)
 		}
 
 		dirty_check();
+
+		term_refresh_freeze();
+		g_main_iteration(TRUE);
+                term_refresh_thaw();
 	}
 
 	g_main_destroy(main_loop);


### PR DESCRIPTION
In glib v2.49.3, an optimization was made to eliminate certain
unnecessary wakeups.  (The specific change was made in
e4ee3079c5afc3c1c3d2415f20c3e8605728f074). Before this change, the
first call to g_main_iteration would always complete immediately.
In Irssi, this effectively reversed the order of the main loop, causing
the reload_config check and the dirty_check to run *before* the first
blocking call to g_main_iteration.

With the new logic, the first g_main_iteration call now blocks,
preventing the screen from being refreshed until the user starts typing
or a timer goes off.  (It also delays processing of SIGHUP, but I
expect that is not a common situation.)

This commit reorders the main loop to wait at the end of the loop,
rather than the beginning, addressing the problem.

(This closes Debian bug #856201.)