### PR TITLE
Fix some glib deprecation warnings

### DIFF
--- a/fuzz-support/fuzz.diff
+++ b/fuzz-support/fuzz.diff
@@ -150,7 +150,7 @@ index ad79e0c..84d0c5c 100644
 +++ b/src/fe-text/irssi.c
 @@ -314,20 +314,16 @@ int main(int argc, char **argv)
  	textui_finish_init();
- 	main_loop = g_main_new(TRUE);
+ 	main_loop = g_main_loop_new(NULL, TRUE);
  
 +#ifdef __AFL_HAVE_MANUAL_CONTROL
 +	__AFL_INIT();
@@ -162,7 +162,7 @@ index ad79e0c..84d0c5c 100644
  	   can call our dirty-checker after each iteration */
  	while (!quitting) {
 -		term_refresh_freeze();
- 		g_main_iteration(TRUE);
+ 		g_main_context_iteration(NULL, TRUE);
 -                term_refresh_thaw();
 -
 -		if (reload_config) {
@@ -174,7 +174,7 @@ index ad79e0c..84d0c5c 100644
 -		dirty_check();
  	}
  
- 	g_main_destroy(main_loop);
+ 	g_main_loop_unref(main_loop);
 diff --git a/src/fe-text/term-terminfo.c b/src/fe-text/term-terminfo.c
 index b2478c6..cebe260 100644
 --- a/src/fe-text/term-terminfo.c

--- a/src/core/commands.c
+++ b/src/core/commands.c
@@ -501,7 +501,7 @@ char *cmd_get_quoted_param(char **data)
 	while (**data != '\0' && (**data != quote ||
 				  ((*data)[1] != ' ' && (*data)[1] != '\0'))) {
 		if (**data == '\\' && (*data)[1] != '\0')
-                        g_memmove(*data, (*data)+1, strlen(*data));
+                        memmove(*data, (*data)+1, strlen(*data));
 		(*data)++;
 	}
 

--- a/src/core/line-split.c
+++ b/src/core/line-split.c
@@ -96,7 +96,7 @@ int line_split(const char *data, int len, char **output, LINEBUF_REC **buffer)
 
 	if (rec->remove > 0) {
 		rec->len -= rec->remove;
-		g_memmove(rec->str, rec->str+rec->remove, rec->len);
+		memmove(rec->str, rec->str+rec->remove, rec->len);
 		rec->remove = 0;
 	}
 

--- a/src/core/net-sendbuffer.c
+++ b/src/core/net-sendbuffer.c
@@ -67,7 +67,7 @@ static int buffer_send(NET_SENDBUF_REC *rec)
 
 	if (ret > 0) {
                 rec->bufpos -= ret;
-		g_memmove(rec->buffer, rec->buffer+ret, rec->bufpos);
+		memmove(rec->buffer, rec->buffer+ret, rec->bufpos);
 	}
 	return FALSE;
 }

--- a/src/fe-common/irc/fe-events-numeric.c
+++ b/src/fe-common/irc/fe-events-numeric.c
@@ -600,7 +600,7 @@ static void print_event_received(IRC_SERVER_REC *server, const char *data,
 		args = g_strdup(ptr);
 		ptr = strstr(args, " :");
 		if (ptr != NULL)
-			g_memmove(ptr+1, ptr+2, strlen(ptr+1));
+			memmove(ptr+1, ptr+2, strlen(ptr+1));
 	}
 
 	recoded = recode_in(SERVER(server), args, NULL);

--- a/src/fe-none/irssi.c
+++ b/src/fe-none/irssi.c
@@ -103,9 +103,9 @@ int main(int argc, char **argv)
 	do {
 		reload = FALSE;
 		module_load(autoload_module, NULL);
-		main_loop = g_main_new(TRUE);
-		g_main_run(main_loop);
-		g_main_destroy(main_loop);
+		main_loop = g_main_loop_new(NULL, TRUE);
+		g_main_loop_run(main_loop);
+		g_main_loop_unref(main_loop);
 	}
 	while (reload);
 	noui_deinit();

