### PR TITLE
automake warns that subdir-objects will be enabled in 2.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_PREREQ(2.50)
 
 AC_CONFIG_HEADERS([irssi-config.h])
 AC_CONFIG_MACRO_DIR([m4])
-AM_INIT_AUTOMAKE([1.9 no-define foreign])
+AM_INIT_AUTOMAKE([1.9 no-define foreign subdir-objects])
 
 AM_SILENT_RULES([yes])
 


### PR DESCRIPTION
this was mentioned in #975