### PR TITLE
Clarify statusbar priorities

### DIFF
--- a/docs/help/in/statusbar.in
+++ b/docs/help/in/statusbar.in
@@ -30,7 +30,9 @@
     -before:      This item is added before the other item.
     -after:       This item is added after the other item.
     -priority:    When the statusbar items overflow, the item with the
-                  lowest priority is removed first
+                  lowest priority is removed or truncated first.
+                  Priority can be negative, in which case it'll have to be
+                  quoted (e.g. -priority "-1")
     -alignment:   Display the item on the right side.
 
     Where statusbar refers to the name of the statusbar; if no argument is


### PR DESCRIPTION
I was misled by the documentation a little bit and thought that status bar items of lower priority will be removed rather than truncated if they didn't fit.

Also, I had a hard time lowering priority below 0 because I didn't realize negative numbers have to be quoted so they won't be interpreted as option flags.