### PR TITLE
Disconnect SASL properly in case the sasl module got unloaded from server

### DIFF
--- a/src/fe-common/irc/fe-sasl.c
+++ b/src/fe-common/irc/fe-sasl.c
@@ -40,36 +40,14 @@ static void sig_sasl_failure(IRC_SERVER_REC *server, const char *reason)
 	printformat(server, NULL, MSGLEVEL_CRAP, IRCTXT_SASL_ERROR, reason);
 }
 
-static void sig_cap_end(IRC_SERVER_REC *server)
-{
-	/* The negotiation has now been terminated, if we didn't manage to
-	 * authenticate successfully with the server just disconnect. */
-	if (!server->sasl_success &&
-	    server->connrec->sasl_mechanism != SASL_MECHANISM_NONE &&
-	    settings_get_bool("sasl_disconnect_on_failure")) {
-		/* We can't use server_disconnect() here because we'd end up
-		 * freeing the 'server' object and be guilty of a slew of UaF. */
-		server->connection_lost = TRUE;
-		/* By setting connection_lost we make sure the communication is
-		 * halted and when the control goes back to irc_parse_incoming
-		 * the server object is safely destroyed. */
-		signal_stop();
-	}
-
-}
-
 void fe_sasl_init(void)
 {
-	settings_add_bool("server", "sasl_disconnect_on_failure", TRUE);
-
 	signal_add("server sasl success", (SIGNAL_FUNC) sig_sasl_success);
 	signal_add("server sasl failure", (SIGNAL_FUNC) sig_sasl_failure);
-	signal_add_first("server cap end", (SIGNAL_FUNC) sig_cap_end);
 }
 
 void fe_sasl_deinit(void)
 {
 	signal_remove("server sasl success", (SIGNAL_FUNC) sig_sasl_success);
 	signal_remove("server sasl failure", (SIGNAL_FUNC) sig_sasl_failure);
-	signal_remove("server cap end", (SIGNAL_FUNC) sig_cap_end);
 }

--- a/src/irc/core/irc-servers-setup.c
+++ b/src/irc/core/irc-servers-setup.c
@@ -98,9 +98,9 @@ static void sig_server_setup_fill_chatnet(IRC_SERVER_CONNECT_REC *conn,
 	if (ircnet->sasl_mechanism != NULL) {
 		if (!g_ascii_strcasecmp(ircnet->sasl_mechanism, "plain")) {
 			/* The PLAIN method needs both the username and the password */
+			conn->sasl_mechanism = SASL_MECHANISM_PLAIN;
 			if (ircnet->sasl_username != NULL && *ircnet->sasl_username &&
 			    ircnet->sasl_password != NULL && *ircnet->sasl_password) {
-				conn->sasl_mechanism = SASL_MECHANISM_PLAIN;
 				conn->sasl_username = ircnet->sasl_username;
 				conn->sasl_password = ircnet->sasl_password;
 			} else


### PR DESCRIPTION
stops from getting on the network when sasl is unavailable

fixes #629