### PR TITLE
fe-text: clear hidelevel in layout if default

### DIFF
--- a/src/fe-text/mainwindows-layout.c
+++ b/src/fe-text/mainwindows-layout.c
@@ -46,6 +46,8 @@ static void sig_layout_window_save(WINDOW_REC *window, CONFIG_NODE *node)
 		char *level = bits2level(gui->view->hidden_level);
 		iconfig_node_set_str(node, "hidelevel", level);
 		g_free(level);
+	} else {
+		iconfig_node_set_str(node, "hidelevel", NULL);
 	}
 
 	if (gui->use_scroll)


### PR DESCRIPTION
This is required, otherwise setting the hidelevel to the default will
not be written in the layout and so won't persist.