### PR TITLE
Revert more of the netsplit print optimisation to fix crashes

### DIFF
--- a/src/fe-common/irc/fe-netjoin.c
+++ b/src/fe-common/irc/fe-netjoin.c
@@ -245,20 +245,18 @@ static void print_netjoins(NETJOIN_SERVER_REC *server, const char *filter_channe
    message before it. */
 static void sig_print_starting(TEXT_DEST_REC *dest)
 {
-	NETJOIN_SERVER_REC *rec;
+	GSList *tmp, *next;
 
 	if (printing_joins)
 		return;
 
-	if (!IS_IRC_SERVER(dest->server))
-		return;
+	for (tmp = joinservers; tmp != NULL; tmp = next) {
+		NETJOIN_SERVER_REC *server = tmp->data;
 
-	if (!server_ischannel(dest->server, dest->target))
-		return;
-
-	rec = netjoin_find_server(IRC_SERVER(dest->server));
-	if (rec != NULL && rec->netjoins != NULL)
-		print_netjoins(rec, NULL);
+		next = tmp->next;
+		if (server->netjoins != NULL)
+			print_netjoins(server, NULL);
+	}
 }
 
 static int sig_check_netjoins(void)

--- a/src/fe-common/irc/fe-netsplit.c
+++ b/src/fe-common/irc/fe-netsplit.c
@@ -247,20 +247,17 @@ static int check_server_splits(IRC_SERVER_REC *server)
    message before it. */
 static void sig_print_starting(TEXT_DEST_REC *dest)
 {
-	IRC_SERVER_REC *rec;
+	GSList *tmp;
 
 	if (printing_splits)
 		return;
 
-	if (!IS_IRC_SERVER(dest->server))
-		return;
+	for (tmp = servers; tmp != NULL; tmp = tmp->next) {
+		IRC_SERVER_REC *rec = tmp->data;
 
-	if (!server_ischannel(dest->server, dest->target))
-		return;
-
-	rec = IRC_SERVER(dest->server);
-	if (rec->split_servers != NULL)
-		print_splits(rec, NULL);
+		if (IS_IRC_SERVER(rec) && rec->split_servers != NULL)
+			print_splits(rec, NULL);
+	}
 }
 
 static int sig_check_splits(void)


### PR DESCRIPTION
Now iterating over all servers to avoid crashes on `server_ischannel()`, which is a macro for `server->ischannel()`, so it dies horribly when it's null.

Fixes #819