### PR TITLE
check for declaration-after-statement on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
 
 install:
     - ./configure --with-proxy --with-bot --with-perl=module --prefix=$HOME/irssi-build
-    - make CFLAGS="-Wall -Werror"
+    - make CFLAGS="-Wall -Werror -Werror=declaration-after-statement"
     - make install
 
 before_script:

--- a/src/core/ignore.h
+++ b/src/core/ignore.h
@@ -27,14 +27,14 @@ int ignore_check(SERVER_REC *server, const char *nick, const char *host,
 		 const char *channel, const char *text, int level);
 
 enum {
-	IGNORE_FIND_PATTERN = 0x01, // Match the pattern
-	IGNORE_FIND_NOACT   = 0x02, // Exclude the targets with NOACT level
+	IGNORE_FIND_PATTERN = 0x01, /* Match the pattern */
+	IGNORE_FIND_NOACT   = 0x02, /* Exclude the targets with NOACT level */
 };
 
 IGNORE_REC *ignore_find_full (const char *servertag, const char *mask, const char *pattern,
                 char **channels, const int flags);
 
-// Convenience wrappers around ignore_find_full, for compatibility purpose
+/* Convenience wrappers around ignore_find_full, for compatibility purpose */
 
 IGNORE_REC *ignore_find(const char *servertag, const char *mask, char **channels);
 IGNORE_REC *ignore_find_noact(const char *servertag, const char *mask, char **channels, int noact);

