### PR TITLE
dcc get shouldn't fail when file attrs can't be changed

### DIFF
--- a/src/irc/dcc/dcc-get.c
+++ b/src/irc/dcc/dcc-get.c
@@ -237,8 +237,12 @@ void sig_dccget_connected(GET_DCC_REC *dcc)
 
 		if (temphandle == -1)
 			ret = -1;
-		else
-			ret = fchmod(temphandle, dcc_file_create_mode);
+		else {
+			if (fchmod(temphandle, dcc_file_create_mode) != 0)
+				g_warning("fchmod(3) failed: %s", strerror(errno));
+			/* proceed even if chmod fails */
+			ret = 0;
+		}
 
 		close(temphandle);
 
@@ -249,7 +253,7 @@ void sig_dccget_connected(GET_DCC_REC *dcc)
 			    /* Linux */
 			    (errno == EPERM ||
 			     /* FUSE */
-			     errno == ENOSYS ||
+			     errno == ENOSYS || errno == EACCES ||
 			     /* BSD */
 			     errno == EOPNOTSUPP)) {
 				/* hard links aren't supported - some people


### PR DESCRIPTION
Running irssi from within Termux on an un-rooted NVIDIA Shield TV.

DCC downloads never worked for me, no matter what target directory I'd choose... Would you be willing to accept this PR? I don't think the DCC download should fail just because the desired file attributes can't be set (according to strace fchmod fails with EPERM).

Also extending the hardlink workaround to EACCES, not just EPERM (happens when my target directory is an external drive w/ NTFS).