### PR TITLE
Fix crash from self-unloading script

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -6,7 +6,7 @@
 #define IRSSI_GLOBAL_CONFIG "irssi.conf" /* config file name in /etc/ */
 #define IRSSI_HOME_CONFIG "config" /* config file name in ~/.irssi/ */
 
-#define IRSSI_ABI_VERSION 29
+#define IRSSI_ABI_VERSION 30
 
 #define DEFAULT_SERVER_ADD_PORT 6667
 #define DEFAULT_SERVER_ADD_TLS_PORT 6697

--- a/src/common.h
+++ b/src/common.h
@@ -6,7 +6,7 @@
 #define IRSSI_GLOBAL_CONFIG "irssi.conf" /* config file name in /etc/ */
 #define IRSSI_HOME_CONFIG "config" /* config file name in ~/.irssi/ */
 
-#define IRSSI_ABI_VERSION 30
+#define IRSSI_ABI_VERSION 31
 
 #define DEFAULT_SERVER_ADD_PORT 6667
 #define DEFAULT_SERVER_ADD_TLS_PORT 6697

--- a/src/perl/perl-core.c
+++ b/src/perl/perl-core.c
@@ -308,8 +308,8 @@ PERL_SCRIPT_REC *perl_script_load_data(const char *data)
 /* Unload perl script */
 void perl_script_unload(PERL_SCRIPT_REC *script)
 {
-	GSList* link;
-        g_return_if_fail(script != NULL);
+	GSList *link;
+	g_return_if_fail(script != NULL);
 
 	perl_script_destroy_package(script);
 
@@ -322,9 +322,6 @@ void perl_script_unload(PERL_SCRIPT_REC *script)
 		g_slist_free(link);
 		perl_script_unref(script);
 	}
-
-/*	perl_scripts = g_slist_remove(perl_scripts, script);
-	perl_script_unref(script);*/
 }
 
 /* Enter a perl script (signal or input source) */

--- a/src/perl/perl-core.h
+++ b/src/perl/perl-core.h
@@ -8,8 +8,7 @@ typedef struct {
         /* Script can be loaded from a file, or from some data in memory */
 	char *path; /* FILE: full path for file */
 	char *data; /* DATA: data used for the script */
-	int unloaded; /* Indicates unloading has been done, so it should be destroyed once all signals exit */
-	int active_signals; /* active signal calls into this script - prevents full teardown when nonzero */
+	int refcount; /* 0 = destroy */
 } PERL_SCRIPT_REC;
 
 extern GSList *perl_scripts;
@@ -29,9 +28,9 @@ PERL_SCRIPT_REC *perl_script_load_data(const char *data);
 void perl_script_unload(PERL_SCRIPT_REC *script);
 
 /* Mark a script as entered */
-void perl_script_enter(PERL_SCRIPT_REC *script);
+void perl_script_ref(PERL_SCRIPT_REC *script);
 /* Mark a script as exited */
-void perl_script_exit(PERL_SCRIPT_REC *script);
+void perl_script_unref(PERL_SCRIPT_REC *script);
 
 /* Find loaded script by name */
 PERL_SCRIPT_REC *perl_script_find(const char *name);

--- a/src/perl/perl-core.h
+++ b/src/perl/perl-core.h
@@ -8,6 +8,8 @@ typedef struct {
         /* Script can be loaded from a file, or from some data in memory */
 	char *path; /* FILE: full path for file */
 	char *data; /* DATA: data used for the script */
+	int unloaded; /* Indicates unloading has been done, so it should be destroyed once all signals exit */
+	int active_signals; /* active signal calls into this script - prevents full teardown when nonzero */
 } PERL_SCRIPT_REC;
 
 extern GSList *perl_scripts;
@@ -25,6 +27,11 @@ PERL_SCRIPT_REC *perl_script_load_file(const char *path);
 PERL_SCRIPT_REC *perl_script_load_data(const char *data);
 /* Unload perl script */
 void perl_script_unload(PERL_SCRIPT_REC *script);
+
+/* Mark a script as entered */
+void perl_script_enter(PERL_SCRIPT_REC *script);
+/* Mark a script as exited */
+void perl_script_exit(PERL_SCRIPT_REC *script);
 
 /* Find loaded script by name */
 PERL_SCRIPT_REC *perl_script_find(const char *name);

