### PR TITLE
fix missing wrapping of line in signals

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -6,7 +6,7 @@
 #define IRSSI_GLOBAL_CONFIG "irssi.conf" /* config file name in /etc/ */
 #define IRSSI_HOME_CONFIG "config" /* config file name in ~/.irssi/ */
 
-#define IRSSI_ABI_VERSION 31
+#define IRSSI_ABI_VERSION 32
 
 #define DEFAULT_SERVER_ADD_PORT 6667
 #define DEFAULT_SERVER_ADD_TLS_PORT 6697

--- a/src/perl/perl-common.h
+++ b/src/perl/perl-common.h
@@ -13,6 +13,8 @@
 
 typedef void (*PERL_OBJECT_FUNC) (HV *hv, void *object);
 
+typedef SV *(*PERL_BLESS_FUNC)(void *object, void *arg1, void *arg2, void *arg3);
+
 typedef struct {
 	char *name;
         PERL_OBJECT_FUNC fill_func;

--- a/src/perl/perl-signals.h
+++ b/src/perl/perl-signals.h
@@ -24,6 +24,8 @@ void perl_command_unbind(const char *cmd, SV *func);
 void perl_command_runsub(const char *cmd, const char *data,
 			 SERVER_REC *server, WI_ITEM_REC *item);
 
+void irssi_add_signal_arg_conv(const char *stash, PERL_BLESS_FUNC func);
+
 void perl_signal_register(const char *signal, const char **args);
 
 void perl_signals_start(void);

--- a/src/perl/textui/TextUI.xs
+++ b/src/perl/textui/TextUI.xs
@@ -85,6 +85,16 @@ static void perl_statusbar_item_fill_hash(HV *hv, SBAR_ITEM_REC *item)
 		(void) hv_store(hv, "window", 6, plain_bless(item->bar->parent_window->active, "Irssi::UI::Window"), 0);
 }
 
+static SV *perl_line_signal_arg_conv(LINE_REC *line, TEXT_BUFFER_VIEW_REC *view, WINDOW_REC *window)
+{
+	if (view != NULL)
+		return buffer_line_bless(view->buffer, line);
+	else if (window != NULL)
+		return buffer_line_bless(WINDOW_GUI(window)->view->buffer, line);
+	else
+		return &PL_sv_undef;
+}
+
 static PLAIN_OBJECT_INIT_REC textui_plains[] = {
 	{ "Irssi::TextUI::MainWindow", (PERL_OBJECT_FUNC) perl_main_window_fill_hash },
 	{ "Irssi::TextUI::TextBuffer", (PERL_OBJECT_FUNC) perl_text_buffer_fill_hash },
@@ -109,7 +119,9 @@ CODE:
 	initialized = TRUE;
 
         irssi_add_plains(textui_plains);
-        perl_statusbar_init();
+	irssi_add_signal_arg_conv("Irssi::TextUI::Line",
+	                          (PERL_BLESS_FUNC) perl_line_signal_arg_conv);
+	perl_statusbar_init();
 
 void
 deinit()


### PR DESCRIPTION
related to #1079 /  57fb173130cec6e82bccfbe6ead09731b591c5a6

the signals that include LINE_REC*s do not have any possibility to wrap these, so we have to create some more code

otherwise we get a segv in perl_line_fill_hash, which is passed a raw LINE_REC* when called from plain_bless
 in perl-signals.c