### PR TITLE
Remove a couple unused functions

### DIFF
--- a/src/core/network.c
+++ b/src/core/network.c
@@ -60,18 +60,6 @@ IPADDR ip4_any = {
 #endif
 };
 
-int net_ip_compare(IPADDR *ip1, IPADDR *ip2)
-{
-	if (ip1->family != ip2->family)
-		return 0;
-
-	if (ip1->family == AF_INET6)
-		return memcmp(&ip1->ip, &ip2->ip, sizeof(ip1->ip)) == 0;
-
-	return memcmp(&ip1->ip, &ip2->ip, 4) == 0;
-}
-
-
 static void sin_set_ip(union sockaddr_union *so, const IPADDR *ip)
 {
 	if (ip == NULL) {

--- a/src/core/network.c
+++ b/src/core/network.c
@@ -48,9 +48,6 @@ GIOChannel *g_io_channel_new(int handle)
 	return chan;
 }
 
-/* Cygwin need this, don't know others.. */
-/*#define BLOCKING_SOCKETS 1*/
-
 IPADDR ip4_any = {
 	AF_INET,
 #if defined(IN6ADDR_ANY_INIT)

--- a/src/core/network.c
+++ b/src/core/network.c
@@ -98,40 +98,6 @@ static int sin_get_port(union sockaddr_union *so)
 		     so->sin.sin_port);
 }
 
-/* Connect to socket */
-GIOChannel *net_connect(const char *addr, int port, IPADDR *my_ip)
-{
-	IPADDR ip4, ip6, *ip;
-
-	g_return_val_if_fail(addr != NULL, NULL);
-
-	if (net_gethostbyname(addr, &ip4, &ip6) == -1)
-		return NULL;
-
-	if (my_ip == NULL) {
-                /* prefer IPv4 addresses */
-		ip = ip4.family != 0 ? &ip4 : &ip6;
-	} else if (IPADDR_IS_V6(my_ip)) {
-                /* my_ip is IPv6 address, use it if possible */
-		if (ip6.family != 0)
-			ip = &ip6;
-		else {
-			my_ip = NULL;
-                        ip = &ip4;
-		}
-	} else {
-                /* my_ip is IPv4 address, use it if possible */
-		if (ip4.family != 0)
-			ip = &ip4;
-		else {
-			my_ip = NULL;
-                        ip = &ip6;
-		}
-	}
-
-	return net_connect_ip(ip, port, my_ip);
-}
-
 int net_connect_ip_handle(const IPADDR *ip, int port, const IPADDR *my_ip)
 {
 	union sockaddr_union so;

--- a/src/core/network.c
+++ b/src/core/network.c
@@ -57,6 +57,18 @@ IPADDR ip4_any = {
 #endif
 };
 
+int net_ip_compare(IPADDR *ip1, IPADDR *ip2)
+{
+	if (ip1->family != ip2->family)
+		return 0;
+
+	if (ip1->family == AF_INET6)
+		return memcmp(&ip1->ip, &ip2->ip, sizeof(ip1->ip)) == 0;
+
+	return memcmp(&ip1->ip, &ip2->ip, 4) == 0;
+}
+
+
 static void sin_set_ip(union sockaddr_union *so, const IPADDR *ip)
 {
 	if (ip == NULL) {

--- a/src/core/network.h
+++ b/src/core/network.h
@@ -35,8 +35,6 @@ GIOChannel *g_io_channel_new(int handle);
 
 int net_connect_ip_handle(const IPADDR *ip, int port, const IPADDR *my_ip);
 
-/* Connect to socket */
-GIOChannel *net_connect(const char *addr, int port, IPADDR *my_ip) G_GNUC_DEPRECATED;
 /* Connect to socket with ip address and SSL*/
 GIOChannel *net_connect_ip_ssl(IPADDR *ip, int port, IPADDR *my_ip, SERVER_REC *server);
 /* Start TLS */

--- a/src/core/network.h
+++ b/src/core/network.h
@@ -33,9 +33,6 @@ extern IPADDR ip4_any;
 
 GIOChannel *g_io_channel_new(int handle);
 
-/* returns 1 if IPADDRs are the same */
-int net_ip_compare(IPADDR *ip1, IPADDR *ip2);
-
 int net_connect_ip_handle(const IPADDR *ip, int port, const IPADDR *my_ip);
 
 /* Connect to socket */

--- a/src/core/network.h
+++ b/src/core/network.h
@@ -33,6 +33,9 @@ extern IPADDR ip4_any;
 
 GIOChannel *g_io_channel_new(int handle);
 
+/* returns 1 if IPADDRs are the same */
+int net_ip_compare(IPADDR *ip1, IPADDR *ip2);
+
 int net_connect_ip_handle(const IPADDR *ip, int port, const IPADDR *my_ip);
 
 /* Connect to socket with ip address and SSL*/

--- a/src/core/network.h
+++ b/src/core/network.h
@@ -33,8 +33,9 @@ extern IPADDR ip4_any;
 
 GIOChannel *g_io_channel_new(int handle);
 
-/* returns 1 if IPADDRs are the same */
-int net_ip_compare(IPADDR *ip1, IPADDR *ip2);
+/* Returns 1 if IPADDRs are the same. */
+/* Deprecated since it is unused. It will be deleted in a later release. */
+int net_ip_compare(IPADDR *ip1, IPADDR *ip2) G_GNUC_DEPRECATED;
 
 int net_connect_ip_handle(const IPADDR *ip, int port, const IPADDR *my_ip);
 


### PR DESCRIPTION
I noticed an unused function and then saw another. I see one was already marked deprecated, so maybe there's a reason we should keep it, but anyway.