### PR TITLE
Improve error message when failing to create the config dir

### DIFF
--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -762,7 +762,8 @@ static void init_configfile(void)
 	if (stat(get_irssi_dir(), &statbuf) != 0) {
 		/* ~/.irssi not found, create it. */
 		if (g_mkdir_with_parents(get_irssi_dir(), 0700) != 0) {
-			g_error("Couldn't create %s directory", get_irssi_dir());
+			g_error("Couldn't create %s directory: %s",
+			        get_irssi_dir(), g_strerror(errno));
 		}
 	} else if (!S_ISDIR(statbuf.st_mode)) {
 		g_error("%s is not a directory.\n"


### PR DESCRIPTION
For #910 

IMO we'll never know what happened there, and it's not very important either, but for the next time we can show the actual reason the mkdir failed.

The fact that it aborts and generates coredump is a bit awkward but `g_error` really is the handiest way to show this sort of thing and quit, so that's fine I think.