### PR TITLE
makes '/window item goto' search on all servers

### DIFF
--- a/src/fe-common/core/window-commands.c
+++ b/src/fe-common/core/window-commands.c
@@ -541,6 +541,8 @@ static void cmd_window_item_goto(const char *data, SERVER_REC *server)
 		item = tmp == NULL ? NULL : tmp->data;
 	} else {
 		item = window_item_find_window(active_win, server, target);
+		if (item == NULL)
+			item = window_item_find_window(active_win, NULL, target);
 	}
 
         if (item != NULL)


### PR DESCRIPTION
Fixes #904 partially, still need to do something about this:
> It needs to handle when items with the same name from several networks, or should enable users to define the network at the end or with -network like for /msg