### PR TITLE
fix perl module build on openbsd

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -406,6 +406,12 @@ if want_capsicum
   endif
 endif
 
+# dependency helper sets
+dep_cflagsonly = []
+foreach d : dep
+  dep_cflagsonly += d.partial_dependency(includes : true, compile_args : true)
+endforeach
+
 ##################
 # irssi-config.h #
 ##################

--- a/src/perl/meson.build
+++ b/src/perl/meson.build
@@ -35,7 +35,8 @@ shared_module('perl_core',
   install_dir : moduledir,
   install_rpath : perl_rpath,
   build_rpath : perl_rpath,
-  dependencies : dep + [ perl_dep ],
+  dependencies : dep_cflagsonly + [ perl_dep ],
+  override_options : ['b_asneeded=false'],
 )
 
 shared_module('fe_perl',


### PR DESCRIPTION
unfortunately, some mangling is needed to create the correct linker and compiler invocations