### PR TITLE
Increment the X509_STORE refcount during the connection

### DIFF
--- a/src/core/network-openssl.c
+++ b/src/core/network-openssl.c
@@ -45,6 +45,19 @@
 #define ASN1_STRING_data(x)       ASN1_STRING_get0_data(x)
 #endif
 
+/* OpenSSL 1.1.0 also introduced some useful additions to the api */
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined (LIBRESSL_VERSION_NUMBER)
+static int X509_STORE_up_ref(X509_STORE *vfy)
+{
+    int n;
+
+    n = CRYPTO_add(&vfy->references, 1, CRYPTO_LOCK_X509_STORE);
+    g_assert(n > 1);
+
+    return (n > 1) ? 1 : 0;
+}
+#endif
+
 /* ssl i/o channel object */
 typedef struct
 {

--- a/src/core/network-openssl.c
+++ b/src/core/network-openssl.c
@@ -510,6 +510,10 @@ static GIOChannel *irssi_ssl_get_iochannel(GIOChannel *handle, int port, SERVER_
 		g_free(scapath);
 		verify = TRUE;
 	} else if (store != NULL) {
+		/* Make sure to increment the refcount every time the store is
+		 * used, that's essential not to get it free'd by OpenSSL when
+		 * the SSL_CTX is destroyed. */
+		X509_STORE_up_ref(store);
 		SSL_CTX_set_cert_store(ctx, store);
 	}
 


### PR DESCRIPTION
OpenSSL doesn't increment the reference count when the store is assigned
to a SSL_CTX.

Fixes #750 