### PR TITLE
Set host to an empty string on error

### DIFF
--- a/src/core/network.c
+++ b/src/core/network.c
@@ -489,7 +489,16 @@ int net_gethostbyaddr(IPADDR *ip, char **name)
 
 int net_ip2host(IPADDR *ip, char *host)
 {
-	return inet_ntop(ip->family, &ip->ip, host, MAX_IP_LEN) ? 0 : -1;
+	if (inet_ntop(ip->family, &ip->ip, host, MAX_IP_LEN)) {
+		return 0;
+	}
+
+	// For callers that do not check our return value and pass in an
+	// uninitialized buffer assuming it will be set, ensure the buffer is a valid
+	// string. Ideally callers should check what we return and handle
+	// appropriately, but this at least gives us safety.
+	host[0] = '\0';
+	return -1;
 }
 
 int net_host2ip(const char *host, IPADDR *ip)

--- a/src/core/network.c
+++ b/src/core/network.c
@@ -489,16 +489,8 @@ int net_gethostbyaddr(IPADDR *ip, char **name)
 
 int net_ip2host(IPADDR *ip, char *host)
 {
-	if (inet_ntop(ip->family, &ip->ip, host, MAX_IP_LEN)) {
-		return 0;
-	}
-
-	// For callers that do not check our return value and pass in an
-	// uninitialized buffer assuming it will be set, ensure the buffer is a valid
-	// string. Ideally callers should check what we return and handle
-	// appropriately, but this at least gives us safety.
 	host[0] = '\0';
-	return -1;
+	return inet_ntop(ip->family, &ip->ip, host, MAX_IP_LEN) ? 0 : -1;
 }
 
 int net_host2ip(const char *host, IPADDR *ip)


### PR DESCRIPTION
While investigating #317, I noticed that it was possible we would access
an uninitialized buffer due to failing to check the return value of
net_ip2host(). This is done in several places. To make such uses safe,
set the host buffer to an empty string on error. It is possible callers
could be improved by handling the error in each spot, but this gives us
some safety.