### PR TITLE
Null check rec on process_destroy

### DIFF
--- a/src/fe-common/core/fe-exec.c
+++ b/src/fe-common/core/fe-exec.c
@@ -175,6 +175,8 @@ static PROCESS_REC *process_find(const char *name, int verbose)
 
 static void process_destroy(PROCESS_REC *rec, int status)
 {
+	if (rec == NULL) return;
+
 	processes = g_slist_remove(processes, rec);
 
 	signal_emit("exec remove", 2, rec, GINT_TO_POINTER(status));


### PR DESCRIPTION
rec=NULL may be a possible code path from handle_exec, if so then we might dereference null.
I am not sure if this is possible, but it looks like it may be.

Let me know if you disagree!