### PR TITLE
use cc.links in meson.build to fix regression of meson 0.56

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -363,7 +363,7 @@ if want_perl
     version : perl_version)
 
   ####
-  if not cc.compiles('''
+  if not cc.links('''
 #include <EXTERN.h>
 #include <perl.h>
 int main()


### PR DESCRIPTION
fixes #1235 reported by dcbaker