### PR TITLE
Don't allow command history to wrap around

### DIFF
--- a/src/fe-common/core/command-history.c
+++ b/src/fe-common/core/command-history.c
@@ -113,11 +113,9 @@ const char *command_history_prev(WINDOW_REC *window, const char *text)
 	pos = history->pos;
 
 	if (pos != NULL) {
-		history->pos = history->pos->prev;
-		if (history->pos == NULL)
-                        history->over_counter++;
-	} else if (history->lines == 0) {
-		history->over_counter++;
+		/* don't go past the first entry (no wrap around) */
+		if (history->pos->prev != NULL)
+			history->pos = history->pos->prev;
 	} else {
 		history->pos = g_list_last(history->list);
 	}
@@ -128,7 +126,7 @@ const char *command_history_prev(WINDOW_REC *window, const char *text)
 		command_history_add(history, text);
 	}
 
-	return history->pos == NULL ? "" : history->pos->data;
+	return history->pos == NULL ? text : history->pos->data;
 }
 
 const char *command_history_next(WINDOW_REC *window, const char *text)
@@ -141,10 +139,6 @@ const char *command_history_next(WINDOW_REC *window, const char *text)
 
 	if (pos != NULL)
 		history->pos = history->pos->next;
-	else if (history->over_counter > 0) {
-		history->over_counter--;
-		history->pos = history->list;
-	}
 
 	if (*text != '\0' &&
 	    (pos == NULL || g_strcmp0(pos->data, text) != 0)) {

--- a/src/fe-common/core/command-history.c
+++ b/src/fe-common/core/command-history.c
@@ -150,7 +150,6 @@ const char *command_history_next(WINDOW_REC *window, const char *text)
 
 void command_history_clear_pos_func(HISTORY_REC *history, gpointer user_data)
 {
-	history->over_counter = 0;
 	history->pos = NULL;
 }
 

--- a/src/fe-common/core/command-history.h
+++ b/src/fe-common/core/command-history.h
@@ -7,7 +7,7 @@ typedef struct {
 	char *name;
 
 	GList *list, *pos;
-	int lines, over_counter;
+	int lines;
 
 	int refcount;
 } HISTORY_REC;


### PR DESCRIPTION
This changes the behavior of the command history to avoid wrapping back
to the bottom once the top of the history is reached.

Tested of course.