### PR TITLE
Free g_strdup() allocated memory with g_free()

### DIFF
--- a/src/core/network-openssl.c
+++ b/src/core/network-openssl.c
@@ -226,7 +226,7 @@ static gboolean irssi_ssl_verify_hostname(X509 *cert, const char *hostname)
 		} else {
 			g_warning("No subjectAltNames and no valid common name in certificate");
 		}
-		free(cert_subject_cn);
+		g_free(cert_subject_cn);
 	}
 
 	return matched;


### PR DESCRIPTION
Memory allocated with g_malloc() must be freed with g_free(). The
allocators may use different memory pools.

See: https://developer.gnome.org/glib/stable/glib-Memory-Allocation.html