### PR TITLE
Add syntax info for completion

### DIFF
--- a/src/fe-common/core/completion.c
+++ b/src/fe-common/core/completion.c
@@ -784,6 +784,7 @@ static void sig_complete_command(GList **list, WINDOW_REC *window,
 	if (*list != NULL) signal_stop();
 }
 
+/* SYNTAX: COMPLETION [-auto] [-delete] <key> <value> */
 static void cmd_completion(const char *data)
 {
 	GHashTable *optlist;


### PR DESCRIPTION
Allows syntax info to be picked up and displayed by help command.

Fixes #687 

Tested.