### PR TITLE
fix /exec -o for blank lines

### DIFF
--- a/src/fe-common/core/fe-exec.c
+++ b/src/fe-common/core/fe-exec.c
@@ -613,7 +613,7 @@ static void sig_exec_input(PROCESS_REC *rec, const char *text)
 
 		str = g_strconcat(rec->target_nick ? "-nick " :
 				  rec->target_channel ? "-channel " : "",
-				  rec->target, " ", text, NULL);
+				  rec->target, " ", *text == '\0' ? " " : text, NULL);
 		signal_emit(rec->notice ? "command notice" : "command msg",
 			    3, str, server, item);
                 g_free(str);


### PR DESCRIPTION
since it is not allowed to send nothing, instead of spamming the status window
with error, send " " instead

Fixes FS#902

Patch by @dj1yfk 