### PR TITLE
Subst vars

### DIFF
--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -703,6 +703,13 @@ int irssi_config_is_changed(const char *fname)
 		 config_last_checksum != file_checksum(fname));
 }
 
+static gboolean filter_stub(const char *key, const char *value, char **new_value)
+{
+	g_warning("Filtering %s in %s", value, key);
+	*new_value = (char *)value;
+	return TRUE;
+}
+
 static CONFIG_REC *parse_configfile(const char *fname)
 {
 	CONFIG_REC *config;
@@ -735,6 +742,8 @@ static CONFIG_REC *parse_configfile(const char *fname)
 
 		config = config_open(NULL, -1);
 	}
+
+	config_set_filter_function(filter_stub);
 
         if (config->fname != NULL)
 		config_parse(config);

--- a/src/lib-config/iconfig.h
+++ b/src/lib-config/iconfig.h
@@ -141,9 +141,9 @@ int config_node_get_bool(CONFIG_NODE *parent, const char *key, int def);
  * if a node with key 'key' exists change its value to 'value',
  * otherwise create a new node with type NODE_TYPE_KEY, key 'key' and value 'value'
  * */
-void config_node_set_str(CONFIG_REC *rec, CONFIG_NODE *parent, const char *key, const char *value);
-void config_node_set_int(CONFIG_REC *rec, CONFIG_NODE *parent, const char *key, int value);
-void config_node_set_bool(CONFIG_REC *rec, CONFIG_NODE *parent, const char *key, int value);
+CONFIG_NODE *config_node_set_str(CONFIG_REC *rec, CONFIG_NODE *parent, const char *key, const char *value);
+CONFIG_NODE *config_node_set_int(CONFIG_REC *rec, CONFIG_NODE *parent, const char *key, int value);
+CONFIG_NODE *config_node_set_bool(CONFIG_REC *rec, CONFIG_NODE *parent, const char *key, int value);
 
 /* Remove one node from block/list. */
 void config_node_remove(CONFIG_REC *rec, CONFIG_NODE *parent, CONFIG_NODE *node);

--- a/src/lib-config/iconfig.h
+++ b/src/lib-config/iconfig.h
@@ -18,8 +18,9 @@ typedef struct _CONFIG_NODE CONFIG_NODE;
 typedef struct _CONFIG_REC CONFIG_REC;
 
 struct _CONFIG_NODE {
-	int type;
-        char *key;
+	int type      : 8;
+	int do_filter : 1;
+	char *key;
 	void *value;
 };
 
