### PR TITLE
CAP 3.2 support

### DIFF
--- a/src/core/misc.c
+++ b/src/core/misc.c
@@ -218,6 +218,19 @@ GSList *gslist_remove_string (GSList *list, const char *str)
 	return list;
 }
 
+GSList *gslist_delete_string (GSList *list, const char *str, GDestroyNotify free_func)
+{
+	GSList *l;
+
+	l = g_slist_find_custom(list, str, (GCompareFunc) g_strcmp0);
+	if (l != NULL) {
+		free_func(l->data);
+		return g_slist_delete_link(list, l);
+	}
+
+	return list;
+}
+
 /* `list' contains pointer to structure with a char* to string. */
 char *gslistptr_to_string(GSList *list, int offset, const char *delimiter)
 {

--- a/src/core/misc.h
+++ b/src/core/misc.h
@@ -22,6 +22,7 @@ GSList *gslist_find_icase_string(GSList *list, const char *key);
 GList *glist_find_string(GList *list, const char *key);
 GList *glist_find_icase_string(GList *list, const char *key);
 GSList *gslist_remove_string (GSList *list, const char *str);
+GSList *gslist_delete_string (GSList *list, const char *str, GDestroyNotify free_func);
 
 void gslist_free_full (GSList *list, GDestroyNotify free_func);
 

--- a/src/core/misc.h
+++ b/src/core/misc.h
@@ -21,7 +21,7 @@ GSList *gslist_find_string(GSList *list, const char *key);
 GSList *gslist_find_icase_string(GSList *list, const char *key);
 GList *glist_find_string(GList *list, const char *key);
 GList *glist_find_icase_string(GList *list, const char *key);
-GSList *gslist_remove_string (GSList *list, const char *str);
+GSList *gslist_remove_string (GSList *list, const char *str) G_GNUC_DEPRECATED;
 GSList *gslist_delete_string (GSList *list, const char *str, GDestroyNotify free_func);
 
 void gslist_free_full (GSList *list, GDestroyNotify free_func);

--- a/src/irc/core/irc-cap.c
+++ b/src/irc/core/irc-cap.c
@@ -140,7 +140,7 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 	caps = g_strsplit(g_strchomp(list), " ", -1);
 	caps_length = g_strv_length(caps);
 
-	if (!g_strcmp0(evt, "LS")) {
+	if (!strcmp(evt, "LS")) {
 		if (server->cap_supported) {
 			g_hash_table_destroy(server->cap_supported);
 		}
@@ -204,7 +204,7 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 			}
 		}
 	}
