### PR TITLE
Add color support for input bar

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -6,7 +6,7 @@
 #define IRSSI_GLOBAL_CONFIG "irssi.conf" /* config file name in /etc/ */
 #define IRSSI_HOME_CONFIG "config" /* config file name in ~/.irssi/ */
 
-#define IRSSI_ABI_VERSION 13
+#define IRSSI_ABI_VERSION 14
 
 #define DEFAULT_SERVER_ADD_PORT 6667
 #define DEFAULT_SERVER_ADD_TLS_PORT 6697

--- a/src/fe-text/gui-entry.c
+++ b/src/fe-text/gui-entry.c
@@ -1107,7 +1107,7 @@ void gui_entry_set_color(GUI_ENTRY_REC *entry, int pos, int len, int color)
 
 	g_return_if_fail(entry != NULL);
 
-	if (pos > entry->text_len)
+	if (pos < 0 || len < 0 || pos > entry->text_len)
 		return;
 
 	end = pos + len;

--- a/src/fe-text/gui-entry.c
+++ b/src/fe-text/gui-entry.c
@@ -242,7 +242,6 @@ static void gui_entry_fix_cursor(GUI_ENTRY_REC *entry)
 static void gui_entry_draw_from(GUI_ENTRY_REC *entry, int pos)
 {
 	int i;
-	const int *col;
 	int xpos, end_xpos, color;
 
 	xpos = entry->xpos + entry->promptlen +
@@ -257,10 +256,9 @@ static void gui_entry_draw_from(GUI_ENTRY_REC *entry, int pos)
 	term_set_color(root_window, ATTR_RESET);
 	term_move(root_window, xpos, entry->ypos);
 
-	col = entry->scrstart + pos < entry->text_len ?
-			entry->colors + entry->scrstart + pos : 0;
-	for (i = entry->scrstart + pos; i < entry->text_len; i++, col++) {
+	for (i = entry->scrstart + pos; i < entry->text_len; i++) {
 		unichar c = entry->text[i];
+		int col = entry->colors[i];
 
 		if (entry->hidden)
 			xpos++;
@@ -274,9 +272,9 @@ static void gui_entry_draw_from(GUI_ENTRY_REC *entry, int pos)
 		if (xpos > end_xpos)
 			break;
 
-		if (*col != color) {
-			term_set_color(root_window, *col);
-			color = *col;
+		if (col != color) {
+			term_set_color(root_window, col);
+			color = col;
 		}
 
 		if (entry->hidden)
@@ -522,7 +520,7 @@ void gui_entry_insert_text(GUI_ENTRY_REC *entry, const char *str)
 		}
 	}
 
-	for(i = 0; i < len; i++) {
+	for (i = 0; i < len; i++) {
 		entry->colors[entry->pos + i] = ATTR_RESET;
 	}
 
@@ -915,7 +913,6 @@ void gui_entry_transpose_words(GUI_ENTRY_REC *entry)
 		g_free(first_color);
 		g_free(sep_color);
 		g_free(second_color);
-
 	}
 
 	gui_entry_redraw_from(entry, spos1);
@@ -1106,7 +1103,7 @@ void gui_entry_redraw(GUI_ENTRY_REC *entry)
 
 void gui_entry_set_color(GUI_ENTRY_REC *entry, int pos, int len, int color)
 {
-	int i, end, update = 0;
+	int i, end, update = FALSE;
 
 	g_return_if_fail(entry != NULL);
 
@@ -1121,7 +1118,7 @@ void gui_entry_set_color(GUI_ENTRY_REC *entry, int pos, int len, int color)
 	for (i = pos; i < end; i++) {
 		if (entry->colors[i] != color) {
 			entry->colors[i] = color;
-			update = 1;
+			update = TRUE;
 		}
 	}
 

--- a/src/fe-text/gui-entry.h
+++ b/src/fe-text/gui-entry.h
@@ -9,6 +9,7 @@ typedef struct {
 typedef struct {
 	int text_len, text_alloc; /* as shorts, not chars */
 	unichar *text;
+	int *colors;
 
 	GSList *kill_ring;
 
@@ -77,5 +78,6 @@ void gui_entry_move_words(GUI_ENTRY_REC *entry, int count, int to_space);
 
 void gui_entry_redraw(GUI_ENTRY_REC *entry);
 
+void gui_entry_set_color(GUI_ENTRY_REC *entry, int pos, int len, int color);
 
 #endif

--- a/src/fe-text/gui-entry.h
+++ b/src/fe-text/gui-entry.h
@@ -9,7 +9,7 @@ typedef struct {
 typedef struct {
 	int text_len, text_alloc; /* as shorts, not chars */
 	unichar *text;
-	int *colors;
+	char **extents;
 
 	GSList *kill_ring;
 
@@ -27,6 +27,7 @@ typedef struct {
 	unsigned int previous_append_next_kill:1;
 	unsigned int append_next_kill:1;
 	unsigned int yank_preceded:1;
+	unsigned int uses_extents:1;
 } GUI_ENTRY_REC;
 
 typedef enum {
@@ -78,6 +79,14 @@ void gui_entry_move_words(GUI_ENTRY_REC *entry, int count, int to_space);
 
 void gui_entry_redraw(GUI_ENTRY_REC *entry);
 
-void gui_entry_set_color(GUI_ENTRY_REC *entry, int pos, int len, int color);
+void gui_entry_set_extent(GUI_ENTRY_REC *entry, int pos, const char *text);
+void gui_entry_set_extents(GUI_ENTRY_REC *entry, int pos, int len, const char *left, const char *right);
+void gui_entry_clear_extents(GUI_ENTRY_REC *entry, int pos, int len);
+char *gui_entry_get_extent(GUI_ENTRY_REC *entry, int pos);
+GSList *gui_entry_get_text_and_extents(GUI_ENTRY_REC *entry);
+void gui_entry_set_text_and_extents(GUI_ENTRY_REC *entry, GSList *list);
+
+void gui_entry_init(void);
+void gui_entry_deinit(void);
 
 #endif

--- a/src/fe-text/irssi.c
+++ b/src/fe-text/irssi.c
@@ -165,6 +165,7 @@ static void textui_finish_init(void)
 	gui_expandos_init();
 	gui_printtext_init();
 	gui_readline_init();
+	gui_entry_init();
 	lastlog_init();
 	mainwindows_init();
 	mainwindow_activity_init();
@@ -230,6 +231,7 @@ static void textui_deinit(void)
 
 	lastlog_deinit();
 	statusbar_deinit();
+	gui_entry_deinit();
 	gui_printtext_deinit();
 	gui_readline_deinit();
 	gui_windows_deinit();

--- a/src/perl/textui/TextUI.xs
+++ b/src/perl/textui/TextUI.xs
@@ -124,6 +124,14 @@ gui_input_set(str)
 CODE:
 	gui_entry_set_text(active_entry, str);
 
+void
+gui_input_color(pos, len, color)
+	int pos
+	int len
+	int color
+CODE:
+	gui_entry_set_color(active_entry, pos, len, color);
+
 int
 gui_input_get_pos()
 CODE:

--- a/src/perl/textui/TextUI.xs
+++ b/src/perl/textui/TextUI.xs
@@ -125,12 +125,72 @@ CODE:
 	gui_entry_set_text(active_entry, str);
 
 void
-gui_input_color(pos, len, color)
+gui_input_set_extent(pos, text)
+	int pos
+	char *text
+PREINIT:
+	char *tt;
+CODE:
+	tt = text != NULL ? format_string_expand(text, NULL) : NULL;
+	gui_entry_set_extent(active_entry, pos, tt);
+	g_free(tt);
+
+void
+gui_input_set_extents(pos, len, left, right)
 	int pos
 	int len
-	int color
+	char *left
+	char *right
+PREINIT:
+	char *tl;
+	char *tr;
 CODE:
-	gui_entry_set_color(active_entry, pos, len, color);
+	tl = left != NULL ? format_string_expand(left, NULL) : NULL;
+	tr = right != NULL ? format_string_expand(right, NULL) : NULL;
+	gui_entry_set_extents(active_entry, pos, len, tl, tr);
+	g_free(tl);
+	g_free(tr);
+
+void
+gui_input_clear_extents(pos, len = 0)
+	int pos
+	int len
+CODE:
+	gui_entry_clear_extents(active_entry, pos, len);
+
+void
+gui_input_get_extent(pos)
+	int pos
+PREINIT:
+	char *ret;
+PPCODE:
+	ret = gui_entry_get_extent(active_entry, pos);
+	XPUSHs(sv_2mortal(new_pv(ret)));
+	g_free(ret);
+
+void
+gui_input_get_text_and_extents()
+PREINIT:
+	GSList *ret, *tmp;
+PPCODE:
+	ret = gui_entry_get_text_and_extents(active_entry);
+	for (tmp = ret; tmp != NULL; tmp = tmp->next) {
+		XPUSHs(sv_2mortal(new_pv(tmp->data)));
+	}
+	g_slist_free_full(ret, g_free);
+
+void
+gui_input_set_text_and_extents(...)
+PREINIT:
+	GSList *list;
+	int i;
+PPCODE:
+	list = NULL;
+	for (i = items; i > 0; i--) {
+		list = g_slist_prepend(list, SvPV_nolen(ST(i-1)));
+	}
+	gui_entry_set_text_and_extents(active_entry, list);
+	g_slist_free(list);
 
 int
 gui_input_get_pos()


### PR DESCRIPTION
This is mostly a rebase of [this patch](http://bugs.irssi.org/index.php?do=details&task_id=621), with a few bugfixes (a segfault in `gui_entry_transpose_words`, and a pointer-to-int assignment).

Allows scripts to specify that ranges of characters in the input bar should be rendered in specific colors; the original intent for this was to implement a spellchecker, my use is to colorise nicks in the input bar.

Example script using this, mostly based on my rewritten [colorize_nicks.pl](https://github.com/irssi/scripts.irssi.org/blob/master/scripts/colorize_nicks.pl): https://thanatos.gn32.uk/f/colorise_input.pl (I'll likely clean up the code a little and submit for scripts.irssi.org, assuming this PR gets merged)