### PR TITLE
Revert "Merge pull request #452 from LemonBoy/terminfo-cup"

### DIFF
--- a/src/fe-text/term-terminfo.c
+++ b/src/fe-text/term-terminfo.c
@@ -629,6 +629,13 @@ void term_stop(void)
 {
 	terminfo_stop(current_term);
 	kill(getpid(), SIGTSTP);
+	/* this call needs to stay here in case the TSTP was ignored,
+	   because then we never see a CONT to call the restoration
+	   code. On the other hand we also cannot remove the CONT
+	   handler because then nothing would restore the screen when
+	   Irssi is killed with TSTP/STOP from external. */
+	terminfo_cont(current_term);
+	irssi_redraw();
 }
 
 static int input_utf8(const unsigned char *buffer, int size, unichar *result)


### PR DESCRIPTION
Fixes #733. The fix outlined in #452 had adverse effects for the
following reason. The code removed the restoration path that would go on
the code path from kill SIGTSTP. The problem is this: When Irssi is not
running in a controlling parent (like a shell), the TSTP will in fact be
ignored. In that case, there is no process sending a CONT either and
thus the screen state never gets restored. Luckily, the patch in #457 is
sufficient to prevent the problem in #450 (which lead to the development
of #452). To that end, we do end up with potentially calling
terminfo_cont twice but that is better than not calling it at all.

This reverts commit b1ffd5f6472584aa3966746da9728c5afefcc4ce, reversing
changes made to 9cb0419435d1ad331c1f55361a003d9682fae9a8.