### PR TITLE
allow rawlog-buffer to shrink again after lowering "rawlog_lines"

### DIFF
--- a/src/core/rawlog.c
+++ b/src/core/rawlog.c
@@ -62,7 +62,7 @@ void rawlog_destroy(RAWLOG_REC *rawlog)
 /* NOTE! str must be dynamically allocated and must not be freed after! */
 static void rawlog_add(RAWLOG_REC *rawlog, char *str)
 {
-	if (rawlog->lines->length >= rawlog_lines && rawlog_lines > 0) {
+	while (rawlog->lines->length >= rawlog_lines && rawlog_lines > 0) {
 		void *tmp = g_queue_pop_head(rawlog->lines);
 		g_free(tmp);
 	}


### PR DESCRIPTION
It seems that when setting the size of the rawlog-buffer (using "rawlog_lines") to a value lower the number of lines already in the buffer, the buffer will never shrink again.
This change allows multiple lines to be popped from the queue.