### PR TITLE
Fix strange history behavior when history is empty

### DIFF
--- a/src/fe-common/core/command-history.c
+++ b/src/fe-common/core/command-history.c
@@ -116,6 +116,8 @@ const char *command_history_prev(WINDOW_REC *window, const char *text)
 		history->pos = history->pos->prev;
 		if (history->pos == NULL)
                         history->over_counter++;
+	} else if (history->lines == 0) {
+		history->over_counter++;
 	} else {
 		history->pos = g_list_last(history->list);
 	}


### PR DESCRIPTION
If text is being entered and then the user presses the up arrow
followed by the down arrow, the expected behavior is to return to the
text being entered. Prior to this commit that was not the case.

Fixes #462