### PR TITLE
#354 Fix hilight behavior for STATUSMSG

### DIFF
--- a/src/fe-common/irc/fe-irc-messages.c
+++ b/src/fe-common/irc/fe-irc-messages.c
@@ -67,13 +67,14 @@ static void sig_message_own_public(SERVER_REC *server, const char *msg,
 
 }
 
-/* received msg to all ops in channel */
+/* received msg to all ops in channel.
+   TODO: this code is a duplication of sig_message_public */
 static void sig_message_irc_op_public(SERVER_REC *server, const char *msg,
 				      const char *nick, const char *address,
 				      const char *target)
 {
 	CHANNEL_REC *chanrec;
-	char *nickmode, *optarget, *prefix, *color;
+	char *nickmode, *optarget, *prefix, *color, *freemsg = NULL;
 	const char *cleantarget;
 	int for_me, level;
 	HILIGHT_REC *hilight;
@@ -86,12 +87,16 @@ static void sig_message_irc_op_public(SERVER_REC *server, const char *msg,
 	/* and clean the rest here */
 	cleantarget = get_visible_target(IRC_SERVER(server), cleantarget);
 
-	nickmode = channel_get_nickmode(channel_find(server, cleantarget),
-					nick);
+	if (ignore_check_plus(server, nick, address, cleantarget, msg, &level, TRUE)) {
+		g_free(prefix);
+		return;
+	}
+
+	chanrec = channel_find(server, cleantarget);
+
+	nickmode = channel_get_nickmode(chanrec, nick);
 
 	optarget = g_strconcat(prefix, cleantarget, NULL);
-
-	chanrec = channel_find(server, target);
 
 	/* Check for hilights */
 	for_me = !settings_get_bool("hilight_nick_matches") ? FALSE :
@@ -99,12 +104,15 @@ static void sig_message_irc_op_public(SERVER_REC *server, const char *msg,
 		nick_match_msg(chanrec, msg, server->nick) :
 		nick_match_msg_everywhere(chanrec, msg, server->nick);
 	hilight = for_me ? NULL :
-		hilight_match_nick(server, target, nick, address, MSGLEVEL_PUBLIC, msg);
+		hilight_match_nick(server, cleantarget, nick, address, MSGLEVEL_PUBLIC, msg);
 	color = (hilight == NULL) ? NULL : hilight_get_color(hilight);
 
 	level = MSGLEVEL_PUBLIC;
 	if (for_me)
 		level |= MSGLEVEL_HILIGHT;
+
+	if (settings_get_bool("emphasis"))
+		msg = freemsg = expand_emphasis((WI_ITEM_REC *) chanrec, msg);
 
 	if (color != NULL) {
 		format_create_dest(&dest, server, cleantarget, level, NULL);
@@ -119,7 +127,10 @@ static void sig_message_irc_op_public(SERVER_REC *server, const char *msg,
 			for_me ? TXT_PUBMSG_ME_CHANNEL : TXT_PUBMSG_CHANNEL,
 			nick, optarget, msg, nickmode);
 	}
+
 	g_free(nickmode);
+	g_free(freemsg);
+	g_free(color);
 	g_free(optarget);
 	g_free(prefix);
 }

--- a/src/fe-common/irc/fe-irc-messages.c
+++ b/src/fe-common/irc/fe-irc-messages.c
@@ -35,6 +35,7 @@
 #include <irssi/src/fe-common/core/fe-messages.h>
 
 #include <irssi/src/fe-common/core/fe-queries.h>
+#include <irssi/src/fe-common/core/hilight-text.h>
 #include <irssi/src/fe-common/core/window-items.h>
 #include <irssi/src/fe-common/irc/fe-irc-channels.h>
 #include <irssi/src/fe-common/irc/fe-irc-server.h>
@@ -71,8 +72,12 @@ static void sig_message_irc_op_public(SERVER_REC *server, const char *msg,
 				      const char *nick, const char *address,
 				      const char *target)
 {
-	char *nickmode, *optarget, *prefix;
+	CHANNEL_REC *chanrec;
+	char *nickmode, *optarget, *prefix, *color;
 	const char *cleantarget;
+	int for_me, level;
+	HILIGHT_REC *hilight;
+	TEXT_DEST_REC dest;
 
 	/* only skip here so the difference can be stored in prefix */
 	cleantarget = fe_channel_skip_prefix(IRC_SERVER(server), target);
@@ -86,10 +91,34 @@ static void sig_message_irc_op_public(SERVER_REC *server, const char *msg,
 
 	optarget = g_strconcat(prefix, cleantarget, NULL);
 
-	printformat_module("fe-common/core", server, cleantarget,
-			   MSGLEVEL_PUBLIC,
-			   TXT_PUBMSG_CHANNEL,
-			   nick, optarget, msg, nickmode);
+	chanrec = channel_find(server, target);
+
+	/* Check for hilights */
+	for_me = !settings_get_bool("hilight_nick_matches") ? FALSE :
+		!settings_get_bool("hilight_nick_matches_everywhere") ?
+		nick_match_msg(chanrec, msg, server->nick) :
+		nick_match_msg_everywhere(chanrec, msg, server->nick);
+	hilight = for_me ? NULL :
+		hilight_match_nick(server, target, nick, address, MSGLEVEL_PUBLIC, msg);
+	color = (hilight == NULL) ? NULL : hilight_get_color(hilight);
+
+	level = MSGLEVEL_PUBLIC;
+	if (for_me)
+		level |= MSGLEVEL_HILIGHT;
+
+	if (color != NULL) {
+		format_create_dest(&dest, server, cleantarget, level, NULL);
+		dest.address = address;
+		dest.nick = nick;
+		hilight_update_text_dest(&dest,hilight);
+		printformat_module_dest("fe-common/core", &dest,
+			TXT_PUBMSG_HILIGHT_CHANNEL,
+			color, nick, optarget, msg, nickmode);
+	} else {
+		printformat_module("fe-common/core", server, cleantarget, level,
+			for_me ? TXT_PUBMSG_ME_CHANNEL : TXT_PUBMSG_CHANNEL,
+			nick, optarget, msg, nickmode);
+	}
 	g_free(nickmode);
 	g_free(optarget);
 	g_free(prefix);


### PR DESCRIPTION
This patch allows irc_op_public messages to properly trigger
hilights when the message mentions the current nick or one of our
hilights. This is done by copying the required code from
sig_message_public. This is important because Freenode has begun
using this message type for messages that can only be seen by ops
due to the +z channel mode, and ops will want to be notified of
watchwords even in that type of message.

To test, make two connections to Freenode, join a new channel. The
first client to join that channel will be an op. To establish a
baseline, use the non-opped client to attempt to "ping" the opped
client by addressing it by name and using terms in /hilight. Then,
set channel mode to +mz and use the non-opped client to send the
messages again. Without this patch, no message will "ping" the opped
client with +mz set. With this patch, "pings" should operate
normally, causing a bell, hilighting the window number, and so on.

What I don't know is whether there is any other code from
sig_message_public that should be copied over too. In particular,
the lines related to "ignore_check_plus", "emphasis", and
"printnick", I don't know if they are needed here. I also don't know
if there are any other message types that these changes should be
    applied to.