### PR TITLE
reconnect lookup_servers also

### DIFF
--- a/src/core/servers-reconnect.c
+++ b/src/core/servers-reconnect.c
@@ -111,6 +111,21 @@ static int server_reconnect_timeout(void)
 		}
 	}
 
+	for (tmp = lookup_servers; tmp != NULL; tmp = next) {
+		SERVER_REC *server = tmp->data;
+
+		next = tmp->next;
+		if (server->connect_time + connect_timeout < now &&
+		    connect_timeout > 0) {
+			if (server->connect_tag != -1) {
+				g_source_remove(server->connect_tag);
+				server->connect_tag = -1;
+			}
+			server->connection_lost = TRUE;
+			server_connect_failed(server, "Timeout");
+		}
+	}
+
 	/* If server_connect() removes the next reconnection in queue,
 	   we're screwed. I don't think this should happen anymore, but just
 	   to be sure we don't crash, do this safely. */

--- a/src/core/servers.c
+++ b/src/core/servers.c
@@ -426,6 +426,7 @@ int server_start_connect(SERVER_REC *server)
 				    server_connect_callback_readpipe,
 				    server);
 
+		server->connect_time = time(NULL);
 		lookup_servers = g_slist_append(lookup_servers, server);
 
 		signal_emit("server looking", 1, server);


### PR DESCRIPTION
This is a simple change which might fix #130 

The lookup_servers are also disconnected if the lookup/SSL handshake doesn't succeed in time. I'm not perfectly sure if this is the master fix but it does seem to be an issue that servers can be stuck in lookup