### PR TITLE
Performance improvements for /lastlog

### DIFF
--- a/src/fe-text/textbuffer.c
+++ b/src/fe-text/textbuffer.c
@@ -616,20 +616,22 @@ GList *textbuffer_find_text(TEXT_BUFFER_REC *buffer, LINE_REC *startline,
 			}
 
 			for (; pre_line != line; pre_line = pre_line->next)
-				matches = g_list_append(matches, pre_line);
+				matches = g_list_prepend(matches, pre_line);
 
 			match_after = after;
 		}
 
 		if (line_matched || match_after > 0) {
 			/* matched */
-			matches = g_list_append(matches, line);
+			matches = g_list_prepend(matches, line);
 
 			if ((!line_matched && --match_after == 0) ||
 			    (line_matched && match_after == 0 && before > 0))
-				matches = g_list_append(matches, NULL);
+				matches = g_list_prepend(matches, NULL);
 		}
 	}
+
+	matches = g_list_reverse(matches);
 
 #ifdef USE_GREGEX
 	if (preg != NULL)

--- a/src/fe-text/textbuffer.c
+++ b/src/fe-text/textbuffer.c
@@ -610,7 +610,8 @@ GList *textbuffer_find_text(TEXT_BUFFER_REC *buffer, LINE_REC *startline,
 			pre_line = line;
 			for (i = 0; i < before; i++) {
 				if (pre_line->prev == NULL ||
-				    g_list_find(matches, pre_line->prev) != NULL)
+				    g_list_nth_data(matches, 0) == pre_line->prev ||
+				    g_list_nth_data(matches, 1) == pre_line->prev)
 					break;
                                 pre_line = pre_line->prev;
 			}


### PR DESCRIPTION
* Performance improvements for /lastlog with big result sets

    This applies to "/lastlog" with no filters (or with filters that don't
    filter a lot) and with large amounts of text in the scrollback.

    Test case:

        /exec seq 1 500000
        /lastlog -file log.txt

    Thanks to morning for reporting this.

* Performance improvements for /lastlog -before

    This avoids the use of g_list_find() to find if a match was already
    added to the list of results, by checking the last two added matches
    instead.

    Checking just the last match isn't enough because a NULL match is added
    as a separator (shown as -- in the UI)

------

Test materials I used:

To test -before i used this in my ~/.irssi/startup

```
echo 1
echo 2
echo 3ASD
echo 4
echo 5
echo 6ASD
echo 7
echo 8ASD
echo 9ASD
echo 10
echo 11
echo 12
echo 13ASD
echo 14
echo 15
echo 16
echo 17
echo 18ASD
echo 19
echo 20
echo 21
echo 22
echo 23
echo 24ASD
```

Then `/lastlog -clear -before 2 ASD`, with different values of before.

To understand how `-before` works I used this gdb script (line numbers for master before this change), using the glib python gdb integration module for gforeach.

```
break textbuffer.c:610
commands
p "matched?"
p line_matched
p "text"
p line->text
p "matches so far"
gforeach i in matches: p $i ? ((LINE_REC *) $i)->text : 0
end

break textbuffer.c:613
commands
p "searching"
p pre_line->prev->text
p "matches so far"
gforeach i in matches: p $i ? ((LINE_REC *) $i)->text : 0
end
```

This needs `/set theme colorless` to read the text of LINE_REC directly.