-	else if (!g_strcmp0(evt, "ACK")) {
+	else if (!strcmp(evt, "ACK")) {
 		int got_sasl = FALSE;
 
 		/* Emit a signal for every ack'd cap */
@@ -216,7 +216,7 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 			else
 				server->cap_active = g_slist_prepend(server->cap_active, g_strdup(caps[i]));
 
-			if (!g_strcmp0(caps[i], "sasl"))
+			if (!strcmp(caps[i], "sasl"))
 				got_sasl = TRUE;
 
 			cap_emit_signal(server, "ack", caps[i]);
@@ -228,7 +228,7 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 		if (got_sasl == FALSE)
 			cap_finish_negotiation(server);
 	}
-	else if (!g_strcmp0(evt, "NAK")) {
+	else if (!strcmp(evt, "NAK")) {
 		g_warning("The server answered with a NAK to our CAP request, this should not happen");
 
 		/* A NAK'd request means that a required cap can't be enabled or disabled, don't update the

--- a/src/irc/core/irc-cap.c
+++ b/src/irc/core/irc-cap.c
@@ -148,8 +148,12 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 	caps_length = g_strv_length(caps);
 
 	if (!g_ascii_strcasecmp(evt, "LS")) {
-		/* Throw away everything and start from scratch */
-		g_hash_table_remove_all(server->cap_supported);
+		if (!server->cap_in_multiline) {
+			/* Throw away everything and start from scratch */
+			g_hash_table_remove_all(server->cap_supported);
+		}
+
+		server->cap_in_multiline = multiline;
 
 		/* Create a list of the supported caps */
 		for (i = 0; i < caps_length; i++) {

--- a/src/irc/core/irc-cap.c
+++ b/src/irc/core/irc-cap.c
@@ -147,7 +147,7 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 	caps = g_strsplit(g_strchomp(list), " ", -1);
 	caps_length = g_strv_length(caps);
 
-	if (!strcmp(evt, "LS")) {
+	if (!g_ascii_strcasecmp(evt, "LS")) {
 		/* Throw away everything and start from scratch */
 		g_hash_table_remove_all(server->cap_supported);
 
@@ -204,7 +204,7 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 			}
 		}
 	}
-	else if (!strcmp(evt, "ACK")) {
+	else if (!g_ascii_strcasecmp(evt, "ACK")) {
 		int got_sasl = FALSE;
 
 		/* Emit a signal for every ack'd cap */
@@ -228,7 +228,7 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 		if (got_sasl == FALSE)
 			cap_finish_negotiation(server);
 	}
-	else if (!strcmp(evt, "NAK")) {
+	else if (!g_ascii_strcasecmp(evt, "NAK")) {
 		g_warning("The server answered with a NAK to our CAP request, this should not happen");
 
 		/* A NAK'd request means that a required cap can't be enabled or disabled, don't update the
@@ -236,7 +236,7 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 		for (i = 0; i < caps_length; i++)
 			cap_emit_signal(server, "nak", caps[i]);
 	}
-	else if (!strcmp(evt, "NEW")) {
+	else if (!g_ascii_strcasecmp(evt, "NEW")) {
 		for (i = 0; i < caps_length; i++) {
 			char *key, *val;
 
@@ -249,7 +249,7 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 			cap_emit_signal(server, "new", key);
 		}
 	}
-	else if (!strcmp(evt, "DEL")) {
+	else if (!g_ascii_strcasecmp(evt, "DEL")) {
 		for (i = 0; i < caps_length; i++) {
 			char *key, *val;
 

--- a/src/irc/core/irc-cap.c
+++ b/src/irc/core/irc-cap.c
@@ -155,17 +155,15 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 		for (i = 0; i < caps_length; i++) {
 			char *key, *val;
 
-			if (parse_cap_name(caps[i], &key, &val)) {
-				if (!g_hash_table_insert(server->cap_supported,
-							 key, val)) {
-					/* The specification doesn't say anything about
-					 * duplicated values, let's just warn the user */
-					g_warning("Duplicate value %s", key);
-				}
-			}
-			else {
+			if (!parse_cap_name(caps[i], &key, &val)) {
 				g_warning("Invalid CAP %s key/value pair", evt);
 				continue;
+			}
+
+			if (!g_hash_table_insert(server->cap_supported, key, val)) {
+				/* The specification doesn't say anything about
+				 * duplicated values, let's just warn the user */
+				g_warning("Duplicate value %s", key);
 			}
 		}
 
@@ -242,14 +240,12 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 		for (i = 0; i < caps_length; i++) {
 			char *key, *val;
 
-			if (parse_cap_name(caps[i], &key, &val)) {
-				g_hash_table_insert(server->cap_supported,
-						    key, val);
-			}
-			else {
+			if (!parse_cap_name(caps[i], &key, &val)) {
 				g_warning("Invalid CAP %s key/value pair", evt);
 				continue;
 			}
+
+			g_hash_table_insert(server->cap_supported, key, val);
 			cap_emit_signal(server, "new", key);
 		}
 	}
@@ -257,13 +253,12 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 		for (i = 0; i < caps_length; i++) {
 			char *key, *val;
 
-			if (parse_cap_name(caps[i], &key, &val)) {
-				g_hash_table_remove(server->cap_supported, key);
-			}
-			else {
+			if (!parse_cap_name(caps[i], &key, &val)) {
 				g_warning("Invalid CAP %s key/value pair", evt);
 				continue;
 			}
+
+			g_hash_table_remove(server->cap_supported, key);
 			cap_emit_signal(server, "delete", key);
 			/* The server removed this CAP, remove it from the list
 			 * of the active ones if we had requested it */

--- a/src/irc/core/irc-cap.c
+++ b/src/irc/core/irc-cap.c
@@ -163,7 +163,7 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 			if (!g_hash_table_insert(server->cap_supported, key, val)) {
 				/* The specification doesn't say anything about
 				 * duplicated values, let's just warn the user */
-				g_warning("Duplicate value %s", key);
+				g_warning("The server sent the %s capability twice", key);
 			}
 		}
 

--- a/src/irc/core/irc-cap.c
+++ b/src/irc/core/irc-cap.c
@@ -266,6 +266,10 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 			/* The server removed this CAP, remove it from the list
 			 * of the active ones if we had requested it */
 			server->cap_active = gslist_delete_string(server->cap_active, key, g_free);
+			/* We don't transfer the ownership of those two
+			 * variables this time, just free them when we're done. */
+			g_free(key);
+			g_free(val);
 		}
 	}
 	else {

--- a/src/irc/core/irc-cap.c
+++ b/src/irc/core/irc-cap.c
@@ -165,8 +165,8 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 			}
 			else {
 				g_warning("Invalid CAP %s key/value pair", evt);
+				continue;
 			}
-
 		}
 
 		/* A multiline response is always terminated by a normal one,
@@ -248,6 +248,7 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 			}
 			else {
 				g_warning("Invalid CAP %s key/value pair", evt);
+				continue;
 			}
 			cap_emit_signal(server, "new", key);
 		}
@@ -261,6 +262,7 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 			}
 			else {
 				g_warning("Invalid CAP %s key/value pair", evt);
+				continue;
 			}
 			cap_emit_signal(server, "delete", key);
 			/* The server removed this CAP, remove it from the list

--- a/src/irc/core/irc-cap.c
+++ b/src/irc/core/irc-cap.c
@@ -119,7 +119,7 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 
 	/* Multiline responses have an additional parameter and we have to do
 	 * this stupid dance to parse them */
-	if (evt[0] == 'L' && !strcmp(star, "*")) {
+	if (!g_ascii_strcasecmp(evt, "LS") && !strcmp(star, "*")) {
 		multiline = TRUE;
 	}
 	/* This branch covers the '*' parameter isn't present, adjust the

--- a/src/irc/core/irc-cap.c
+++ b/src/irc/core/irc-cap.c
@@ -91,19 +91,13 @@ static gboolean parse_cap_name(char *name, char **key, char **val)
 	if (eq == NULL) {
 		*key = g_strdup(name);
 		*val = NULL;
-		return TRUE;
 	/* Some values are in a KEY=VALUE form, parse them */
-	} else if (eq[1] != '\0') {
+	} else {
 		*key = g_strndup(name, (gsize)(eq - name));
 		*val = g_strdup(eq + 1);
-		return TRUE;
-	/* If the string ends after the '=' consider the value
-	 * as invalid */
-	} else {
-		*key = NULL;
-		*val = NULL;
-		return FALSE;
 	}
+
+	return TRUE;
 }
 
 static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *address)

