### PR TITLE
use visible channel name in layout save

### DIFF
--- a/irssi.conf
+++ b/irssi.conf
@@ -107,7 +107,7 @@ channels = (
 
 aliases = {
   ATAG        = "WINDOW SERVER";
-  ADDALLCHANS = "SCRIPT EXEC foreach my \\$channel (Irssi::channels()) { Irssi::command(\"CHANNEL ADD -auto \\$channel->{name} \\$channel->{server}->{tag} \\$channel->{key}\")\\;}";
+  ADDALLCHANS = "SCRIPT EXEC foreach my \\$channel (Irssi::channels()) { Irssi::command(\"CHANNEL ADD -auto \\$channel->{visible_name} \\$channel->{server}->{tag} \\$channel->{key}\")\\;}";
   B           = "BAN";
   BACK        = "AWAY";
   BANS        = "BAN";

--- a/src/fe-common/core/windows-layout.c
+++ b/src/fe-common/core/windows-layout.c
@@ -169,12 +169,12 @@ static void sig_layout_save_item(WINDOW_REC *window, WI_ITEM_REC *item,
 		chat_protocol_find_id(item->chat_type);
 	if (proto != NULL)
 		iconfig_node_set_str(subnode, "chat_type", proto->name);
-	iconfig_node_set_str(subnode, "name", item->name);
+	iconfig_node_set_str(subnode, "name", item->visible_name);
 
 	if (item->server != NULL) {
 		iconfig_node_set_str(subnode, "tag", item->server->tag);
 		if (IS_CHANNEL(item)) {
-			rec = window_bind_add(window, item->server->tag, item->name);
+			rec = window_bind_add(window, item->server->tag, item->visible_name);
 			if (rec != NULL)
 				rec->sticky = TRUE;
 		}


### PR DESCRIPTION
Hi,

there's something of a long standing problem with /layout save and !-channels (eg. on IRCnet). Consider the following initial config file, without channels or windows saved:

```
servers = (
  {
    address = "irc.cs.hut.fi";
    chatnet = "IRCnet";
    port = "6667";
    autoconnect = "yes";
  }
);

chatnets = {
  IRCnet = {
    type = "IRC";
    max_kicks = "1";
    max_msgs = "1";
    max_whois = "1";
  };
};

settings = {
  core = {
    real_name = "irssi-chansave";
    user_name = "irssi-chansave";
    nick = "irssi-chansave";
  };
  "fe-text" = { actlist_sort = "refnum"; };
};
windows = {
  1 = { immortal = "yes"; name = "(status)"; level = "ALL"; };
};
```

When irssi is started on this config file, and a !-channel is joined (`/join !!new-channel`, or `/join !existing-channel`), a new window is created and the channel item is added to that window, as expected. `/window` will report:
```
11:27 Window  : #3
11:27 Size    : 113x54
11:27 Level   : NONE
11:27 Server  : IRCnet
11:27 Items   : Name                           Server tag
11:27  CHANNEL: !existing-channel              IRCnet
```

Now, however, if `/layout save` is used by the user who wants this channel to stay in the same window next time they run irssi, a discrepancy is created:

```
11:29 Window  : #3
11:29 Size    : 113x54
11:29 Level   : NONE
11:29 Server  : IRCnet
11:29 Bounds  : Name                           Server tag
11:29         : !KYKAFexisting-channel         IRCnet          sticky
11:29 Items   : Name                           Server tag
11:29  CHANNEL: !existing-channel              IRCnet
```

When irssi is restarted, window #3 is again created with the bound:
```
11:29 Window  : #3
11:29 Size    : 113x54
11:29 Level   : NONE
11:29 Server  : IRCnet
11:29 Bounds  : Name                           Server tag
11:29         : !KYKAFexisting-channel         IRCnet          sticky
```

but when !existing-channel is rejoined, it does not match the bound on window 3, creating a new window instead and leaving window 3 empty.

So, I propose this patch to modify layout saving to create a binding for the visible_name of the channel instead, which makes this scenario of saving layouts for !-channels work correctly.