### PR TITLE
Don't compute log_dir_create_mode in three different places.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -158,7 +158,7 @@ AC_ARG_ENABLE(true-color,
 	want_truecolor=no)
 
 AC_ARG_ENABLE(gregex,
-[  --disable-gregex     Build without GRegex (fall back to regex.h)],
+[  --disable-gregex        Build without GRegex (fall back to regex.h)],
 	if test x$enableval = xno ; then
 		want_gregex=no
 	else

--- a/src/core/log.c
+++ b/src/core/log.c
@@ -33,6 +33,8 @@
 #define DEFAULT_LOG_FILE_CREATE_MODE 600
 
 GSList *logs;
+int log_file_create_mode;
+int log_dir_create_mode;
 
 static const char *log_item_types[] = {
 	"target",
@@ -42,8 +44,6 @@ static const char *log_item_types[] = {
 };
 
 static char *log_timestamp;
-static int log_file_create_mode;
-static int log_dir_create_mode;
 static int rotate_tag;
 
 static int log_item_str2type(const char *type)
@@ -562,7 +562,6 @@ static void read_settings(void)
 	log_timestamp = g_strdup(settings_get_str("log_timestamp"));
 
 	log_file_create_mode = octal2dec(settings_get_int("log_create_mode"));
-
 	log_dir_create_mode = log_file_create_mode;
 	if (log_file_create_mode & 0400) log_dir_create_mode |= 0100;
 	if (log_file_create_mode & 0040) log_dir_create_mode |= 0010;

--- a/src/core/log.h
+++ b/src/core/log.h
@@ -35,6 +35,8 @@ struct _LOG_REC {
 };
 
 extern GSList *logs;
+extern int log_file_create_mode;
+extern int log_dir_create_mode;
 
 /* Create log record - you still need to call log_update() to actually add it
    into log list */

--- a/src/core/rawlog.c
+++ b/src/core/rawlog.c
@@ -128,6 +128,9 @@ void rawlog_open(RAWLOG_REC *rawlog, const char *fname)
 	path = convert_home(fname);
 	rawlog->handle = open(path, O_WRONLY | O_APPEND | O_CREAT,
 			      log_file_create_mode);
+	if (rawlog->handle == -1) {
+		g_warning("rawlog open() failed: %s", strerror(errno));
+	}
 	g_free(path);
 
 	rawlog_dump(rawlog, rawlog->handle);

--- a/src/core/rawlog.c
+++ b/src/core/rawlog.c
@@ -128,13 +128,15 @@ void rawlog_open(RAWLOG_REC *rawlog, const char *fname)
 	path = convert_home(fname);
 	rawlog->handle = open(path, O_WRONLY | O_APPEND | O_CREAT,
 			      log_file_create_mode);
-	if (rawlog->handle == -1) {
-		g_warning("rawlog open() failed: %s", strerror(errno));
-	}
 	g_free(path);
 
+	if (rawlog->handle == -1) {
+		g_warning("rawlog open() failed: %s", strerror(errno));
+		return;
+	}
+
 	rawlog_dump(rawlog, rawlog->handle);
-	rawlog->logging = rawlog->handle != -1;
+	rawlog->logging = TRUE;
 }
 
 void rawlog_close(RAWLOG_REC *rawlog)

--- a/src/core/rawlog.c
+++ b/src/core/rawlog.c
@@ -20,6 +20,7 @@
 
 #include "module.h"
 #include "rawlog.h"
+#include "log.h"
 #include "modules.h"
 #include "signals.h"
 #include "commands.h"
@@ -31,8 +32,6 @@
 
 static int rawlog_lines;
 static int signal_rawlog;
-static int log_file_create_mode;
-static int log_dir_create_mode;
 
 RAWLOG_REC *rawlog_create(void)
 {
@@ -174,12 +173,6 @@ void rawlog_set_size(int lines)
 static void read_settings(void)
 {
 	rawlog_set_size(settings_get_int("rawlog_lines"));
-	log_file_create_mode = octal2dec(settings_get_int("log_create_mode"));
-        log_dir_create_mode = log_file_create_mode;
-        if (log_file_create_mode & 0400) log_dir_create_mode |= 0100;
-        if (log_file_create_mode & 0040) log_dir_create_mode |= 0010;
-        if (log_file_create_mode & 0004) log_dir_create_mode |= 0001;
-
 }
 
 static void cmd_rawlog(const char *data, SERVER_REC *server, void *item)

--- a/src/core/rawlog.c
+++ b/src/core/rawlog.c
@@ -144,7 +144,7 @@ void rawlog_close(RAWLOG_REC *rawlog)
 	if (rawlog->logging) {
 		write_buffer_flush();
 		close(rawlog->handle);
-		rawlog->logging = 0;
+		rawlog->logging = FALSE;
 	}
 }
 

--- a/src/fe-common/core/fe-log.c
+++ b/src/fe-common/core/fe-log.c
@@ -49,8 +49,6 @@ static THEME_REC *log_theme;
 static int skip_next_printtext;
 static char *log_theme_name;
 
-static int log_dir_create_mode;
-
 static char **autolog_ignore_targets;
 
 static char *log_colorizer_strip(const char *str)
@@ -676,7 +674,6 @@ static void sig_theme_destroyed(THEME_REC *theme)
 static void read_settings(void)
 {
 	int old_autolog = autolog_level;
-	int log_file_create_mode;
 
 	g_free_not_null(autolog_path);
 	autolog_path = g_strdup(settings_get_str("autolog_path"));
@@ -703,12 +700,6 @@ static void read_settings(void)
 
 	log_theme = log_theme_name == NULL ? NULL :
 		theme_load(log_theme_name);
-
-	log_file_create_mode = octal2dec(settings_get_int("log_create_mode"));
-        log_dir_create_mode = log_file_create_mode;
-        if (log_file_create_mode & 0400) log_dir_create_mode |= 0100;
-        if (log_file_create_mode & 0040) log_dir_create_mode |= 0010;
-        if (log_file_create_mode & 0004) log_dir_create_mode |= 0001;
 
 	if (autolog_ignore_targets != NULL)
 		g_strfreev(autolog_ignore_targets);


### PR DESCRIPTION
Signed-off-by: Edward Tomasz Napierala <trasz@FreeBSD.org>