### PR TITLE
revert netsplit print optimisation

### DIFF
--- a/src/fe-common/irc/fe-netjoin.c
+++ b/src/fe-common/irc/fe-netjoin.c
@@ -253,15 +253,12 @@ static void sig_print_starting(TEXT_DEST_REC *dest)
 	if (!IS_IRC_SERVER(dest->server))
 		return;
 
-	if (!(dest->level & MSGLEVEL_PUBLIC))
-		return;
-
 	if (!server_ischannel(dest->server, dest->target))
 		return;
 
 	rec = netjoin_find_server(IRC_SERVER(dest->server));
 	if (rec != NULL && rec->netjoins != NULL)
-		print_netjoins(rec, dest->target);
+		print_netjoins(rec, NULL);
 }
 
 static int sig_check_netjoins(void)

--- a/src/fe-common/irc/fe-netsplit.c
+++ b/src/fe-common/irc/fe-netsplit.c
@@ -199,7 +199,7 @@ static void temp_split_chan_free(TEMP_SPLIT_CHAN_REC *rec)
 	g_free(rec);
 }
 
-static void print_splits(IRC_SERVER_REC *server, const char *channel)
+static void print_splits(IRC_SERVER_REC *server, const char *filter_channel)
 {
 	TEMP_SPLIT_REC temp;
 	GSList *servers;
@@ -218,7 +218,7 @@ static void print_splits(IRC_SERVER_REC *server, const char *channel)
 
 		g_hash_table_foreach(server->splits,
 				     (GHFunc) get_server_splits, &temp);
-		print_server_splits(server, &temp, channel);
+		print_server_splits(server, &temp, filter_channel);
 
 		g_slist_foreach(temp.channels,
 				(GFunc) temp_split_chan_free, NULL);
@@ -255,15 +255,12 @@ static void sig_print_starting(TEXT_DEST_REC *dest)
 	if (!IS_IRC_SERVER(dest->server))
 		return;
 
-	if (!(dest->level & MSGLEVEL_PUBLIC))
-		return;
-
 	if (!server_ischannel(dest->server, dest->target))
 		return;
 
 	rec = IRC_SERVER(dest->server);
 	if (rec->split_servers != NULL)
-		print_splits(rec, dest->target);
+		print_splits(rec, NULL);
 }
 
 static int sig_check_splits(void)


### PR DESCRIPTION
this reverts part of #465

unfortunately we need to further refine the initial patch

 - when filtering by channel, the whole split is cleaned up nevertheless
 - something similar happens for the netjoins
 - furthermore, we cannot wait only for PUBLIC msgs, j/p/q are equivalently relevant for temporal integrity

this is a temporary band aid until we can properly implement #465 and f.x #420. the basic idea presented therein seems sound

this is intended to fix #809 