### PR TITLE
Don't ignore SIGWINCH when window size is unchanged

### DIFF
--- a/src/fe-text/term.c
+++ b/src/fe-text/term.c
@@ -81,11 +81,9 @@ void term_resize_dirty(void)
 	if (!term_get_size(&width, &height))
 		width = height = -1;
 
-	if (height != term_height || width != term_width) {
-		term_resize(width, height);
-		mainwindows_resize(term_width, term_height);
-		term_resize_final(width, height);
-	}
+	term_resize(width, height);
+	mainwindows_resize(term_width, term_height);
+	term_resize_final(width, height);
 }
 
 #ifdef SIGWINCH


### PR DESCRIPTION
Currently, the SIGWINCH handler assumes that the entire window doesn't
need to be redrawn. This assumption fails when session detachment tools
like abduco rely on SIGWINCH to ask a curses program to redraw itself
after a session is resumed.

~~This patch makes SIGWINCH trigger a full redraw instead of just a dirty
mark being applied.~~

The updated patch makes irssi stop ignoring a SIGWINCH if the reported terminal size hasn't changed.