### PR TITLE
Keep errstr set to NULL if errno is not set

### DIFF
--- a/src/core/network-openssl.c
+++ b/src/core/network-openssl.c
@@ -842,7 +842,7 @@ int irssi_ssl_handshake(GIOChannel *handle)
 				return -1;
 			case SSL_ERROR_SYSCALL:
 				errstr = ERR_reason_error_string(ERR_get_error());
-				if (errstr == NULL && ret == -1)
+				if (errstr == NULL && ret == -1 && errno)
 					errstr = strerror(errno);
 				g_warning("SSL handshake failed: %s", errstr != NULL ? errstr : "server closed connection unexpectedly");
 				return -1;


### PR DESCRIPTION
Don't use errno if it is not set and show the default error message
instead. This prevents messages like "SSL handshake failed: Success"
from being shown.