### PR TITLE
signals.txt: add missing 'server cap new|delete' signals

### DIFF
--- a/docs/signals.txt
+++ b/docs/signals.txt
@@ -132,6 +132,8 @@ irc-servers.c:
 irc-cap.c
  "server cap ack "<cmd>, SERVER_REC
  "server cap nak "<cmd>, SERVER_REC
+ "server cap new "<cmd>, SERVER_REC
+ "server cap delete "<cmd>, SERVER_REC
  "server cap end", SERVER_REC
 
 sasl.c


### PR DESCRIPTION
Emitted by cap_emit_signal in irc/core/irc-cap.c, added as part of the
CAP 3.2 PR merged recentlyish.