--- a/src/perl/perl-fe.c
+++ b/src/perl/perl-fe.c
@@ -106,7 +106,7 @@ static void cmd_script_unload(const char *data)
 
         script_fix_name(name);
 	script = perl_script_find(name);
-	if (script == NULL || script->unloaded) {
+	if (script == NULL) {
 		printformat(NULL, NULL, MSGLEVEL_CLIENTERROR,
                             TXT_SCRIPT_NOT_LOADED, name);
 	} else {

--- a/src/perl/perl-fe.c
+++ b/src/perl/perl-fe.c
@@ -106,7 +106,7 @@ static void cmd_script_unload(const char *data)
 
         script_fix_name(name);
 	script = perl_script_find(name);
-	if (script == NULL) {
+	if (script == NULL || script->unloaded) {
 		printformat(NULL, NULL, MSGLEVEL_CLIENTERROR,
                             TXT_SCRIPT_NOT_LOADED, name);
 	} else {

--- a/src/perl/perl-signals.c
+++ b/src/perl/perl-signals.c
@@ -420,7 +420,10 @@ static void sig_func(const void *p1, const void *p2,
 	args[3] = p4; args[4] = p5; args[5] = p6;
 
 	rec = signal_get_user_data();
+	if (rec->script->unloaded) return; /* Drop signal calls into unloaded scripts. */
+	perl_script_enter(rec->script);
 	perl_call_signal(rec->script, rec->func, signal_get_emitted_id(), args);
+	perl_script_exit(rec->script);
 }
 
 static void perl_signal_add_full_int(const char *signal, SV *func,
@@ -437,6 +440,7 @@ static void perl_signal_add_full_int(const char *signal, SV *func,
 
         script = perl_script_find_package(perl_get_package());
         g_return_if_fail(script != NULL);
+	g_return_if_fail(script->unloaded);
 
 	rec = g_new(PERL_SIGNAL_REC, 1);
         rec->script = script;

--- a/src/perl/perl-signals.c
+++ b/src/perl/perl-signals.c
@@ -414,16 +414,18 @@ static void sig_func(const void *p1, const void *p2,
 		     const void *p5, const void *p6)
 {
 	PERL_SIGNAL_REC *rec;
+	PERL_SCRIPT_REC *script;
 	const void *args[SIGNAL_MAX_ARGUMENTS];
 
 	args[0] = p1; args[1] = p2; args[2] = p3;
 	args[3] = p4; args[4] = p5; args[5] = p6;
 
 	rec = signal_get_user_data();
+	script = rec->script;
 	if (rec->script->unloaded) return; /* Drop signal calls into unloaded scripts. */
-	perl_script_enter(rec->script);
-	perl_call_signal(rec->script, rec->func, signal_get_emitted_id(), args);
-	perl_script_exit(rec->script);
+	perl_script_enter(script);
+	perl_call_signal(script, rec->func, signal_get_emitted_id(), args);
+	perl_script_exit(script);
 }
 
 static void perl_signal_add_full_int(const char *signal, SV *func,

--- a/src/perl/perl-signals.c
+++ b/src/perl/perl-signals.c
@@ -422,10 +422,9 @@ static void sig_func(const void *p1, const void *p2,
 
 	rec = signal_get_user_data();
 	script = rec->script;
-	if (rec->script->unloaded) return; /* Drop signal calls into unloaded scripts. */
-	perl_script_enter(script);
+	perl_script_ref(script);
 	perl_call_signal(script, rec->func, signal_get_emitted_id(), args);
-	perl_script_exit(script);
+	perl_script_unref(script);
 }
 
 static void perl_signal_add_full_int(const char *signal, SV *func,
@@ -442,7 +441,6 @@ static void perl_signal_add_full_int(const char *signal, SV *func,
 
         script = perl_script_find_package(perl_get_package());
         g_return_if_fail(script != NULL);
-	g_return_if_fail(!script->unloaded);
 
 	rec = g_new(PERL_SIGNAL_REC, 1);
         rec->script = script;

--- a/src/perl/perl-signals.c
+++ b/src/perl/perl-signals.c
@@ -440,7 +440,7 @@ static void perl_signal_add_full_int(const char *signal, SV *func,
 
         script = perl_script_find_package(perl_get_package());
         g_return_if_fail(script != NULL);
-	g_return_if_fail(script->unloaded);
+	g_return_if_fail(!script->unloaded);
 
 	rec = g_new(PERL_SIGNAL_REC, 1);
         rec->script = script;

--- a/src/perl/perl-sources.c
+++ b/src/perl/perl-sources.c
@@ -107,7 +107,7 @@ int perl_timeout_add(int msecs, SV *func, SV *data, int once)
         pkg = perl_get_package();
 	script = perl_script_find_package(pkg);
         g_return_val_if_fail(script != NULL, -1);
-	g_return_val_if_fail(script->unloaded, -1);
+	g_return_val_if_fail(!script->unloaded, -1);
 
 	rec = g_new0(PERL_SOURCE_REC, 1);
 	perl_source_ref(rec);
@@ -131,7 +131,7 @@ int perl_input_add(int source, int condition, SV *func, SV *data, int once)
         pkg = perl_get_package();
 	script = perl_script_find_package(pkg);
         g_return_val_if_fail(script != NULL, -1);
-	g_return_val_if_fail(script->unloaded, -1);
+	g_return_val_if_fail(!script->unloaded, -1);
 
 	rec = g_new0(PERL_SOURCE_REC, 1);
 	perl_source_ref(rec);

--- a/src/perl/perl-sources.c
+++ b/src/perl/perl-sources.c
@@ -78,7 +78,7 @@ static int perl_source_event(PERL_SOURCE_REC *rec)
 	PUTBACK;
 
         perl_source_ref(rec);
-	perl_script_enter(rec->script);
+	perl_script_ref(rec->script);
 	perl_call_sv(rec->func, G_EVAL|G_DISCARD);
 
 	if (SvTRUE(ERRSV)) {
@@ -87,7 +87,7 @@ static int perl_source_event(PERL_SOURCE_REC *rec)
                 g_free(error);
 	}
 
-	perl_script_exit(rec->script);
+	perl_script_unref(rec->script);
 
 	if (perl_source_unref(rec) && rec->once)
 		perl_source_destroy(rec);
@@ -107,7 +107,6 @@ int perl_timeout_add(int msecs, SV *func, SV *data, int once)
         pkg = perl_get_package();
 	script = perl_script_find_package(pkg);
         g_return_val_if_fail(script != NULL, -1);
-	g_return_val_if_fail(!script->unloaded, -1);
 
 	rec = g_new0(PERL_SOURCE_REC, 1);
 	perl_source_ref(rec);
@@ -131,7 +130,6 @@ int perl_input_add(int source, int condition, SV *func, SV *data, int once)
         pkg = perl_get_package();
 	script = perl_script_find_package(pkg);
         g_return_val_if_fail(script != NULL, -1);
-	g_return_val_if_fail(!script->unloaded, -1);
 
 	rec = g_new0(PERL_SOURCE_REC, 1);
 	perl_source_ref(rec);


### PR DESCRIPTION
Fixes a crash that can be caused by self-unloading scripts (or other cases of unloading scripts that also have active code), by guarding against multiple calls of perl_script_unload (by /script unload and by sig_script_error).

The particular test case that prompted this is http://urchlay.naptime.net/repos/misc-scripts/tree/selfunload.pl

The crash in the above test case was caused by the following:

1. The script unloads itself using Irssi::command("/script unload selfunload")
2. This leads to perl_script_unload which in turn destroys the script package and then calls perl_script_destroy (freeing the PERL_SCRIPT_REC).
3. Execution then returns to the perl script. An insertion of a print to STDERR can confirm that execution does in fact return to the script (the original version incorrectly believed the first command() never returned - it does).
4. However, the second command() refers to command() unqualified. Before this was imported via the use statement, but due to step 2, this import was undefined, so this second command causes a perl error.
5. The unhandled error triggers a "script error" signal, which sig_script_error() then calls perl_script_unload. On the same PERL_SCRIPT_REC that had already had perl_script_unload called upon it.
6. This leads to perl_script_unload executing against a free()'d memory block, and eventually leads to perl_script_destroy again which results in a double-free of the PERL_SCRIPT_REC and its constituent variables. And so everything explodes.

The resolution is to make PERL_SCRIPT_REC ref-counted. Some of the unload logic that previously existed in perl_script_destroy was moved to perl_script_unload: e.g. de-registration of signals and event handlers and removal from the active-scripts list. perl_script_destroy now is exclusively free()ing of the PERL_SCRIPT_REC (and still is responsible for generating the "script destroyed" signal. The signal and input/timeout handling trampolines will now ref/unref the PERL_SCRIPT_REC, so it will not be destroyed by perl_script_unload until these handlers complete.