### PR TITLE
Allow selection of what kind of activity targets to ignore v2

### DIFF
--- a/src/fe-common/core/fe-common-core.c
+++ b/src/fe-common/core/fe-common-core.c
@@ -461,16 +461,19 @@ void fe_common_core_finish_init(void)
 
 gboolean strarray_find_dest(char **array, const TEXT_DEST_REC *dest)
 {
-	int channel_type = module_get_uniq_id_str("WINDOW ITEM TYPE", "CHANNEL");
-	int query_type = module_get_uniq_id_str("WINDOW ITEM TYPE", "QUERY");
+	WI_ITEM_REC *item;
+	int server_tag_len, channel_type, query_type;
 	char **tmp;
+
+	channel_type = module_get_uniq_id_str("WINDOW ITEM TYPE", "CHANNEL");
+	query_type = module_get_uniq_id_str("WINDOW ITEM TYPE", "QUERY");
 
 	g_return_val_if_fail(array != NULL, FALSE);
 	g_return_val_if_fail(dest != NULL, FALSE);
 	g_return_val_if_fail(dest->window != NULL, FALSE);
 	g_return_val_if_fail(dest->target != NULL, FALSE);
 
-	WI_ITEM_REC *item = window_item_find_window(dest->window, dest->server, dest->target);
+	item = window_item_find_window(dest->window, dest->server, dest->target);
 	if (item == NULL) {
 		return FALSE;
 	}

--- a/src/fe-common/core/fe-common-core.c
+++ b/src/fe-common/core/fe-common-core.c
@@ -478,7 +478,7 @@ gboolean strarray_find_dest(char **array, const TEXT_DEST_REC *dest)
 		return FALSE;
 	}
 
-	int server_tag_len = dest->server_tag != NULL ? strlen(dest->server_tag) : 0;
+	server_tag_len = dest->server_tag != NULL ? strlen(dest->server_tag) : 0;
 	for (tmp = array; *tmp != NULL; tmp++) {
 		char *str = *tmp;
 		if (*str == '\0') {

--- a/src/fe-common/core/fe-common-core.c
+++ b/src/fe-common/core/fe-common-core.c
@@ -475,26 +475,29 @@ gboolean strarray_find_dest(char **array, const TEXT_DEST_REC *dest)
 		return FALSE;
 	}
 
-	int server_tag_len = dest->server_tag ? strlen(dest->server_tag) : 0;
+	int server_tag_len = dest->server_tag != NULL ? strlen(dest->server_tag) : 0;
 	for (tmp = array; *tmp != NULL; tmp++) {
 		char *str = *tmp;
 		if (*str == '\0') {
 			continue;
 		}
 
-		if (server_tag_len && !g_ascii_strncasecmp(str, dest->server_tag, server_tag_len) && str[server_tag_len] == '/') {
+		if (server_tag_len &&
+		    g_ascii_strncasecmp(str, dest->server_tag, server_tag_len) == 0 &&
+		    str[server_tag_len] == '/') {
 			str += server_tag_len + 1;
 		}
 
-		if (!g_strcmp0(str, "") || !g_strcmp0(str, "::all")) {
+		if (g_strcmp0(str, "") == 0 || g_strcmp0(str, "::all") == 0) {
 			return TRUE;
-		} else if (!g_ascii_strcasecmp(str, dest->target)) {
+		} else if (g_ascii_strcasecmp(str, dest->target) == 0) {
 			return TRUE;
 		} else if (item->type == query_type &&
-			!g_strcmp0(str, (dest->target[0] == '=') ? "::dccqueries" : "::queries")) {
+		           g_strcmp0(str, dest->target[0] == '=' ? "::dccqueries" :
+			             "::queries") == 0) {
 			return TRUE;
 		} else if (item->type == channel_type &&
-			!g_strcmp0(str, "::channels")) {
+			   g_strcmp0(str, "::channels") == 0) {
 			return TRUE;
 		}
 	}

--- a/src/fe-common/core/fe-common-core.c
+++ b/src/fe-common/core/fe-common-core.c
@@ -461,26 +461,43 @@ void fe_common_core_finish_init(void)
 
 gboolean strarray_find_dest(char **array, const TEXT_DEST_REC *dest)
 {
+	int channel_type = module_get_uniq_id_str("WINDOW ITEM TYPE", "CHANNEL");
+	int query_type = module_get_uniq_id_str("WINDOW ITEM TYPE", "QUERY");
+	char **tmp;
+
 	g_return_val_if_fail(array != NULL, FALSE);
+	g_return_val_if_fail(dest != NULL, FALSE);
+	g_return_val_if_fail(dest->window != NULL, FALSE);
+	g_return_val_if_fail(dest->target != NULL, FALSE);
 
-	if (strarray_find(array, "*") != -1)
-		return TRUE;
-
-	if (strarray_find(array, dest->target) != -1)
-		return TRUE;
-
-	if (dest->server_tag != NULL) {
-		char *tagtarget = g_strdup_printf("%s/%s", dest->server_tag, "*");
-		int ret = strarray_find(array, tagtarget);
-		g_free(tagtarget);
-		if (ret != -1)
-			return TRUE;
-
-		tagtarget = g_strdup_printf("%s/%s", dest->server_tag, dest->target);
-		ret = strarray_find(array, tagtarget);
-		g_free(tagtarget);
-		if (ret != -1)
-			return TRUE;
+	WI_ITEM_REC *item = window_item_find_window(dest->window, dest->server, dest->target);
+	if (item == NULL) {
+		return FALSE;
 	}
+
+	int server_tag_len = dest->server_tag ? strlen(dest->server_tag) : 0;
+	for (tmp = array; *tmp != NULL; tmp++) {
+		char *str = *tmp;
+		if (*str == '\0') {
+			continue;
+		}
+
+		if (server_tag_len && !g_ascii_strncasecmp(str, dest->server_tag, server_tag_len) && str[server_tag_len] == '/') {
+			str += server_tag_len + 1;
+		}
+
+		if (!g_strcmp0(str, "") || !g_strcmp0(str, "::all")) {
+			return TRUE;
+		} else if (!g_ascii_strcasecmp(str, dest->target)) {
+			return TRUE;
+		} else if (item->type == query_type &&
+			!g_strcmp0(str, (dest->target[0] == '=') ? "::dccqueries" : "::queries")) {
+			return TRUE;
+		} else if (item->type == channel_type &&
+			!g_strcmp0(str, "::channels")) {
+			return TRUE;
+		}
+	}
+
 	return FALSE;
 }


### PR DESCRIPTION
Syntax:
<pre>
 ::all	 	        Ignore activity in all windows
 ::channels       	Ignore activity in all channels
 ::queries  		Ignore activity in all queries
 ::dccqueries    	Ignore activity in all dcc chats
 #chan|[=]nick  	Ignore activity in named target(channel, query, dcc chat)
 tag/::all	        Ignore all activity on network 'tag'
 tag/::channels 	Ignore activity in all channels on network 'tag'
 tag/::queries	        Ignore activity in all queries on network 'tag'
 tag/::dccqueries	Ignore activity in all dcc chats on network 'tag'
 tag/#chan|[=]nick	Ignore activity in named channel/query/dcc chat on network 'tag'
</pre>