--- a/src/core/network-openssl.c
+++ b/src/core/network-openssl.c
@@ -583,9 +583,6 @@ static void set_cipher_info(TLS_REC *tls, SSL *ssl)
 
 static void set_pubkey_info(TLS_REC *tls, X509 *cert, unsigned char *cert_fingerprint, size_t cert_fingerprint_size, unsigned char *public_key_fingerprint, size_t public_key_fingerprint_size)
 {
-	g_return_if_fail(tls != NULL);
-	g_return_if_fail(cert != NULL);
-
 	EVP_PKEY *pubkey = NULL;
 	char *cert_fingerprint_hex = NULL;
 	char *public_key_fingerprint_hex = NULL;
@@ -593,6 +590,9 @@ static void set_pubkey_info(TLS_REC *tls, X509 *cert, unsigned char *cert_finger
 	BIO *bio = NULL;
 	char buffer[128];
 	size_t length;
+
+	g_return_if_fail(tls != NULL);
+	g_return_if_fail(cert != NULL);
 
 	pubkey = X509_get_pubkey(cert);
 
@@ -647,9 +647,6 @@ static void set_pubkey_info(TLS_REC *tls, X509 *cert, unsigned char *cert_finger
 
 static void set_peer_cert_chain_info(TLS_REC *tls, SSL *ssl)
 {
-	g_return_if_fail(tls != NULL);
-	g_return_if_fail(ssl != NULL);
-
 	int nid;
 	char *key = NULL;
 	char *value = NULL;
@@ -661,6 +658,9 @@ static void set_peer_cert_chain_info(TLS_REC *tls, SSL *ssl)
 	X509_NAME_ENTRY *entry = NULL;
 	TLS_CERT_ENTRY_REC *tls_cert_entry_rec = NULL;
 	ASN1_STRING *data = NULL;
+
+	g_return_if_fail(tls != NULL);
+	g_return_if_fail(ssl != NULL);
 
 	chain = SSL_get_peer_cert_chain(ssl);
 
@@ -714,9 +714,6 @@ static void set_peer_cert_chain_info(TLS_REC *tls, SSL *ssl)
 
 static void set_server_temporary_key_info(TLS_REC *tls, SSL *ssl)
 {
-	g_return_if_fail(tls != NULL);
-	g_return_if_fail(ssl != NULL);
-
 #ifdef SSL_get_server_tmp_key
 	/* Show ephemeral key information. */
 	EVP_PKEY *ephemeral_key = NULL;
@@ -728,6 +725,9 @@ static void set_server_temporary_key_info(TLS_REC *tls, SSL *ssl)
 	char *ephemeral_key_algorithm = NULL;
 	char *cname = NULL;
 	int nid;
+
+	g_return_if_fail(tls != NULL);
+	g_return_if_fail(ssl != NULL);
 
 	if (SSL_get_server_tmp_key(ssl, &ephemeral_key)) {
 		switch (EVP_PKEY_id(ephemeral_key)) {

--- a/src/core/network-openssl.c
+++ b/src/core/network-openssl.c
@@ -600,7 +600,7 @@ static void set_pubkey_info(TLS_REC *tls, X509 *cert, unsigned char *cert_finger
 	tls_rec_set_certificate_fingerprint(tls, cert_fingerprint_hex);
 	tls_rec_set_certificate_fingerprint_algorithm(tls, "SHA256");
 
-	// Show algorithm.
+	/* Show algorithm. */
 	switch (EVP_PKEY_id(pubkey)) {
 		case EVP_PKEY_RSA:
 			tls_rec_set_public_key_algorithm(tls, "RSA");
@@ -624,7 +624,7 @@ static void set_pubkey_info(TLS_REC *tls, X509 *cert, unsigned char *cert_finger
 	tls_rec_set_public_key_size(tls, EVP_PKEY_bits(pubkey));
 	tls_rec_set_public_key_fingerprint_algorithm(tls, "SHA256");
 
-	// Read the NotBefore timestamp.
+	/* Read the NotBefore timestamp. */
 	bio = BIO_new(BIO_s_mem());
 	ASN1_TIME_print(bio, X509_get_notBefore(cert));
 	length = BIO_read(bio, buffer, sizeof(buffer));
@@ -632,7 +632,7 @@ static void set_pubkey_info(TLS_REC *tls, X509 *cert, unsigned char *cert_finger
 	BIO_free(bio);
 	tls_rec_set_not_before(tls, buffer);
 
-	// Read the NotAfter timestamp.
+	/* Read the NotAfter timestamp. */
 	bio = BIO_new(BIO_s_mem());
 	ASN1_TIME_print(bio, X509_get_notAfter(cert));
 	length = BIO_read(bio, buffer, sizeof(buffer));
@@ -670,7 +670,7 @@ static void set_peer_cert_chain_info(TLS_REC *tls, SSL *ssl)
 	for (i = 0; i < sk_X509_num(chain); i++) {
 		cert_rec = tls_cert_create_rec();
 
-		// Subject.
+		/* Subject. */
 		name = X509_get_subject_name(sk_X509_value(chain, i));
 
 		for (j = 0; j < X509_NAME_entry_count(name); j++) {
@@ -689,7 +689,7 @@ static void set_peer_cert_chain_info(TLS_REC *tls, SSL *ssl)
 			tls_cert_rec_append_subject_entry(cert_rec, tls_cert_entry_rec);
 		}
 
-		// Issuer.
+		/* Issuer. */
 		name = X509_get_issuer_name(sk_X509_value(chain, i));
 
 		for (j = 0; j < X509_NAME_entry_count(name); j++) {
@@ -718,10 +718,10 @@ static void set_server_temporary_key_info(TLS_REC *tls, SSL *ssl)
 	g_return_if_fail(ssl != NULL);
 
 #ifdef SSL_get_server_tmp_key
-	// Show ephemeral key information.
+	/* Show ephemeral key information. */
 	EVP_PKEY *ephemeral_key = NULL;
 
-	// OPENSSL_NO_EC is for solaris 11.3 (2016), github ticket #598
+	/* OPENSSL_NO_EC is for solaris 11.3 (2016), github ticket #598 */
 #ifndef OPENSSL_NO_EC
 	EC_KEY *ec_key = NULL;
 #endif
@@ -759,7 +759,7 @@ static void set_server_temporary_key_info(TLS_REC *tls, SSL *ssl)
 
 		EVP_PKEY_free(ephemeral_key);
 	}
-#endif // SSL_get_server_tmp_key.
+#endif /* SSL_get_server_tmp_key. */
 }
 
 GIOChannel *net_connect_ip_ssl(IPADDR *ip, int port, IPADDR *my_ip, SERVER_REC *server)
@@ -866,7 +866,7 @@ int irssi_ssl_handshake(GIOChannel *handle)
 	set_peer_cert_chain_info(tls, chan->ssl);
 	set_server_temporary_key_info(tls, chan->ssl);
 
-	// Emit the TLS rec.
+	/* Emit the TLS rec. */
 	signal_emit("tls handshake finished", 2, chan->server, tls);
 
 	ret = 1;
@@ -893,7 +893,7 @@ int irssi_ssl_handshake(GIOChannel *handle)
 		ret = irssi_ssl_verify(chan->ssl, chan->ctx, chan->server->connrec->address, chan->port, cert, chan->server, tls);
 
 		if (! ret) {
-			// irssi_ssl_verify emits a warning itself.
+			/* irssi_ssl_verify emits a warning itself. */
 			goto done;
 		}
 	}

--- a/src/fe-common/core/fe-windows.c
+++ b/src/fe-common/core/fe-windows.c
@@ -563,8 +563,10 @@ GSList *windows_get_sorted(void)
 	begin = windows_seq_begin();
 
 	while (iter != begin) {
+		WINDOW_REC *rec;
+
 		iter = g_sequence_iter_prev(iter);
-		WINDOW_REC *rec = g_sequence_get(iter);
+		rec = g_sequence_get(iter);
 
 		sorted = g_slist_prepend(sorted, rec);
 	}

--- a/src/fe-fuzz/irssi.c
+++ b/src/fe-fuzz/irssi.c
@@ -21,7 +21,7 @@
 #include "module.h"
 #include "modules-load.h"
 #include "levels.h"
-#include "../fe-text/module-formats.h" // need to explicitly grab from fe-text
+#include "../fe-text/module-formats.h" /* need to explicitly grab from fe-text */
 #include "themes.h"
 #include "core.h"
 #include "fe-common-core.h"

--- a/src/fe-text/statusbar-items.c
+++ b/src/fe-text/statusbar-items.c
@@ -369,8 +369,8 @@ static void item_lag(SBAR_ITEM_REC *item, int get_size_only)
 	last_lag_unknown = lag_unknown;
 
 	if (lag_unknown) {
-		// "??)" in C becomes ']'
-		// See: https://en.wikipedia.org/wiki/Digraphs_and_trigraphs#C
+		/* "??)" in C becomes ']'
+		   See: https://en.wikipedia.org/wiki/Digraphs_and_trigraphs#C */
 		g_snprintf(str, sizeof(str), "%d (?""?)", lag / 100);
 	} else {
 		if (lag % 100 == 0)

--- a/src/irc/core/sasl.c
+++ b/src/irc/core/sasl.c
@@ -30,16 +30,16 @@
  * Based on IRCv3 SASL Extension Specification:
  * http://ircv3.net/specs/extensions/sasl-3.1.html
  */
-#define AUTHENTICATE_CHUNK_SIZE 400 // bytes
+#define AUTHENTICATE_CHUNK_SIZE 400 /* bytes */
 
 /*
  * Maximum size to allow the buffer to grow to before the next fragment comes in. Note that
  * due to the way fragmentation works, the maximum message size will actually be:
  * floor(AUTHENTICATE_MAX_SIZE / AUTHENTICATE_CHUNK_SIZE) + AUTHENTICATE_CHUNK_SIZE - 1
  */
-#define AUTHENTICATE_MAX_SIZE 8192 // bytes
+#define AUTHENTICATE_MAX_SIZE 8192 /* bytes */
 
-#define SASL_TIMEOUT (20 * 1000) // ms
+#define SASL_TIMEOUT (20 * 1000) /* ms */
 
 static gboolean sasl_timeout(IRC_SERVER_REC *server)
 {

--- a/src/perl/common/Expando.xs
+++ b/src/perl/common/Expando.xs
@@ -74,6 +74,7 @@ static char *perl_expando_event(PerlExpando *rec, SERVER_REC *server,
 
 	ret = NULL;
 	if (SvTRUE(ERRSV)) {
+		char *error;
 		PERL_SCRIPT_REC *script = rec->script;
 
 		(void) POPs;
@@ -85,7 +86,7 @@ static char *perl_expando_event(PerlExpando *rec, SERVER_REC *server,
 			script_unregister_expandos(script);
 		/* rec has been freed now */
 
-		char *error = g_strdup(SvPV_nolen(ERRSV));
+		error = g_strdup(SvPV_nolen(ERRSV));
 		signal_emit("script error", 2, script, error);
 		g_free(error);
 	} else if (retcount > 0) {

--- a/src/perl/textui/Statusbar.xs
+++ b/src/perl/textui/Statusbar.xs
@@ -67,7 +67,7 @@ static void perl_statusbar_event(char *function, SBAR_ITEM_REC *item,
 
 	if (SvTRUE(ERRSV)) {
                 PERL_SCRIPT_REC *script;
-                char *package;
+                char *package, *error;
 
                 package = perl_function_get_package(function);
                 script = perl_script_find_package(package);
@@ -78,7 +78,7 @@ static void perl_statusbar_event(char *function, SBAR_ITEM_REC *item,
 			script_unregister_statusbars(script);
 		}
 
-		char *error = g_strdup(SvPV_nolen(ERRSV));
+		error = g_strdup(SvPV_nolen(ERRSV));
 		signal_emit("script error", 2, script, error);
 		g_free(error);
 	} else {


### PR DESCRIPTION
this will make variable declarations after statements illegal. most of the code follows this practice. in the past, this was required to be able to compile on BeOS iirc