### PR TITLE
Get rid of the zombies in Capsicum capability mode.

### DIFF
--- a/src/core/capsicum.c
+++ b/src/core/capsicum.c
@@ -403,6 +403,13 @@ static void cmd_capsicum_enter(void)
 		return;
 	}
 
+	/*
+	 * XXX: We should use pdwait(2) to wait for children.  Unfortunately
+	 *      it's not implemented yet.  Thus the workaround, to get rid
+	 *      of the zombies at least.
+	 */
+	signal(SIGCHLD, SIG_IGN);
+
 	error = cap_enter();
 	if (error != 0) {
 		signal_emit("capability mode failed", 1, strerror(errno));


### PR DESCRIPTION
This solves the problem where Irssi running in capability mode would leave zombies, probably from either DNS resolving or connecting in the background.  The reason, from what I understand, is that glib doesn't know about Capsicum and cannot use process descriptors; the usual method of waiting for processes - wait(2) et al - is not available in capability mode due to requiring access to a global namespace (PID namespace in this case).  The right thing would be to add the neccessary functionality to glib - but until this happens, this workaround should be ok - I don't think it breaks anything that isn't already broken in capability mode, like Perl.

Signed-off-by: Edward Tomasz Napierala <trasz@FreeBSD.org>