### PR TITLE
term-terminfo: Avoid switching out of alt screen on unexpected exits

### DIFF
--- a/src/fe-text/term-terminfo.c
+++ b/src/fe-text/term-terminfo.c
@@ -102,6 +102,17 @@ static GSourceFuncs sigcont_funcs = {
 	.dispatch = sigcont_dispatch
 };
 
+static void term_atexit(void)
+{
+	if (!quitting && current_term && current_term->TI_rmcup) {
+		/* Unexpected exit, avoid switching out of alternate screen
+		   to keep any on-screen errors (like noperl_die()'s) */
+		current_term->TI_rmcup = NULL;
+	}
+
+	term_deinit();
+}
+
 int term_init(void)
 {
 	struct sigaction act;
@@ -140,7 +151,7 @@ int term_init(void)
 
         term_set_input_type(TERM_TYPE_8BIT);
 	term_common_init();
-        atexit(term_deinit);
+	atexit(term_atexit);
         return TRUE;
 }
 


### PR DESCRIPTION
Perl sucks and kills the whole process when there's a version mismatch
in Perl_xs_handshake(). Our atexit handler catches the exit and
deinitializes the terminal, removing the error.

This commit uses the 'quitting' global variable which is set when irssi
is voluntarily quitting, and avoids sending TI_rmcup, which restores the
original screen and makes the error invisible.

----

Fixes #287 

Check that beauty:

![screenshot](https://user-images.githubusercontent.com/94108/27254691-35aa53e0-5364-11e7-8c3b-b0b44de9bfe9.png)
