### PR TITLE
Add a check for term.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -355,6 +355,10 @@ if test "x$want_textui" != "xno"; then
 	AC_SUBST(TEXTUI_LIBS)
 	LIBS="$TEXTUI_NO_LIBS"
 
+	AC_CHECK_HEADER([term.h], [
+		AC_DEFINE(HAVE_TERM_H, [], [Define to 1 if you have the `term.h' header.])
+	])
+
 fi
 
 dnl **

--- a/meson.build
+++ b/meson.build
@@ -525,6 +525,7 @@ headers = [
   'sys/time.h',
   'sys/utsname.h',
   'dirent.h',
+  'term.h',
   'unistd.h',
 ]
 foreach h : headers

--- a/src/fe-text/terminfo-core.c
+++ b/src/fe-text/terminfo-core.c
@@ -12,6 +12,9 @@ inline static int term_putchar(int c)
         return fputc(c, current_term->out);
 }
 
+#ifdef HAVE_TERM_H
+#include <term.h>
+#else
 /* Don't bother including curses.h because of these -
    they might not even be defined there */
 char *tparm();
@@ -21,6 +24,8 @@ int setupterm();
 char *tigetstr();
 int tigetnum();
 int tigetflag();
+#endif
+
 #define term_getstr(x, buffer) tigetstr(x.ti_name)
 #define term_getnum(x) tigetnum(x.ti_name);
 #define term_getflag(x) tigetflag(x.ti_name);


### PR DESCRIPTION
If `term.h` is present, use that instead of defining prototypes for the terminfo functions in `terminfo-core.c`. This causes problems on certain platforms (e.g. Apple aarch64) due to the functions being prototyped as non-variadic but called as variadic. If `term.h` isn't found, it falls back to the old behaviour.

This fixes #1238; I was able to test on my Apple ARM Mac and it builds/works as expected using the system curses. I wasn't able to test the meson build since it's failing for me for unrelated reasons, but I think my fix should fix that as well.