### PR TITLE
Reconnect retry IPv4 on IPv6 failure 

### DIFF
--- a/src/core/server-connect-rec.h
+++ b/src/core/server-connect-rec.h
@@ -11,6 +11,7 @@ int proxy_port;
 char *proxy_string, *proxy_string_after, *proxy_password;
 
 unsigned short family; /* 0 = don't care, AF_INET or AF_INET6 */
+unsigned short chosen_family; /* family actually chosen during name resolution */
 char *tag; /* try to keep this tag when connected to server */
 char *address;
 int port;
@@ -43,5 +44,6 @@ unsigned int unix_socket:1; /* Connect using named unix socket */
 unsigned int use_tls:1; /* this connection uses TLS */
 unsigned int tls_verify:1;
 unsigned int no_connect:1; /* don't connect() at all, it's done by plugin */
+unsigned short last_failed_family; /* #641: if we failed to connect to ipv6, try ipv4 and vice versa */
 char *channels;
 char *away_reason;

--- a/src/core/servers-reconnect.c
+++ b/src/core/servers-reconnect.c
@@ -168,6 +168,7 @@ server_connect_copy_skeleton(SERVER_CONNECT_REC *src, int connect_info)
         server_connect_ref(dest);
 	dest->type = module_get_uniq_id("SERVER CONNECT", 0);
 	dest->reconnection = src->reconnection;
+	dest->last_failed_family = src->last_failed_family;
 	dest->proxy = g_strdup(src->proxy);
         dest->proxy_port = src->proxy_port;
 	dest->proxy_string = g_strdup(src->proxy_string);


### PR DESCRIPTION
Track the address family of the last failed connection attempt (either immediately or during TLS handshake), then disprefer that address family during reconnection.

A note on testing ipv6 connectivity failure on Linux: `disable_ipv6` will not simulate it correctly, because irssi calls `getaddrinfo(3)` with `AI_ADDRCONFIG`, which suppresses resolution of ipv6 addresses if no local ipv6 address is available.

The correct way to simulate this is with `disable_ra`. That way, the link-local address will remain, and `getaddrinfo(3)` will return addresses corresponding to AAAA records, but attempts to connect to them will fail with "Network is unreachable".

I tested a few different cases (disable_ra for cutting off ipv6, an iptables rule dropping outgoing packets for cutting off ipv4), but this probably needs more testing --- let me know if you have suggestions.