### PR TITLE
enable irc cap ls 302

### DIFF
--- a/src/irc/core/irc-servers.c
+++ b/src/irc/core/irc-servers.c
@@ -236,9 +236,9 @@ static void server_init(IRC_SERVER_REC *server)
 	}
 
 	if (conn->sasl_mechanism != SASL_MECHANISM_NONE)
-		irc_cap_toggle(server, "sasl", TRUE);
+		irc_cap_toggle(server, CAP_SASL, TRUE);
 
-	irc_cap_toggle(server, "multi-prefix", TRUE);
+	irc_cap_toggle(server, CAP_MULTI_PREFIX, TRUE);
 
 	irc_send_cmd_now(server, "CAP LS " CAP_LS_VERSION);
 

--- a/src/irc/core/irc-servers.c
+++ b/src/irc/core/irc-servers.c
@@ -240,7 +240,7 @@ static void server_init(IRC_SERVER_REC *server)
 
 	irc_cap_toggle(server, "multi-prefix", TRUE);
 
-	irc_send_cmd_now(server, "CAP LS");
+	irc_send_cmd_now(server, "CAP LS " CAP_LS_VERSION);
 
 	if (conn->password != NULL && *conn->password != '\0') {
                 /* send password */

--- a/src/irc/core/irc-servers.h
+++ b/src/irc/core/irc-servers.h
@@ -5,6 +5,8 @@
 #include <irssi/src/core/servers.h>
 #include <irssi/src/irc/core/modes.h>
 
+#define CAP_LS_VERSION "302"
+
 /* returns IRC_SERVER_REC if it's IRC server, NULL if it isn't */
 #define IRC_SERVER(server) \
 	PROTO_CHECK_CAST(SERVER(server), IRC_SERVER_REC, chat_type, "IRC")

--- a/src/irc/core/irc-servers.h
+++ b/src/irc/core/irc-servers.h
@@ -6,6 +6,8 @@
 #include <irssi/src/irc/core/modes.h>
 
 #define CAP_LS_VERSION "302"
+#define CAP_SASL "sasl"
+#define CAP_MULTI_PREFIX "multi-prefix"
 
 /* returns IRC_SERVER_REC if it's IRC server, NULL if it isn't */
 #define IRC_SERVER(server) \


### PR DESCRIPTION
this is needed to learn about the values of capabilities, otherwise
they are not sent for backwards compatibility reasons

the values are required to support for example the maximum line length
value (upcoming patch)

also change the strings to #defines for easier handling