--- a/src/fe-text/gui-entry.c
+++ b/src/fe-text/gui-entry.c
@@ -611,13 +611,13 @@ void gui_entry_insert_text(GUI_ENTRY_REC *entry, const char *str)
         entry_text_grow(entry, len);
 
         /* make space for the string */
-	g_memmove(entry->text + entry->pos + len, entry->text + entry->pos,
-		  (entry->text_len-entry->pos + 1) * sizeof(unichar));
+	memmove(entry->text + entry->pos + len, entry->text + entry->pos,
+	        (entry->text_len-entry->pos + 1) * sizeof(unichar));
 
 	/* make space for the color */
 	if (entry->uses_extents) {
-		g_memmove(entry->extents + entry->pos + len + 1, entry->extents + entry->pos + 1,
-			  (entry->text_len-entry->pos) * sizeof(char *));
+		memmove(entry->extents + entry->pos + len + 1, entry->extents + entry->pos + 1,
+		        (entry->text_len-entry->pos) * sizeof(char *));
 		for (i = 0; i < len; i++) {
 			entry->extents[entry->pos + i + 1] = NULL;
 		}
@@ -662,12 +662,12 @@ void gui_entry_insert_char(GUI_ENTRY_REC *entry, unichar chr)
 	entry_text_grow(entry, 1);
 
 	/* make space for the string */
-	g_memmove(entry->text + entry->pos + 1, entry->text + entry->pos,
-		  (entry->text_len-entry->pos + 1) * sizeof(unichar));
+	memmove(entry->text + entry->pos + 1, entry->text + entry->pos,
+	        (entry->text_len-entry->pos + 1) * sizeof(unichar));
 
 	if (entry->uses_extents) {
-		g_memmove(entry->extents + entry->pos + 1 + 1, entry->extents + entry->pos + 1,
-			  (entry->text_len-entry->pos) * sizeof(char *));
+		memmove(entry->extents + entry->pos + 1 + 1, entry->extents + entry->pos + 1,
+		        (entry->text_len-entry->pos) * sizeof(char *));
 		entry->extents[entry->pos + 1] = NULL;
 	}
 
@@ -838,8 +838,8 @@ void gui_entry_erase(GUI_ENTRY_REC *entry, int size, CUTBUFFER_UPDATE_OP update_
 		while (entry->pos-size-w > 0 &&
 		       i_wcwidth(entry->text[entry->pos-size-w]) == 0) w++;
 
-	g_memmove(entry->text + entry->pos - size, entry->text + entry->pos,
-		  (entry->text_len-entry->pos+1) * sizeof(unichar));
+	memmove(entry->text + entry->pos - size, entry->text + entry->pos,
+	        (entry->text_len-entry->pos+1) * sizeof(unichar));
 
 	if (entry->uses_extents) {
 		for (i = entry->pos - size; i < entry->pos; i++) {
@@ -847,8 +847,8 @@ void gui_entry_erase(GUI_ENTRY_REC *entry, int size, CUTBUFFER_UPDATE_OP update_
 				g_free(entry->extents[i+1]);
 			}
 		}
-		g_memmove(entry->extents + entry->pos - size + 1, entry->extents + entry->pos + 1,
-			  (entry->text_len - entry->pos) * sizeof(void *)); /* no null terminator here */
+		memmove(entry->extents + entry->pos - size + 1, entry->extents + entry->pos + 1,
+		        (entry->text_len - entry->pos) * sizeof(void *)); /* no null terminator here */
 		for (i = 0; i < size; i++) {
 			entry->extents[entry->text_len - i] = NULL;
 		}
@@ -876,16 +876,16 @@ void gui_entry_erase_cell(GUI_ENTRY_REC *entry)
 		while (entry->pos+size < entry->text_len &&
 		       i_wcwidth(entry->text[entry->pos+size]) == 0) size++;
 
-	g_memmove(entry->text + entry->pos, entry->text + entry->pos + size,
-	          (entry->text_len-entry->pos-size+1) * sizeof(unichar));
+	memmove(entry->text + entry->pos, entry->text + entry->pos + size,
+	        (entry->text_len-entry->pos-size+1) * sizeof(unichar));
 
 	if (entry->uses_extents) {
 		int i;
 		for (i = 0; i < size; i++) {
 			g_free(entry->extents[entry->pos + i + 1]);
 		}
-		g_memmove(entry->extents + entry->pos + 1, entry->extents + entry->pos + size + 1,
-			  (entry->text_len-entry->pos-size) * sizeof(char *));
+		memmove(entry->extents + entry->pos + 1, entry->extents + entry->pos + size + 1,
+		        (entry->text_len-entry->pos-size) * sizeof(char *));
 		for (i = 0; i < size; i++) {
 			entry->extents[entry->text_len - i] = NULL;
 		}

--- a/src/fe-text/irssi.c
+++ b/src/fe-text/irssi.c
@@ -334,7 +334,7 @@ int main(int argc, char **argv)
 
 	g_log_set_always_fatal(loglev);
 	textui_finish_init();
-	main_loop = g_main_new(TRUE);
+	main_loop = g_main_loop_new(NULL, TRUE);
 
 	/* Does the same as g_main_run(main_loop), except we
 	   can call our dirty-checker after each iteration */
@@ -348,11 +348,11 @@ int main(int argc, char **argv)
 		dirty_check();
 
 		term_refresh_freeze();
-		g_main_iteration(TRUE);
+		g_main_context_iteration(NULL, TRUE);
 		term_refresh_thaw();
 	}
 
-	g_main_destroy(main_loop);
+	g_main_loop_unref(main_loop);
 	textui_deinit();
 
 	session_upgrade(); /* if we /UPGRADEd, start the new process */

--- a/src/irc/core/bans.c
+++ b/src/irc/core/bans.c
@@ -75,7 +75,7 @@ char *ban_get_mask(IRC_CHANNEL_REC *channel, const char *nick, int ban_type)
         size = (int) (host-user);
 	if (size >= 10) {
 		/* too long user mask */
-		g_memmove(user+1, user+(size-9), strlen(user+(size-9))+1);
+		memmove(user+1, user+(size-9), strlen(user+(size-9))+1);
 	}
 	return str;
 }

--- a/src/irc/dcc/dcc-get.c
+++ b/src/irc/dcc/dcc-get.c
@@ -477,8 +477,8 @@ static void ctcp_msg_dcc_send(IRC_SERVER_REC *server, const char *data,
 	if (len > 1 && *fname == '"' && fname[len-1] == '"') {
 		/* "file name" - MIRC sends filenames with spaces like this */
 		fname[len-1] = '\0';
-		g_memmove(fname, fname+1, len);
-                quoted = TRUE;
+		memmove(fname, fname+1, len);
+		quoted = TRUE;
 	}
 
 	if (passive && port != 0) {

--- a/src/irc/dcc/dcc-server.c
+++ b/src/irc/dcc/dcc-server.c
@@ -261,7 +261,7 @@ static void dcc_server_msg(SERVER_DCC_REC *dcc, const char *msg)
 			if (len > 1 && *fname == '"' && fname[len-1] == '"') {
 				/* "file name" - MIRC sends filenames with spaces like this */
 				fname[len-1] = '\0';
-				g_memmove(fname, fname+1, len);
+				memmove(fname, fname+1, len);
 				quoted = TRUE;
 			}
 


### PR DESCRIPTION
Most of these have been deprecated since forever (2.2), but they didn't
raise warnings. Now they do, and the warnings are not the most verbose
warnings you could ask for, but, they point in the right direction.

This doesn't handle the GTimeVal deprecation warnings. Those seem
trickier since they cover API, will look into those right after this.