### PR TITLE
Turn the style guide into a clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -19,7 +19,7 @@ BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Linux
 BreakBeforeTernaryOperators: false
 ColumnLimit: 100
-IndentCaseLabels: true
+IndentCaseLabels: false
 IndentWidth: 8
 IndentWrappedFunctionNames: true
 KeepEmptyLinesAtTheStartOfBlocks: false

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,37 @@
+# IndentPPDirectives: None
+# SpaceInParentheses: false
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignOperands: true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+ColumnLimit: 100
+IndentCaseLabels: true
+IndentWidth: 8
+IndentWrappedFunctionNames: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+Language: Cpp
+MaxEmptyLinesToKeep: 1
+PointerAlignment: Right
+SortIncludes: true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpacesInSquareBrackets: false
+TabWidth: 8
+UseTab: ForIndentation

--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-# IndentPPDirectives: None
+# IndentPPDirectives: AfterHash
 # SpaceInParentheses: false
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: false
@@ -12,22 +12,23 @@ AllowShortFunctionsOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakBeforeMultilineStrings: false
 BinPackArguments: true
 BinPackParameters: true
 BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Attach
-BreakBeforeTernaryOperators: true
+BreakBeforeBraces: Linux
+BreakBeforeTernaryOperators: false
 ColumnLimit: 100
 IndentCaseLabels: true
 IndentWidth: 8
 IndentWrappedFunctionNames: true
 KeepEmptyLinesAtTheStartOfBlocks: false
 Language: Cpp
+Cpp11BracedListStyle: false
 MaxEmptyLinesToKeep: 1
 PointerAlignment: Right
 SortIncludes: true
-SpaceAfterCStyleCast: false
+SpaceAfterCStyleCast: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
 SpaceInEmptyParentheses: false


### PR DESCRIPTION
Note that his has been written with clang-format 3.8 in mind since that's what Debian ships, see [here](http://releases.llvm.org/3.8.1/tools/docs/ClangFormatStyleOptions.html) for the docs.

I'm not too fond of the tabs + 100 columns combo since my laptop has a tiny screen, but that's not much of a problem.

So, I hereby declare the style-related bikeshed season open!