### PR TITLE
Clarified ambiguous autogen.sh error

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -39,6 +39,7 @@ elif type links >/dev/null 2>&1 ; then
   links -dump docs/faq.html|perl -pe 's/^ *//; if ($_ eq "\n" && $state eq "Q") { $_ = ""; } elsif (/^([QA]):/) { $state = $1 } elsif ($_ ne "\n") { $_ = "   $_"; };' > docs/faq.txt
 else
   echo "**Error**: No lynx or elinks present"
+  echo "Install lynx or elinks, then run autogen.sh again"
   exit 1
 fi
 


### PR DESCRIPTION
autogen.sh now instructs the user to install elinks or lynx if needed.

To install the program, I needed to read autogen.sh to understand that lynx and elinks were applications. Now: When run without neither elinks nor lynx, autogen.sh now echos the following, lowest line mine. 

```
Documentation: html -> txt...
**Error**: No lynx or elinks present
Install lynx or elinks, then run autogen.sh again
```