### PR TITLE
Setting sasl_mechanism to '' disables the auth

### DIFF
--- a/docs/help/in/network.in
+++ b/docs/help/in/network.in
@@ -36,6 +36,7 @@
     -sasl_mechanism  Specifies the mechanism to use for the SASL authentication.
                      At the moment irssi only supports the 'plain' and the
                      'external' mechanisms.
+                     Use '' to disable the authentication.
     -sasl_username   Specifies the username to use during the SASL authentication.
     -sasl_password   Specifies the password to use during the SASL authentication.
 

--- a/src/fe-common/irc/fe-ircnet.c
+++ b/src/fe-common/irc/fe-ircnet.c
@@ -163,11 +163,11 @@ static void cmd_network_add_modify(const char *data, gboolean add)
 
 	/* the validity of the parameters is checked in sig_server_setup_fill_chatnet */
 	value = g_hash_table_lookup(optlist, "sasl_mechanism");
-	if (value != NULL && *value != '\0') rec->sasl_mechanism = g_strdup(value);
+	if (value != NULL) rec->sasl_mechanism = *value != '\0' ? g_strdup(value) : NULL;
 	value = g_hash_table_lookup(optlist, "sasl_username");
-	if (value != NULL && *value != '\0') rec->sasl_username = g_strdup(value);
+	if (value != NULL) rec->sasl_username = *value != '\0' ? g_strdup(value) : NULL;
 	value = g_hash_table_lookup(optlist, "sasl_password");
-	if (value != NULL && *value != '\0') rec->sasl_password = g_strdup(value);
+	if (value != NULL) rec->sasl_password = *value != '\0' ? g_strdup(value) : NULL;
 
 	ircnet_create(rec);
 	printformat(NULL, NULL, MSGLEVEL_CLIENTNOTICE, IRCTXT_NETWORK_ADDED, name);

--- a/src/irc/core/irc-servers-setup.c
+++ b/src/irc/core/irc-servers-setup.c
@@ -89,6 +89,8 @@ static void sig_server_setup_fill_chatnet(IRC_SERVER_CONNECT_REC *conn,
 
 	/* Validate the SASL parameters filled by sig_chatnet_read() or cmd_network_add */
 	conn->sasl_mechanism = SASL_MECHANISM_NONE;
+	conn->sasl_username = NULL;
+	conn->sasl_password = NULL;
 
 	if (ircnet->sasl_mechanism != NULL) {
 		if (!g_ascii_strcasecmp(ircnet->sasl_mechanism, "plain")) {
@@ -102,9 +104,7 @@ static void sig_server_setup_fill_chatnet(IRC_SERVER_CONNECT_REC *conn,
 				g_warning("The fields sasl_username and sasl_password are either missing or empty");
 		}
 		else if (!g_ascii_strcasecmp(ircnet->sasl_mechanism, "external")) {
-				conn->sasl_mechanism = SASL_MECHANISM_EXTERNAL;
-				conn->sasl_username = NULL;
-				conn->sasl_password = NULL;
+			conn->sasl_mechanism = SASL_MECHANISM_EXTERNAL;
 		}
 		else
 			g_warning("Unsupported SASL mechanism \"%s\" selected", ircnet->sasl_mechanism);


### PR DESCRIPTION
There was no easy way for the user to disable the SASL authentication
once the network was created.
Closes #718