### PR TITLE
do not touch uninitialised protocols on item restore

### DIFF
--- a/src/fe-common/core/windows-layout.c
+++ b/src/fe-common/core/windows-layout.c
@@ -70,7 +70,7 @@ static void sig_layout_restore_item(WINDOW_REC *window, const char *type,
                 restore_win = window;
 
 		protocol = chat_protocol_find(chat_type);
-		if (protocol == NULL)
+		if (protocol == NULL || protocol->not_initialized)
 			window_bind_add(window, tag, name);
 		else if (protocol->query_create != NULL)
 			protocol->query_create(tag, name, TRUE);


### PR DESCRIPTION
if there are saved QUERY items inside the layout, Irssi will restore them in a way similar to doing `/query`. This works differently from channels which are only saved as bounds.

The code has a 'generic' path to create basic QUERY_REC objects for any protocol that does not require more. However, Irssi will also 'fake' protocols that are not loaded yet (thus their query_create vtable entry will not be valid)

As a result, the protocol-specific query_create method will not be invoked and the created object will be of wrong type, causing type confusion and oob write later on.

This patch will stop Irssi from creating any query in that case. Instead, only a bound will be created.

Protocol modules such as IRC might need to be updated to scan the bounds on load and recreate the queries as the original code did.

Open question: where should we store the type of the bound (i.e. QUERY)?

I have also pondered moving the autorun_startup code earlier: if it works, then this would be a workaround for this issue (the patch should still be done for protocols that are not loaded in startup)

But it does not work easily because the startup expects a working window. dummy window does not work easily because mainwindows cannot be destroyed. :-(