### PR TITLE
Fix memory leak in cap code

### DIFF
--- a/src/irc/core/irc-cap.c
+++ b/src/irc/core/irc-cap.c
@@ -132,6 +132,7 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 	else {
 		irc_cap_finish_negotiation(server);
 		g_warn_if_reached();
+		g_free(params);
 		return;
 	}
 


### PR DESCRIPTION
Malformed CAPs fail to free params before returning from event_cap.

This makes oss-fuzz sad.