### PR TITLE
Fix finding OpenSSL when 1.1 with deprecated APIs disabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -319,7 +319,7 @@ PKG_CHECK_MODULES([OPENSSL], [openssl], [
 	CFLAGS="$CFLAGS $OPENSSL_CFLAGS"
 	LIBS="$LIBS $OPENSSL_LIBS"
 ], [
-	AC_CHECK_LIB([ssl], [SSL_library_init], [
+	AC_CHECK_LIB([ssl], [SSL_CTX_new], [
 		LIBS="$LIBS -lssl -lcrypto"
 	], [
 		AC_MSG_ERROR([The OpenSSL library was not found])


### PR DESCRIPTION
SSL_library_init is a deprecated function. OPENSSL_init_ssl is not in 1.0.2.
SSL_CTX_new is in both.