### PR TITLE
configure: fix Perl detection on macOS Mojave

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -388,8 +388,8 @@ if test "$want_perl" != "no"; then
 		dnl * fix those command line options a bit so GCC won't
 		dnl * complain about them. Normally there's only few options
 		dnl * that we want to keep:
-		dnl * -Ddefine -Uundef -I/path -fopt -mopt
-		PERL_CFLAGS=`echo $PERL_CFLAGS | $perlpath -pe 's/^(.* )?-@<:@^DUIfm@:>@@<:@^ @:>@+/\1/g; s/^(.* )?\+@<:@^ @:>@+/\1/g'`
+		dnl * -Ddefine -Uundef -I/path -fopt -mopt -iwithsysroot
+		PERL_CFLAGS=`echo $PERL_CFLAGS | $perlpath -pe 's/^(.* )?-@<:@^DUIifm@:>@@<:@^ @:>@+/\1/g; s/^(.* )?\+@<:@^ @:>@+/\1/g'`
 
 		PERL_EXTRA_OPTS="CCCDLFLAGS=\"-fPIC\""
 		AC_SUBST(PERL_EXTRA_OPTS)


### PR DESCRIPTION
Apple has significantly changed the way `perl` is structured in macOS Mojave/10.14, which is due to ship stable this month. The `perl` restructuring has been an issue for a while but I recently obtained confirmation from Apple the changes were intentional & consequently not something that was going to be walked back before Mojave reaches its stable release.

As of 10.14 the Perl headers are moving inside the SDK, instead of residing in `/System` directly. There's a flag to tell Clang to look inside the SDK without projects having to explicitly locate the SDK & fiddle with the location themselves, which is `-iwithsysroot`, and that's what `perl` outputs now when `configure` checks `perl -MExtUtils::Embed -e ccopts`:

```
  -g -pipe -fno-common -DPERL_DARWIN -fno-strict-aliasing -fstack-protector  -iwithsysroot /System/Library/Perl/5.18/darwin-thread-multi-2level/CORE
```

The latter bit of that was previously `-I/System/Library/Perl/5.18/darwin-thread-multi-2level/CORE`. The problem here is that `configure` filters out flags that start with a lowercase `i` and consequently the Perl elements fail to build. This tiny patch fixes that issue, restoring Perl support to `irssi` when built on macOS 10.14.