### PR TITLE
OS X install notes

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -82,8 +82,8 @@ things that can go wrong:
  - If configure complains that it doesn't find some perl stuff, you're
    probably missing libperl.so or libperl.a. In debian, you'll need to do
    apt-get install libperl-dev
- - For unprivileged home directory installations, you probably do not want 
-   to specify --with-perl-lib=(site|vendor). Instead, you can use the 
+ - For unprivileged home directory installations, you probably do not want
+   to specify --with-perl-lib=(site|vendor). Instead, you can use the
    default perl installation target (below the irssi prefix). If you are
    using local::lib you can also choose to install there by specifying
    --with-perl-lib=$PERL_LOCAL_LIB_ROOT/lib/perl5
@@ -113,3 +113,17 @@ Getting perl scripting to work needs a few things:
    It doesn't hurt to be defined everywhere, so configure irssi with:
 
      CFLAGS='-DUSEIMPORTLIB' ./configure --with-perl-staticlib
+
+ OS X
+
+Build may fail with a message similar to:
+
+    "_EVP_PKEY_id", referenced from:
+          _irssi_ssl_handshake in libcore.a(network-openssl.o)
+    ld: symbol(s) not found for architecture x86_64
+
+To resolve this run
+
+    CPPFLAGS=-I/path/to/recent/openssl/include \
+    LDFLAGS=-L/path/to/recent/openssl/lib \
+    ./configure

--- a/INSTALL
+++ b/INSTALL
@@ -117,9 +117,9 @@ Getting perl scripting to work needs a few things:
  OS X
 
 Build may fail with a message similar to:
-
-    "_EVP_PKEY_id", referenced from:
-          _irssi_ssl_handshake in libcore.a(network-openssl.o)
+    Undefined symbols for architecture x86_64:
+        "_EVP_PKEY_id", referenced from:
+              _irssi_ssl_handshake in libcore.a(network-openssl.o)
     ld: symbol(s) not found for architecture x86_64
 
 To resolve this run


### PR DESCRIPTION
I was having problems building Irssi from source on OS X and found the issue was that the system openSSL library was the problem. I updated the INSTALL file so that hopefully people don't have to
search too far if they have this problem as well.