### PR TITLE
Use CXX for fe-fuzz linking

### DIFF
--- a/src/fe-fuzz/Makefile.am
+++ b/src/fe-fuzz/Makefile.am
@@ -1,7 +1,7 @@
 bin_PROGRAMS = irssi-fuzz
 
-# Force link with clang++ for libfuzzer support
-CCLD=clang++ $(CXXFLAGS)
+# Force link with CXX for libfuzzer support
+CCLD=$(CXX) $(CXXFLAGS)
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir)/src \


### PR DESCRIPTION
This should fix the currently broken honggfuzz support for oss-fuzz (https://github.com/google/oss-fuzz/issues/646).