### PR TITLE
fix and document window width on screen width dependency

### DIFF
--- a/src/fe-text/mainwindows.c
+++ b/src/fe-text/mainwindows.c
@@ -252,9 +252,9 @@ MAIN_WINDOW_REC *mainwindow_create(int right)
 			}
 			g_slist_free(line);
 		} else {
-			if (MAIN_WINDOW_TEXT_WIDTH(parent) <
-			    2* NEW_WINDOW_WIDTH)
+			if (MAIN_WINDOW_TEXT_WIDTH(parent) < 2 * NEW_WINDOW_WIDTH) {
 				parent = find_window_with_room_right();
+			}
 			if (parent == NULL)
 				return NULL; /* not enough space */
 

--- a/src/fe-text/mainwindows.h
+++ b/src/fe-text/mainwindows.h
@@ -5,7 +5,7 @@
 #include "term.h"
 
 #define WINDOW_MIN_SIZE 2
-#define NEW_WINDOW_WIDTH 10
+#define NEW_WINDOW_WIDTH 20 /* must be >= MIN_SCREEN_WIDTH defined in term.c */
 
 #define MAIN_WINDOW_TEXT_HEIGHT(window) \
         ((window)->height-(window)->statusbar_lines)


### PR DESCRIPTION
previously, the rsplits would be created in an incorrect way and the text would spill over for widths < 20