--- a/src/irc/core/irc-cap.c
+++ b/src/irc/core/irc-cap.c
@@ -86,14 +86,14 @@ static gboolean parse_cap_name(char *name, char **key, char **val)
 
 	const char *eq = strchr(name, '=');
 	/* KEY only value */
-	if (!eq) {
+	if (eq == NULL) {
 		*key = g_strdup(name);
 		*val = NULL;
 		return TRUE;
 	}
 	/* Some values are in a KEY=VALUE form, parse them */
 	else if (eq[1] != '\0') {
-		*key = g_strndup(name, (int)(eq - name));
+		*key = g_strndup(name, (gsize)(eq - name));
 		*val = g_strdup(eq + 1);
 		return TRUE;
 	}

--- a/src/irc/core/irc-cap.c
+++ b/src/irc/core/irc-cap.c
@@ -135,19 +135,21 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 		return;
 	}
 
+	/* The table is created only when needed */
+	if (server->cap_supported == NULL) {
+		server->cap_supported = g_hash_table_new_full(g_str_hash,
+							      g_str_equal,
+							      g_free, g_free);
+	}
+
 	/* Strip the trailing whitespaces before splitting the string, some servers send responses with
 	 * superfluous whitespaces that g_strsplit the interprets as tokens */
 	caps = g_strsplit(g_strchomp(list), " ", -1);
 	caps_length = g_strv_length(caps);
 
 	if (!strcmp(evt, "LS")) {
-		if (server->cap_supported) {
-			g_hash_table_destroy(server->cap_supported);
-		}
-		/* Start with a fresh table */
-		server->cap_supported = g_hash_table_new_full(g_str_hash,
-							      g_str_equal,
-							      g_free, g_free);
+		/* Throw away everything and start from scratch */
+		g_hash_table_remove_all(server->cap_supported);
 
 		/* Create a list of the supported caps */
 		for (i = 0; i < caps_length; i++) {

--- a/src/irc/core/irc-cap.c
+++ b/src/irc/core/irc-cap.c
@@ -79,6 +79,33 @@ static void cap_emit_signal (IRC_SERVER_REC *server, char *cmd, char *args)
 	g_free(signal_name);
 }
 
+static gboolean parse_cap_name(char *name, char **key, char **val)
+{
+	g_return_val_if_fail(name != NULL, FALSE);
+	g_return_val_if_fail(name[0] != '\0', FALSE);
+
+	const char *eq = strchr(name, '=');
+	/* KEY only value */
+	if (!eq) {
+		*key = g_strdup(name);
+		*val = NULL;
+		return TRUE;
+	}
+	/* Some values are in a KEY=VALUE form, parse them */
+	else if (eq[1] != '\0') {
+		*key = g_strndup(name, (int)(eq - name));
+		*val = g_strdup(eq + 1);
+		return TRUE;
+	}
+	/* If the string ends after the '=' consider the value
+	 * as invalid */
+	else {
+		*key = NULL;
+		*val = NULL;
+		return FALSE;
+	}
+}
+
 static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *address)
 {
 	GSList *tmp;
@@ -106,33 +133,20 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 
 		/* Create a list of the supported caps */
 		for (i = 0; i < caps_length; i++) {
-			const char *name = caps[i];
-			const char *eq = strchr(name, '=');
-			int fresh = TRUE;
+			char *key, *val;
 
-			if (!eq) {
-				fresh = g_hash_table_insert(server->cap_supported,
-							    g_strdup(name),
-							    NULL);
+			if (parse_cap_name(caps[i], &key, &val)) {
+				if (!g_hash_table_insert(server->cap_supported,
+							 key, val)) {
+					/* The specification doesn't say anything about
+					 * duplicated values, let's just warn the user */
+					g_warning("Duplicate value");
+				}
 			}
-			/* Some values are in a KEY=VALUE form, parse them */
-			else if (eq[1] != '\0') {
-				char *key = g_strndup(name, (int)(eq - name));
-				char *val = g_strdup(eq + 1);
-				fresh = g_hash_table_insert(server->cap_supported,
-							    key, val);
-			}
-			/* If the string ends after the '=' consider the value
-			 * as invalid */
 			else {
 				g_warning("Invalid CAP key/value pair");
 			}
 
-			/* The specification doesn't say anything about
-			 * duplicated values, let's just warn the user */
-			if (fresh == FALSE) {
-				g_warning("Duplicate value");
-			}
 		}
 
 		/* Request the required caps, if any */

--- a/src/irc/core/irc-cap.c
+++ b/src/irc/core/irc-cap.c
@@ -36,7 +36,7 @@ int cap_toggle (IRC_SERVER_REC *server, char *cap, int enable)
 			return TRUE;
 		}
 		else if (!enable && gslist_find_string(server->cap_queue, cap)) {
-			server->cap_queue = gslist_remove_string(server->cap_queue, cap);
+			server->cap_queue = gslist_delete_string(server->cap_queue, cap, g_free);
 			return TRUE;
 		}
 
@@ -135,8 +135,6 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 		return;
 	}
 
