### PR TITLE
manually handle NUL unicode in g_utf8_get_next_char_validated

### DIFF
--- a/src/fe-text/term-terminfo.c
+++ b/src/fe-text/term-terminfo.c
@@ -672,7 +672,11 @@ void term_stop(void)
 
 static int input_utf8(const unsigned char *buffer, int size, unichar *result)
 {
-	unichar c = g_utf8_get_char_validated((char *)buffer, size);
+	unichar c = g_utf8_get_char_validated((char *) buffer, size);
+
+	/* GLib >= 2.63 do not accept Unicode NUL anymore */
+	if (c == (unichar) -2 && *buffer == 0 && size > 0)
+		c = 0;
 
 	switch (c) {
 	case (unichar)-1:


### PR DESCRIPTION
A change in GLib 2.63 broke some assumptions in Irssi that the null-byte NUL  / U+0000 is a valid Unicode character. This would occur when the user types Ctrl+Space. As a result, the input loop never manages to process the NUL-byte (and any other user input that follows, ever).

This patch adds a manual check that properly advances the input loop if GLib returns -2 (incomplete character) despite the length being positive and a NUL is in first position.

Fixes #1180 
https://gitlab.gnome.org/GNOME/glib/-/merge_requests/967
https://gitlab.gnome.org/GNOME/glib/-/issues/2093