### PR TITLE
fe-dcc-(get|send): Fix some -Wpointer-compare with newer gcc

### DIFF
--- a/src/fe-common/irc/dcc/fe-dcc-get.c
+++ b/src/fe-common/irc/dcc/fe-dcc-get.c
@@ -108,7 +108,7 @@ static void dcc_error_close_not_found(const char *type, const char *nick,
 	g_return_if_fail(fname != NULL);
 	if (g_ascii_strcasecmp(type, "GET") != 0) return;
 
-	if (fname == '\0') fname = "(ANY)";
+	if (fname == NULL || *fname == '\0') fname = "(ANY)";
 	printformat(NULL, NULL, MSGLEVEL_DCC,
 		    IRCTXT_DCC_GET_NOT_FOUND, nick, fname);
 }

--- a/src/fe-common/irc/dcc/fe-dcc-send.c
+++ b/src/fe-common/irc/dcc/fe-dcc-send.c
@@ -108,7 +108,7 @@ static void dcc_error_close_not_found(const char *type, const char *nick,
 	g_return_if_fail(fname != NULL);
 	if (g_ascii_strcasecmp(type, "SEND") != 0) return;
 
-	if (fname == '\0') fname = "(ANY)";
+	if (fname == NULL || *fname == '\0') fname = "(ANY)";
 	printformat(NULL, NULL, MSGLEVEL_DCC,
 		    IRCTXT_DCC_SEND_NOT_FOUND, nick, fname);
 }


### PR DESCRIPTION
The warning itself:

>warning: comparison between pointer and zero character constant [-Wpointer-compare]

Harmless stuff as far as I can tell.

The fix adds a null check that probably isn't needed. The old code that
compared against '\0' worked a lot like a null check so it makes sense
to keep that, while also adding the intended check for empty string.

This was visible with "/dcc close send a" showing an empty filename.
The equivalent for get didn't show the filename in the format string.