### PR TITLE
Add tls_* options to manual

### DIFF
--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -394,10 +394,26 @@
 
  5.4 Server settings
 
-	/SERVER ADD [-auto | -noauto] [-network <network>] [-host <hostname>]
+	/SERVER ADD [-tls] [-tls_cert <cert>] [-tls_pkey <pkey>]
+		    [-tls_pass <password>] [-tls_verify] [-tls_cafile <cafile>]
+		    [-tls_capath <capath>] [-tls_ciphers <list>] 
+		    [-tls_pinned_cert <fingerprint>] [-tls_pinned_pubkey <fingerprint>] 
+		    [-auto | -noauto] [-network <network>] [-host <hostname>]
 	            [-cmdspeed <ms>] [-cmdmax <count>] [-port <port>]
 	            <address> [<port> [<password>]]
 
+	    -tls: Connects using TLS encryption.
+	    -tls_cert: The TLS client certificate file.
+	    -tls_pkey: The TLS client private key, if not included in the 
+	               certificate file.
+	    -tls_pass: The password for the TLS client private key or 
+	    	       certificate.
+	    -tls_verify: Verifies the TLS certificate of the server.
+	    -tls_cafile: The file with the list of CA certificates.
+	    -tls_capath: The directory which contains the CA certificates.
+	    -tls_ciphers: TLS cipher suite preference lists.
+	    -tls_pinned_cert: Pinned x509 certificate fingerprint.
+	    -tls_pinned_pubkey: Pinned public key fingerprint.
 	    -auto: Automatically connect to server at startup
 	    -noauto: Don't connect to server at startup (default)
 	    -network: Specify what IRC network this server belongs to

--- a/src/fe-common/irc/fe-irc-server.c
+++ b/src/fe-common/irc/fe-irc-server.c
@@ -51,9 +51,9 @@ const char *get_visible_target(IRC_SERVER_REC *server, const char *target)
 	return target;
 }
 
-/* SYNTAX: SERVER ADD|MODIFY [-4 | -6] [-ssl] [-ssl_cert <cert>] [-ssl_pkey <pkey>] [-ssl_pass <password>]
-                             [-ssl_verify] [-ssl_cafile <cafile>] [-ssl_capath <capath>]
-                             [-ssl_ciphers <list>]
+/* SYNTAX: SERVER ADD|MODIFY [-4 | -6] [-tls] [-tls_cert <cert>] [-tls_pkey <pkey>] [-tls_pass <password>]
+                             [-tls_verify] [-tls_cafile <cafile>] [-tls_capath <capath>]
+                             [-tls_ciphers <list>]
                              [-auto | -noauto] [-network <network>] [-host <hostname>]
                              [-cmdspeed <ms>] [-cmdmax <count>] [-port <port>]
                              <address> [<port> [<password>]] */


### PR DESCRIPTION
Add tls_* options to the SERVER section of the manual.
Part of solution to #1029 