### PR TITLE
make the $Z time overridable

### DIFF
--- a/src/core/expandos.c
+++ b/src/core/expandos.c
@@ -48,6 +48,7 @@ typedef struct {
 } EXPANDO_REC;
 
 const char *current_expando = NULL;
+time_t current_time = (time_t)-1;
 
 static int timer_tag;
 
@@ -441,7 +442,7 @@ static char *expando_time(SERVER_REC *server, void *item, int *free_ret)
 	struct tm *tm;
         char str[256];
 
-        now = time(NULL);
+        now = current_time != (time_t)-1 ? current_time : time(NULL);
 	tm = localtime(&now);
 
 	if (strftime(str, sizeof(str), timestamp_format, tm) == 0)

--- a/src/core/expandos.h
+++ b/src/core/expandos.h
@@ -17,6 +17,7 @@ typedef char* (*EXPANDO_FUNC)
 	(SERVER_REC *server, void *item, int *free_ret);
 
 extern const char *current_expando;
+extern time_t current_time;
 
 /* Create expando - overrides any existing ones.
    ... = signal, type, ..., NULL - list of signals that might change the


### PR DESCRIPTION
this will aid in implementing server-time

it is also required for proper time rendering in #1079 