### PR TITLE
Remove unused functions

### DIFF
--- a/src/core/net-nonblock.c
+++ b/src/core/net-nonblock.c
@@ -63,7 +63,7 @@ int net_gethostbyname_nonblock(const char *addr, GIOChannel *pipe,
 	/* child */
 	srand(time(NULL));
 
-        memset(&rec, 0, sizeof(rec));
+	memset(&rec, 0, sizeof(rec));
 	rec.error = net_gethostbyname(addr, &rec.ip4, &rec.ip6);
 	if (rec.error == 0) {
 		errorstr = NULL;
@@ -79,7 +79,7 @@ int net_gethostbyname_nonblock(const char *addr, GIOChannel *pipe,
 		rec.errlen = errorstr == NULL ? 0 : strlen(errorstr)+1;
 	}
 
-        g_io_channel_write_block(pipe, &rec, sizeof(rec));
+	g_io_channel_write_block(pipe, &rec, sizeof(rec));
 	if (rec.errlen != 0)
 		g_io_channel_write_block(pipe, (void *) errorstr, rec.errlen);
 	else {
@@ -129,7 +129,7 @@ int net_gethostbyname_return(GIOChannel *pipe, RESOLVED_IP_REC *rec)
 		/* read error string, if we can't read everything for some
 		   reason, just ignore it. */
 		rec->errorstr = g_malloc0(rec->errlen+1);
-                g_io_channel_read_block(pipe, rec->errorstr, rec->errlen);
+		g_io_channel_read_block(pipe, rec->errorstr, rec->errlen);
 	} else {
 		if (rec->host4) {
 			g_io_channel_read_block(pipe, &len, sizeof(int));
@@ -170,7 +170,7 @@ static void simple_init(SIMPLE_THREAD_REC *rec, GIOChannel *handle)
 	if (net_geterror(handle) != 0) {
 		/* failed */
 		g_io_channel_shutdown(handle, TRUE, NULL);
-                g_io_channel_unref(handle);
+		g_io_channel_unref(handle);
 		handle = NULL;
 	}
 

--- a/src/core/net-nonblock.c
+++ b/src/core/net-nonblock.c
@@ -197,8 +197,7 @@ static void simple_readpipe(SIMPLE_THREAD_REC *rec, GIOChannel *pipe)
 	g_io_channel_unref(rec->pipes[1]);
 
 	ip = iprec.ip4.family != 0 ? &iprec.ip4 : &iprec.ip6;
-	handle = iprec.error == -1 ? NULL :
-		net_connect_ip(ip, rec->port, rec->my_ip);
+	handle = iprec.error ? NULL : net_connect_ip(ip, rec->port, rec->my_ip);
 
 	g_free_not_null(rec->my_ip);
 

--- a/src/core/net-nonblock.h
+++ b/src/core/net-nonblock.h
@@ -13,7 +13,7 @@ typedef struct {
 } RESOLVED_IP_REC;
 
 typedef struct {
-        int namelen;
+	int namelen;
 	char *name;
 
 	int error;

--- a/src/core/net-nonblock.h
+++ b/src/core/net-nonblock.h
@@ -12,29 +12,12 @@ typedef struct {
 	char *host4, *host6; /* dito */
 } RESOLVED_IP_REC;
 
-typedef struct {
-	int namelen;
-	char *name;
-
-	int error;
-	int errlen;
-	char *errorstr;
-} RESOLVED_NAME_REC;
-
-typedef void (*NET_CALLBACK) (GIOChannel *, void *);
-typedef void (*NET_HOST_CALLBACK) (RESOLVED_NAME_REC *, void *);
-
 /* nonblocking gethostbyname(), PID of the resolver child is returned. */
 int net_gethostbyname_nonblock(const char *addr, GIOChannel *pipe,
 			       int reverse_lookup);
-/* Get host's name, call func when finished */
-int net_gethostbyaddr_nonblock(IPADDR *ip, NET_HOST_CALLBACK func, void *data);
 /* get the resolved IP address. returns -1 if some error occurred with read() */
 int net_gethostbyname_return(GIOChannel *pipe, RESOLVED_IP_REC *rec);
 
-/* Connect to server, call func when finished */
-int net_connect_nonblock(const char *server, int port, const IPADDR *my_ip,
-			 NET_CALLBACK func, void *data);
 /* Kill the resolver child */
 void net_disconnect_nonblock(int pid);
 

--- a/src/core/server-rec.h
+++ b/src/core/server-rec.h
@@ -21,7 +21,7 @@ unsigned int no_reconnect:1; /* Don't reconnect to server */
 NET_SENDBUF_REC *handle;
 int readtag; /* input tag */
 
-/* for net_connect_nonblock() */
+/* for net_gethostbyname_return() */
 GIOChannel *connect_pipe[2];
 int connect_tag;
 int connect_pid;

--- a/src/irc/dcc/dcc-chat.c
+++ b/src/irc/dcc/dcc-chat.c
@@ -361,7 +361,7 @@ static void dcc_chat_listen(CHAT_DCC_REC *dcc)
 	signal_emit("dcc connected", 1, dcc);
 }
 
-/* callback: DCC CHAT - net_connect_nonblock() finished */
+/* callback: DCC CHAT - connect finished */
 static void sig_chat_connected(CHAT_DCC_REC *dcc)
 {
 	g_return_if_fail(IS_DCC_CHAT(dcc));


### PR DESCRIPTION
I noticed a bug in one of these functions but then saw that it wasn't actually even used. So I figure it is better to delete!

These are public so perhaps we don't want to merge yet.

**Edited by Nei**
Functions to be removed:
- NET_CALLBACK
- NET_HOST_CALLBACK
- RESOLVED_NAME_REC
- net_gethostbyaddr_nonblock
- net_connect_nonblock
- [ SIMPLE_THREAD_REC, simple_init, simple_readpipe ]
