### PR TITLE
Change the default awaylog_file to ~/irclogs/away.log.

### DIFF
--- a/docs/capsicum.txt
+++ b/docs/capsicum.txt
@@ -7,7 +7,6 @@ or the libraries it depends on.
 To make Irssi enter capability mode on startup, add
 
 capsicum = "yes";
-awaylog_file = "~/irclogs/away.log";
 
 to your ~/.irssi/config and restart the client.  Alternatively you can
 enter it "by hand", using the "/capsicum enter" command.  From the security

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -973,7 +973,7 @@ If <color> is a
 	yourself unaway, Irssi will display all the messages in the awaylog.
 
 	/SET awaylog_level <level> - Default is MSGS HILIGHT
-	/SET awaylog_file <filename> - Default is ~/.irssi/away.log
+	/SET awaylog_file <filename> - Default is ~/irclogs/away.log
 
 	You can disable this feature by setting awaylog_level to NONE.
 

--- a/docs/startup-HOWTO.html
+++ b/docs/startup-HOWTO.html
@@ -365,7 +365,7 @@ Ctrl-X                - set the next server in list active
 <p>Irssi can automatically log important messages when you’re set away (<code>/AWAY reason</code>). When you set yourself unaway (<code>/AWAY</code>), the new messages in away log are printed to screen. You can configure it with:</p>
 
 <div><div><pre><code>/SET awaylog_level MSGS HILIGHT     - Specifies what messages to log
-/SET awaylog_file ~/.irssi/away.log - Specifies the file to use
+/SET awaylog_file ~/irclogs/away.log - Specifies the file to use
 </code></pre></div></div>
 
 <p>Easiest way to start logging with Irssi is to use autologging. With it Irssi logs all channels and private messages to specified directory. You can turn it on with</p>

--- a/src/core/log-away.c
+++ b/src/core/log-away.c
@@ -105,15 +105,11 @@ static void sig_away_changed(SERVER_REC *server)
 
 void log_away_init(void)
 {
-	char *awaylog_file;
-
 	awaylog = NULL;
 	away_filepos = 0;
 	away_msgs = 0;
 
-	awaylog_file = g_strconcat(get_irssi_dir(), "/away.log", NULL);
-	settings_add_str("log", "awaylog_file", awaylog_file);
-	g_free(awaylog_file);
+	settings_add_str("log", "awaylog_file", "~/irclogs/away.log");
 	settings_add_level("log", "awaylog_level", "msgs hilight");
 
 	signal_add("log written", (SIGNAL_FUNC) sig_log_written);


### PR DESCRIPTION
The new location is more compatible with Capsicum sandboxing,
and also seems a bit more logical - it is, after all, a log file.

Signed-off-by: Edward Tomasz Napierala <trasz@FreeBSD.org>