### PR TITLE
Improve clarity of nick in use message

### DIFF
--- a/src/fe-common/irc/module-formats.c
+++ b/src/fe-common/irc/module-formats.c
@@ -98,7 +98,7 @@ FORMAT_REC fecommon_irc_formats[] = {
 	{ "no_such_nick", "{nick $0}: No such nick/channel", 1, { 0 } },
 	{ "nick_in_use", "Nick {nick $0} is already in use", 1, { 0 } },
 	{ "nick_unavailable", "Nick {nick $0} is temporarily unavailable", 1, { 0 } },
-        { "your_nick_owned", "Your nick is owned by {nick $3} {comment $1@$2}", 4, { 0, 0, 0, 0 } },
+        { "your_nick_owned", "Your nick is in use by {nick $3} {comment $1@$2}", 4, { 0, 0, 0, 0 } },
 
 	/* ---- */
 	{ NULL, "Who queries", 0 },


### PR DESCRIPTION
If irssi's preferred nick is in use irssi will issue a whois command and report some information
on the current user of the nick. As the "is owned by" wording can be confusing to users of networks with nickname registration, I propose rephrasing this to "is in use by".