-	g_warning("%s -> %s", evt, list);
-
 	/* Strip the trailing whitespaces before splitting the string, some servers send responses with
 	 * superfluous whitespaces that g_strsplit the interprets as tokens */
 	caps = g_strsplit(g_strchomp(list), " ", -1);
@@ -214,7 +212,7 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 			disable = (*caps[i] == '-');
 
 			if (disable)
-				server->cap_active = gslist_remove_string(server->cap_active, caps[i] + 1);
+				server->cap_active = gslist_delete_string(server->cap_active, caps[i] + 1, g_free);
 			else
 				server->cap_active = g_slist_prepend(server->cap_active, g_strdup(caps[i]));
 
@@ -265,7 +263,7 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 			cap_emit_signal(server, "delete", key);
 			/* The server removed this CAP, remove it from the list
 			 * of the active ones if we had requested it */
-			server->cap_active = gslist_remove_string(server->cap_active, key);
+			server->cap_active = gslist_delete_string(server->cap_active, key, g_free);
 		}
 	}
 	else {

--- a/src/irc/core/irc-cap.c
+++ b/src/irc/core/irc-cap.c
@@ -81,25 +81,25 @@ static void cap_emit_signal (IRC_SERVER_REC *server, char *cmd, char *args)
 
 static gboolean parse_cap_name(char *name, char **key, char **val)
 {
+	const char *eq;
+
 	g_return_val_if_fail(name != NULL, FALSE);
 	g_return_val_if_fail(name[0] != '\0', FALSE);
 
-	const char *eq = strchr(name, '=');
+	eq = strchr(name, '=');
 	/* KEY only value */
 	if (eq == NULL) {
 		*key = g_strdup(name);
 		*val = NULL;
 		return TRUE;
-	}
 	/* Some values are in a KEY=VALUE form, parse them */
-	else if (eq[1] != '\0') {
+	} else if (eq[1] != '\0') {
 		*key = g_strndup(name, (gsize)(eq - name));
 		*val = g_strdup(eq + 1);
 		return TRUE;
-	}
 	/* If the string ends after the '=' consider the value
 	 * as invalid */
-	else {
+	} else {
 		*key = NULL;
 		*val = NULL;
 		return FALSE;

--- a/src/irc/core/irc-servers.c
+++ b/src/irc/core/irc-servers.c
@@ -443,7 +443,7 @@ static void sig_disconnected(IRC_SERVER_REC *server)
 	gslist_free_full(server->cap_active, (GDestroyNotify) g_free);
 	server->cap_active = NULL;
 
-	gslist_free_full(server->cap_supported, (GDestroyNotify) g_free);
+	g_hash_table_destroy(server->cap_supported);
 	server->cap_supported = NULL;
 
 	gslist_free_full(server->cap_queue, (GDestroyNotify) g_free);

--- a/src/irc/core/irc-servers.c
+++ b/src/irc/core/irc-servers.c
@@ -444,8 +444,8 @@ static void sig_disconnected(IRC_SERVER_REC *server)
 	server->cap_active = NULL;
 
 	if (server->cap_supported) {
-	    g_hash_table_destroy(server->cap_supported);
-	    server->cap_supported = NULL;
+		g_hash_table_destroy(server->cap_supported);
+		server->cap_supported = NULL;
 	}
 
 	gslist_free_full(server->cap_queue, (GDestroyNotify) g_free);

--- a/src/irc/core/irc-servers.c
+++ b/src/irc/core/irc-servers.c
@@ -443,8 +443,10 @@ static void sig_disconnected(IRC_SERVER_REC *server)
 	gslist_free_full(server->cap_active, (GDestroyNotify) g_free);
 	server->cap_active = NULL;
 
-	g_hash_table_destroy(server->cap_supported);
-	server->cap_supported = NULL;
+	if (server->cap_supported) {
+	    g_hash_table_destroy(server->cap_supported);
+	    server->cap_supported = NULL;
+	}
 
 	gslist_free_full(server->cap_queue, (GDestroyNotify) g_free);
 	server->cap_queue = NULL;

--- a/src/irc/core/irc-servers.h
+++ b/src/irc/core/irc-servers.h
@@ -75,7 +75,7 @@ struct _IRC_SERVER_REC {
 	int max_whois_in_cmd; /* max. number of nicks in one /WHOIS command */
 	int max_msgs_in_cmd; /* max. number of targets in one /MSG */
 
-	GSList *cap_supported; /* A list of caps supported by the server */
+	GHashTable *cap_supported; /* A list of caps supported by the server */
 	GSList *cap_active;    /* A list of caps active for this session */
 	GSList *cap_queue;     /* A list of caps to request on connection */ 
 

--- a/src/irc/core/irc-servers.h
+++ b/src/irc/core/irc-servers.h
@@ -68,6 +68,7 @@ struct _IRC_SERVER_REC {
 	unsigned int motd_got:1; /* We've received MOTD */
 	unsigned int isupport_sent:1; /* Server has sent us an isupport reply */
 	unsigned int cap_complete:1; /* We've done the initial CAP negotiation */
+	unsigned int cap_in_multiline:1; /* We're waiting for the multiline response to end */
 	unsigned int sasl_success:1; /* Did we authenticate successfully ? */
 
 	int max_kicks_in_cmd; /* max. number of people to kick with one /KICK command */

--- a/src/perl/irc/Irc.xs
+++ b/src/perl/irc/Irc.xs
@@ -12,7 +12,10 @@ static void perl_irc_connect_fill_hash(HV *hv, IRC_SERVER_CONNECT_REC *conn)
 static void perl_irc_server_fill_hash(HV *hv, IRC_SERVER_REC *server)
 {
 	AV *av;
+	HV *hv_;
 	GSList *tmp;
+	GHashTableIter iter;
+	gpointer key_, val_;
 
 	perl_irc_connect_fill_hash(hv, server->connrec);
 	perl_server_fill_hash(hv, (SERVER_REC *) server);
@@ -34,10 +37,14 @@ static void perl_irc_server_fill_hash(HV *hv, IRC_SERVER_REC *server)
 	(void) hv_store(hv, "cap_complete", 12, newSViv(server->cap_complete), 0);
 	(void) hv_store(hv, "sasl_success", 12, newSViv(server->sasl_success), 0);
 
-	av = newAV();
-	for (tmp = server->cap_supported; tmp != NULL; tmp = tmp->next)
-		av_push(av, new_pv(tmp->data));
-	(void) hv_store(hv, "cap_supported", 13, newRV_noinc((SV*)av), 0);
+	hv_ = newHV();
+	g_hash_table_iter_init(&iter, server->cap_supported);
+	while (g_hash_table_iter_next(&iter, &key_, &val_)) {
+		char *key = (char *)key_;
+		char *val = (char *)val_;
+		hv_store(hv_, key, strlen(key), new_pv(val), 0);
+	}
+	(void) hv_store(hv, "cap_supported", 13, newRV_noinc((SV*)hv_), 0);
 
 	av = newAV();
 	for (tmp = server->cap_active; tmp != NULL; tmp = tmp->next)


### PR DESCRIPTION
~~This is a prerequisite for the IRC v3.2 compliance.~~
Fuck this shit, I've accidentally implemented the whole thing.

This has been tested this with Freenode and Unrealircd and found no problem with the old 3.1 flow and Valgrind looks happy with this.
I've tested the multiline thing using netcat and the strings found on the ircv3 page and the `ADD`/`DEL` things are untested as of now (I'd like to talk with a real ircd instead of netcat...)
I'm not sure about the XS part as it kept loading the `Irssi.pm` module off `/usr` so feel free to give it a shot.

