### PR TITLE
Decolor the vertical window split bar in stock `colorless` theme

### DIFF
--- a/themes/colorless.theme
+++ b/themes/colorless.theme
@@ -251,6 +251,7 @@ abstracts = {
   # default background for all statusbars. You can also give
   # the default foreground color for statusbar items.
   sb_background = "%8";
+  window_border = "%8";
 
   # default backround for "default" statusbar group
   #sb_default_bg = "%8";


### PR DESCRIPTION
Current Irssi's stock `colorless` theme does not contain any code to de-color vertical window split bars (i.e. bug #1220), resulting in them being colored with default blue background; defeating the purpose of the theme.

This one-line change introduces following line into `themes/colorless.theme`:

	  window_border = "%8";

Which makes the vertical window split bars use reverse-video of default terminal foreground/background instead.

### Screenshots ###

Before the fix:
![(Screenshot)](https://u.cubeupload.com/xwindows/jSkFjv.png)

**After** the fix:
![(Screenshot)](https://u.cubeupload.com/xwindows/hCt5f7.png)

### Caveat ###

This fix brings out a quirk in Irssi's styling implementation&mdash; where vertical window split bar's styling overlapped with the bottom status bar's styling, resulting in a black cell at the middle of bottom status bar. (Status bar used reverse video, and split bar reversed it back)

Fixing the quirk itself might entail redefining the extent of of window split bar and/or status bar drawing inside Irssi's main codebase (with consideration on effects on other themes' compatibility); but that warrants a dedicated ticket for another day.

Having this fix is likely to be better than leaving color in `colorless` theme of course.

### System Information ###

Irssi: 1.2.2 (20190829 0225)<sup>\*</sup>  
System: Fedora 32 (GNU/Linux x86_64)

<sup>\*</sup> The change is tested by installing the new theme file as a user's own theme file.