@@ -45,6 +46,10 @@ struct _CONFIG_NODE {
    written.
 
 */
+
+typedef gboolean (*ConfigFilterFunc)(const char *key,
+				     const char *value,
+				     char **new_value);
 
 struct _CONFIG_REC {
 	char *fname;
@@ -72,6 +77,8 @@ CONFIG_REC *config_open(const char *fname, int create_mode);
 void config_close(CONFIG_REC *rec);
 /* Change file name of config file */
 void config_change_file_name(CONFIG_REC *rec, const char *fname, int create_mode);
+/* Set the default function to handle the variable filtering */
+void config_set_filter_function(ConfigFilterFunc func);
 
 /* Parse configuration file */
 int config_parse(CONFIG_REC *rec);

--- a/src/lib-config/set.c
+++ b/src/lib-config/set.c
@@ -88,14 +88,14 @@ void config_nodes_remove_all(CONFIG_REC *rec)
 		config_node_remove(rec, rec->mainnode, ((GSList *) rec->mainnode->value)->data);
 }
 
-void config_node_set_str(CONFIG_REC *rec, CONFIG_NODE *parent, const char *key, const char *value)
+CONFIG_NODE *config_node_set_str(CONFIG_REC *rec, CONFIG_NODE *parent, const char *key, const char *value)
 {
 	CONFIG_NODE *node;
 	int no_key;
 
-	g_return_if_fail(rec != NULL);
-	g_return_if_fail(parent != NULL);
-	g_return_if_fail(is_node_list(parent));
+	g_return_val_if_fail(rec != NULL, NULL);
+	g_return_val_if_fail(parent != NULL, NULL);
+	g_return_val_if_fail(is_node_list(parent), NULL);
 
 	no_key = key == NULL;
 	node = no_key ? NULL : config_node_find(parent, key);
@@ -103,7 +103,7 @@ void config_node_set_str(CONFIG_REC *rec, CONFIG_NODE *parent, const char *key, 
 	if (value == NULL) {
                 /* remove the key */
 		if (node != NULL) config_node_remove(rec, parent, node);
-		return;
+		return NULL;
 	}
 
 	if (node != NULL && !has_node_value(node)) {
@@ -114,7 +114,7 @@ void config_node_set_str(CONFIG_REC *rec, CONFIG_NODE *parent, const char *key, 
 	}
 	if (node != NULL) {
 		if (g_strcmp0(node->value, value) == 0)
-			return;
+			return node;
                 g_free(node->value);
 	} else {
 		node = g_new0(CONFIG_NODE, 1);
@@ -126,19 +126,21 @@ void config_node_set_str(CONFIG_REC *rec, CONFIG_NODE *parent, const char *key, 
 
 	node->value = g_strdup(value);
 	rec->modifycounter++;
+
+	return node;
 }
 
-void config_node_set_int(CONFIG_REC *rec, CONFIG_NODE *parent, const char *key, int value)
+CONFIG_NODE *config_node_set_int(CONFIG_REC *rec, CONFIG_NODE *parent, const char *key, int value)
 {
 	char str[MAX_INT_STRLEN];
 
 	g_snprintf(str, sizeof(str), "%d", value);
-	config_node_set_str(rec, parent, key, str);
+	return config_node_set_str(rec, parent, key, str);
 }
 
-void config_node_set_bool(CONFIG_REC *rec, CONFIG_NODE *parent, const char *key, int value)
+CONFIG_NODE *config_node_set_bool(CONFIG_REC *rec, CONFIG_NODE *parent, const char *key, int value)
 {
-	config_node_set_str(rec, parent, key, value ? "yes" : "no");
+	return config_node_set_str(rec, parent, key, value ? "yes" : "no");
 }
 
 int config_set_str(CONFIG_REC *rec, const char *section, const char *key, const char *value)

--- a/src/lib-config/write.c
+++ b/src/lib-config/write.c
@@ -142,6 +142,7 @@ static int config_write_node(CONFIG_REC *rec, CONFIG_NODE *node, int line_feeds)
 	case NODE_TYPE_KEY:
 		if (config_write_word(rec, node->key, FALSE) == -1 ||
 		    config_write_str(rec, " = ") == -1 ||
+		    (node->do_filter && config_write_str(rec, "&") == -1) ||
 		    config_write_word(rec, node->value, TRUE) == -1)
 			return -1;
 		break;
@@ -212,6 +213,8 @@ static int config_node_get_length(CONFIG_REC *rec, CONFIG_NODE *node)
 	case NODE_TYPE_KEY:
 		/* "key = value; " */
 		len = 5 + strlen(node->key) + strlen(node->value);
+		/* optional '&' before the value */
+		len += node->do_filter ? 1 : 0;
 		break;
 	case NODE_TYPE_VALUE:
 		/* "value, " */


### PR DESCRIPTION
Extra wip.

Loosely inspired by `muttrc` and its backtick syntax, this is the nicest thing I could carve out from our not-so-friendly usage of `GScanner`: prepending a `&` before a quoted variable runs the content trough a user-supplied function, right now it is just a simple stub.

Nothing's set in stone so feel free to drop in with any suggestion about the design.

### Todo
* Decide if this approach is worth pursuing.
* Remove the `g_assert` and provide a nice way to recover from that error case.
* Ownership of the `new_value`.
* Should we cache the resulting values?
* Fuzz the shit out of this.