### PR TITLE
add backwards compatible code for running tap tests

### DIFF
--- a/utils/tap-test
+++ b/utils/tap-test
@@ -2,4 +2,22 @@
 
 # run a GTest in tap mode. The test binary is passed as $1
 
-$1 -k --tap
+t="$1"; shift
+if ${PKG_CONFIG:-pkg-config} --atleast-version 2.40 glib-2.0; then
+exec "$t" -k --tap "$@"
+else # GTest does not support tap yet
+    (((("$t" "$@"; echo $? >&3) | ${AM_TAP_AWK:-awk} '
+{
+    if (/: /) {
+        i++
+        ok = /: OK/
+        sub(/:/, " #")
+        print (ok ? "ok " : "not ok ") i " " $0
+    } else {
+        print "# " $0
+    }
+} END {
+    print 1 ".." i
+}
+' >&4) 3>&1) | (read xs; exit $xs)) 4>&1
+fi


### PR DESCRIPTION
fixes make check on Debian 7.0 and possibly other systems with old GLib