### PR TITLE
Add a startup warning if the TERM var is wrong inside tmux/screen

### DIFF
--- a/src/fe-text/irssi.c
+++ b/src/fe-text/irssi.c
@@ -207,6 +207,8 @@ static void textui_finish_init(void)
 		fe_settings_set_print("nick");
 	if (user_settings_changed & USER_SETTINGS_HOSTNAME)
 		fe_settings_set_print("hostname");
+
+	term_environment_check();
 }
 
 static void textui_deinit(void)

--- a/src/fe-text/term-terminfo.c
+++ b/src/fe-text/term-terminfo.c
@@ -733,3 +733,31 @@ void term_gets(GArray *buffer, int *line_count)
 		}
 	}
 }
+
+static const char* term_env_warning =
+	"The TERM environment variable is set to '%s' which can cause display "
+	"glitches when running under %s.\n"
+	"Consider changing TERM to 'screen' or 'screen-256color' instead.";
+
+void term_environment_check(void)
+{
+	const char *term, *sty, *tmux, *multiplexer;
+
+	term = g_getenv("TERM");
+	sty = g_getenv("STY");
+	tmux = g_getenv("TMUX");
+
+	multiplexer = (sty && *sty) ? "screen" :
+	              (tmux && *tmux) ? "tmux" : NULL;
+
+	if (!multiplexer) {
+		return;
+	}
+
+	if (term && (g_str_has_prefix(term, "screen") ||
+	             g_str_has_prefix(term, "tmux"))) {
+		return;
+	}
+
+	g_warning(term_env_warning, term, multiplexer);
+}

--- a/src/fe-text/term-terminfo.c
+++ b/src/fe-text/term-terminfo.c
@@ -735,7 +735,7 @@ void term_gets(GArray *buffer, int *line_count)
 }
 
 static const char* term_env_warning =
-	"You seem to be running Irssi inside %2$s, but the TERM environment variable"
+	"You seem to be running Irssi inside %2$s, but the TERM environment variable "
 	"is set to '%1$s', which can cause display glitches.\n"
 	"Consider changing TERM to '%2$s' or '%2$s-256color' instead.";
 

--- a/src/fe-text/term-terminfo.c
+++ b/src/fe-text/term-terminfo.c
@@ -735,9 +735,9 @@ void term_gets(GArray *buffer, int *line_count)
 }
 
 static const char* term_env_warning =
-	"The TERM environment variable is set to '%s' which can cause display "
-	"glitches when running under %s.\n"
-	"Consider changing TERM to 'screen' or 'screen-256color' instead.";
+	"You seem to be running Irssi inside %2$s, but the TERM environment variable"
+	"is set to '%1$s', which can cause display glitches.\n"
+	"Consider changing TERM to '%2$s' or '%2$s-256color' instead.";
 
 void term_environment_check(void)
 {

--- a/src/fe-text/term.h
+++ b/src/fe-text/term.h
@@ -105,4 +105,6 @@ void term_gets(GArray *buffer, int *line_count);
 void term_common_init(void);
 void term_common_deinit(void);
 
+void term_environment_check(void);
+
 #endif


### PR DESCRIPTION
One of the most common and confusing issues we get in #irssi, this should help identifying and mitigating it.

----

![screnshot](https://user-images.githubusercontent.com/94108/27504442-c4c873fe-585f-11e7-851a-e84ff7415fca.png)

> 12:34 -!- Irssi: warning The TERM environment variable is set to 'xterm' which can cause display glitches when running under tmux.
> 12:34 -!- Irssi: Consider changing TERM to 'screen' or 'screen-256color' instead.

Feel free to bikeshed the text of the message, not sure i'm entirely happy with it myself.

* The "can cause display glitches" has a bit too much certainty given how little this code knows about screen-compatible TERM values. Maybe it's ok.

* I like the tradeoff of suggesting only 'screen' or 'screen-256color' and not mentioning 'tmux' and 'tmux-256color' - while the latter is slightly better, I found it's a bit annoying to set globally and then get errors when you ssh to servers with older terminfo that don't know about it.

* Mentioning the name of the multiplexer hopefully helps mitigate the unavoidable "it tells me to use screen but i'm using tmux" but it's not foolproof. Not that anything is.

* I think half of the issues are about someone setting TERM inside .bashrc or equivalent, but some of them have the wrong TERM inside the multiplexer config itself. Could consider guiding users to look in some of those places. Or not.

Out of scope concern: Starting my main irssi connects me to a trillion servers and this message would be lost up there, but the same thing applies to script load failures and other early-startup errors.