### PR TITLE
Fix build on operating systems with X/Open Curses, version 2

### DIFF
--- a/src/fe-text/terminfo-core.c
+++ b/src/fe-text/terminfo-core.c
@@ -134,23 +134,23 @@ static void _move_relative(TERM_REC *term, int oldx, int oldy, int x, int y)
                 /* move cursor left/right */
 		if (x == oldx-1 && term->TI_cub1) {
 			tput(tparm(term->TI_cub1, 0, 0, 0, 0, 0, 0, 0, 0, 0));
-                        return;
+			return;
 		}
 		if (x == oldx+1 && y == oldy && term->TI_cuf1) {
 			tput(tparm(term->TI_cuf1, 0, 0, 0, 0, 0, 0, 0, 0, 0));
-                        return;
+			return;
 		}
 	}
 
         /* fallback to absolute positioning */
 	if (term->TI_cup) {
 		tput(tparm(term->TI_cup, y, x, 0, 0, 0, 0, 0, 0, 0));
-                return;
+		return;
 	}
 
 	if (oldy != y)
 		tput(tparm(term->TI_vpa, y, 0, 0, 0, 0, 0, 0, 0, 0));
-        if (oldx != x)
+	if (oldx != x)
 		tput(tparm(term->TI_hpa, x, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
@@ -160,11 +160,11 @@ static void _set_cursor_visible(TERM_REC *term, int set)
 	tput(tparm(set ? term->TI_cnorm : term->TI_civis, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
-#define scroll_region_setup(term, y1, y2) \
-	if ((term)->TI_csr != NULL) \
-		tput(tparm((term)->TI_csr, y1, y2, 0, 0, 0, 0, 0, 0, 0)); \
-	else if ((term)->TI_wind != NULL) \
-		tput(tparm((term)->TI_wind, y1, y2, 0, (term)->width-1, 0, 0, 0, 0, 0));
+#define scroll_region_setup(term, y1, y2)                                                          \
+	if ((term)->TI_csr != NULL)                                                                \
+		tput(tparm((term)->TI_csr, y1, y2, 0, 0, 0, 0, 0, 0, 0));                          \
+	else if ((term)->TI_wind != NULL)                                                          \
+		tput(tparm((term)->TI_wind, y1, y2, 0, (term)->width - 1, 0, 0, 0, 0, 0));
 
 /* Scroll (change_scroll_region+parm_rindex+parm_index / csr+rin+indn) */
 static void _scroll_region(TERM_REC *term, int y1, int y2, int count)
@@ -478,11 +478,12 @@ void terminfo_setup_colors(TERM_REC *term, int force)
 	if (term->TI_setaf) {
 		for (i = 0; i < term->TI_colors; i++) {
 			color = i < 16 ? ansitab[i] : i;
-			term->TI_fg[i] = g_strdup(tparm(term->TI_setaf, color, 0, 0, 0, 0, 0, 0, 0, 0));
+			term->TI_fg[i] =
+			    g_strdup(tparm(term->TI_setaf, color, 0, 0, 0, 0, 0, 0, 0, 0));
 		}
 	} else if (term->TI_setf) {
 		for (i = 0; i < term->TI_colors; i++)
-                        term->TI_fg[i] = g_strdup(tparm(term->TI_setf, i, 0, 0, 0, 0, 0, 0, 0, 0));
+			term->TI_fg[i] = g_strdup(tparm(term->TI_setf, i, 0, 0, 0, 0, 0, 0, 0, 0));
 	} else if (force) {
 		for (i = 0; i < 8; i++)
                         term->TI_fg[i] = g_strdup_printf("\033[%dm", 30+ansitab[i]);
@@ -491,11 +492,12 @@ void terminfo_setup_colors(TERM_REC *term, int force)
 	if (term->TI_setab) {
 		for (i = 0; i < term->TI_colors; i++) {
 			color = i < 16 ? ansitab[i] : i;
-			term->TI_bg[i] = g_strdup(tparm(term->TI_setab, color, 0, 0, 0, 0, 0, 0, 0, 0));
+			term->TI_bg[i] =
+			    g_strdup(tparm(term->TI_setab, color, 0, 0, 0, 0, 0, 0, 0, 0));
 		}
 	} else if (term->TI_setb) {
 		for (i = 0; i < term->TI_colors; i++)
-                        term->TI_bg[i] = g_strdup(tparm(term->TI_setb, i, 0, 0, 0, 0, 0, 0, 0, 0));
+			term->TI_bg[i] = g_strdup(tparm(term->TI_setb, i, 0, 0, 0, 0, 0, 0, 0, 0));
 	} else if (force) {
 		for (i = 0; i < 8; i++)
                         term->TI_bg[i] = g_strdup_printf("\033[%dm", 40+ansitab[i]);

--- a/src/fe-text/terminfo-core.c
+++ b/src/fe-text/terminfo-core.c
@@ -110,14 +110,14 @@ static TERMINFO_REC tcaps[] = {
 /* Move cursor (cursor_address / cup) */
 static void _move_cup(TERM_REC *term, int x, int y)
 {
-	tput(tparm(term->TI_cup, y, x));
+	tput(tparm(term->TI_cup, y, x, 0, 0, 0, 0, 0, 0, 0));
 }
 
 /* Move cursor (column_address+row_address / hpa+vpa) */
 static void _move_pa(TERM_REC *term, int x, int y)
 {
-	tput(tparm(term->TI_hpa, x));
-	tput(tparm(term->TI_vpa, y));
+	tput(tparm(term->TI_hpa, x, 0, 0, 0, 0, 0, 0, 0, 0));
+	tput(tparm(term->TI_vpa, y, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 /* Move cursor from a known position */
@@ -133,38 +133,38 @@ static void _move_relative(TERM_REC *term, int oldx, int oldy, int x, int y)
 	if (oldx > 0 && y == oldy) {
                 /* move cursor left/right */
 		if (x == oldx-1 && term->TI_cub1) {
-			tput(tparm(term->TI_cub1));
+			tput(tparm(term->TI_cub1, 0, 0, 0, 0, 0, 0, 0, 0, 0));
                         return;
 		}
 		if (x == oldx+1 && y == oldy && term->TI_cuf1) {
-			tput(tparm(term->TI_cuf1));
+			tput(tparm(term->TI_cuf1, 0, 0, 0, 0, 0, 0, 0, 0, 0));
                         return;
 		}
 	}
 
         /* fallback to absolute positioning */
 	if (term->TI_cup) {
-		tput(tparm(term->TI_cup, y, x));
+		tput(tparm(term->TI_cup, y, x, 0, 0, 0, 0, 0, 0, 0));
                 return;
 	}
 
 	if (oldy != y)
-		tput(tparm(term->TI_vpa, y));
+		tput(tparm(term->TI_vpa, y, 0, 0, 0, 0, 0, 0, 0, 0));
         if (oldx != x)
-		tput(tparm(term->TI_hpa, x));
+		tput(tparm(term->TI_hpa, x, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 /* Set cursor visible/invisible */
 static void _set_cursor_visible(TERM_REC *term, int set)
 {
-	tput(tparm(set ? term->TI_cnorm : term->TI_civis));
+	tput(tparm(set ? term->TI_cnorm : term->TI_civis, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 #define scroll_region_setup(term, y1, y2) \
 	if ((term)->TI_csr != NULL) \
-		tput(tparm((term)->TI_csr, y1, y2)); \
+		tput(tparm((term)->TI_csr, y1, y2, 0, 0, 0, 0, 0, 0, 0)); \
 	else if ((term)->TI_wind != NULL) \
-		tput(tparm((term)->TI_wind, y1, y2, 0, (term)->width-1));
+		tput(tparm((term)->TI_wind, y1, y2, 0, (term)->width-1, 0, 0, 0, 0, 0));
 
 /* Scroll (change_scroll_region+parm_rindex+parm_index / csr+rin+indn) */
 static void _scroll_region(TERM_REC *term, int y1, int y2, int count)
@@ -175,10 +175,10 @@ static void _scroll_region(TERM_REC *term, int y1, int y2, int count)
 	term->move(term, 0, y1);
 	if (count > 0) {
 		term->move(term, 0, y2);
-		tput(tparm(term->TI_indn, count, count));
+		tput(tparm(term->TI_indn, count, count, 0, 0, 0, 0, 0, 0, 0));
 	} else if (count < 0) {
 		term->move(term, 0, y1);
-		tput(tparm(term->TI_rin, -count, -count));
+		tput(tparm(term->TI_rin, -count, -count, 0, 0, 0, 0, 0, 0, 0));
 	}
 
         /* reset the scrolling region to full screen */
@@ -196,11 +196,11 @@ static void _scroll_region_1(TERM_REC *term, int y1, int y2, int count)
 	if (count > 0) {
 		term->move(term, 0, y2);
 		for (i = 0; i < count; i++)
-			tput(tparm(term->TI_ind));
+			tput(tparm(term->TI_ind, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 	} else if (count < 0) {
 		term->move(term, 0, y1);
 		for (i = count; i < 0; i++)
-			tput(tparm(term->TI_ri));
+			tput(tparm(term->TI_ri, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 	}
 
         /* reset the scrolling region to full screen */
@@ -217,14 +217,14 @@ static void _scroll_line(TERM_REC *term, int y1, int y2, int count)
 
 	if (count > 0) {
 		term->move(term, 0, y1);
-		tput(tparm(term->TI_dl, count, count));
+		tput(tparm(term->TI_dl, count, count, 0, 0, 0, 0, 0, 0, 0));
 		term->move(term, 0, y2-count+1);
-		tput(tparm(term->TI_il, count, count));
+		tput(tparm(term->TI_il, count, count, 0, 0, 0, 0, 0, 0, 0));
 	} else if (count < 0) {
 		term->move(term, 0, y2+count+1);
-		tput(tparm(term->TI_dl, -count, -count));
+		tput(tparm(term->TI_dl, -count, -count, 0, 0, 0, 0, 0, 0, 0));
 		term->move(term, 0, y1);
-		tput(tparm(term->TI_il, -count, -count));
+		tput(tparm(term->TI_il, -count, -count, 0, 0, 0, 0, 0, 0, 0));
 	}
 
         /* reset the scrolling region to full screen */
@@ -239,38 +239,38 @@ static void _scroll_line_1(TERM_REC *term, int y1, int y2, int count)
 	if (count > 0) {
 		term->move(term, 0, y1);
                 for (i = 0; i < count; i++)
-			tput(tparm(term->TI_dl1));
+			tput(tparm(term->TI_dl1, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 		term->move(term, 0, y2-count+1);
                 for (i = 0; i < count; i++)
-			tput(tparm(term->TI_il1));
+			tput(tparm(term->TI_il1, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 	} else if (count < 0) {
 		term->move(term, 0, y2+count+1);
 		for (i = count; i < 0; i++)
-			tput(tparm(term->TI_dl1));
+			tput(tparm(term->TI_dl1, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 		term->move(term, 0, y1);
 		for (i = count; i < 0; i++)
-			tput(tparm(term->TI_il1));
+			tput(tparm(term->TI_il1, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 	}
 }
 
 /* Clear screen (clear_screen / clear) */
 static void _clear_screen(TERM_REC *term)
 {
-	tput(tparm(term->TI_clear));
+	tput(tparm(term->TI_clear, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 /* Clear screen (clr_eos / ed) */
 static void _clear_eos(TERM_REC *term)
 {
         term->move(term, 0, 0);
-	tput(tparm(term->TI_ed));
+	tput(tparm(term->TI_ed, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 /* Clear screen (parm_delete_line / dl) */
 static void _clear_del(TERM_REC *term)
 {
         term->move(term, 0, 0);
-	tput(tparm(term->TI_dl, term->height, term->height));
+	tput(tparm(term->TI_dl, term->height, term->height, 0, 0, 0, 0, 0, 0, 0));
 }
 
 /* Clear screen (delete_line / dl1) */
@@ -280,19 +280,19 @@ static void _clear_del_1(TERM_REC *term)
 
 	term->move(term, 0, 0);
         for (i = 0; i < term->height; i++)
-		tput(tparm(term->TI_dl1));
+		tput(tparm(term->TI_dl1, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 /* Clear to end of line (clr_eol / el) */
 static void _clrtoeol(TERM_REC *term)
 {
-	tput(tparm(term->TI_el));
+	tput(tparm(term->TI_el, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 /* Repeat character (rep / rp) */
 static void _repeat(TERM_REC *term, char chr, int count)
 {
-	tput(tparm(term->TI_rep, chr, count));
+	tput(tparm(term->TI_rep, chr, count, 0, 0, 0, 0, 0, 0, 0));
 }
 
 /* Repeat character (manual) */
@@ -307,42 +307,42 @@ static void _repeat_manual(TERM_REC *term, char chr, int count)
 /* Reset all terminal attributes */
 static void _set_normal(TERM_REC *term)
 {
-	tput(tparm(term->TI_normal));
+	tput(tparm(term->TI_normal, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 static void _set_blink(TERM_REC *term)
 {
-	tput(tparm(term->TI_blink));
+	tput(tparm(term->TI_blink, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 /* Reverse on */
 static void _set_reverse(TERM_REC *term)
 {
-	tput(tparm(term->TI_rev));
+	tput(tparm(term->TI_rev, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 /* Bold on */
 static void _set_bold(TERM_REC *term)
 {
-	tput(tparm(term->TI_bold));
+	tput(tparm(term->TI_bold, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 /* Underline on/off */
 static void _set_uline(TERM_REC *term, int set)
 {
-	tput(tparm(set ? term->TI_smul : term->TI_rmul));
+	tput(tparm(set ? term->TI_smul : term->TI_rmul, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 /* Standout on/off */
 static void _set_standout(TERM_REC *term, int set)
 {
-	tput(tparm(set ? term->TI_smso : term->TI_rmso));
+	tput(tparm(set ? term->TI_smso : term->TI_rmso, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 /* Italic on/off */
 static void _set_italic(TERM_REC *term, int set)
 {
-	tput(tparm(set ? term->TI_sitm : term->TI_ritm));
+	tput(tparm(set ? term->TI_sitm : term->TI_ritm, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 /* Standout on (fallback for reverse) */
@@ -367,19 +367,19 @@ inline static int color256(const TERM_REC *term, const int color) {
 /* Change foreground color */
 static void _set_fg(TERM_REC *term, int color)
 {
-	tput(tparm(term->TI_fg[color256(term, color)]));
+	tput(tparm(term->TI_fg[color256(term, color)], 0, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 /* Change background color */
 static void _set_bg(TERM_REC *term, int color)
 {
-	tput(tparm(term->TI_bg[color256(term, color)]));
+	tput(tparm(term->TI_bg[color256(term, color)], 0, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 /* Beep */
 static void _beep(TERM_REC *term)
 {
-	tput(tparm(term->TI_bel));
+	tput(tparm(term->TI_bel, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 static void _ignore(TERM_REC *term)
@@ -393,7 +393,7 @@ static void _ignore_parm(TERM_REC *term, int param)
 static void terminfo_set_appkey_mode(TERM_REC *term, int set)
 {
 	if (term->TI_smkx && term->TI_rmkx)
-		tput(tparm(set ? term->TI_smkx : term->TI_rmkx));
+		tput(tparm(set ? term->TI_smkx : term->TI_rmkx, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 static void term_dec_set_bracketed_paste_mode(int enable)
@@ -478,11 +478,11 @@ void terminfo_setup_colors(TERM_REC *term, int force)
 	if (term->TI_setaf) {
 		for (i = 0; i < term->TI_colors; i++) {
 			color = i < 16 ? ansitab[i] : i;
-			term->TI_fg[i] = g_strdup(tparm(term->TI_setaf, color, 0));
+			term->TI_fg[i] = g_strdup(tparm(term->TI_setaf, color, 0, 0, 0, 0, 0, 0, 0, 0));
 		}
 	} else if (term->TI_setf) {
 		for (i = 0; i < term->TI_colors; i++)
-                        term->TI_fg[i] = g_strdup(tparm(term->TI_setf, i, 0));
+                        term->TI_fg[i] = g_strdup(tparm(term->TI_setf, i, 0, 0, 0, 0, 0, 0, 0, 0));
 	} else if (force) {
 		for (i = 0; i < 8; i++)
                         term->TI_fg[i] = g_strdup_printf("\033[%dm", 30+ansitab[i]);
@@ -491,11 +491,11 @@ void terminfo_setup_colors(TERM_REC *term, int force)
 	if (term->TI_setab) {
 		for (i = 0; i < term->TI_colors; i++) {
 			color = i < 16 ? ansitab[i] : i;
-			term->TI_bg[i] = g_strdup(tparm(term->TI_setab, color, 0));
+			term->TI_bg[i] = g_strdup(tparm(term->TI_setab, color, 0, 0, 0, 0, 0, 0, 0, 0));
 		}
 	} else if (term->TI_setb) {
 		for (i = 0; i < term->TI_colors; i++)
-                        term->TI_bg[i] = g_strdup(tparm(term->TI_setb, i, 0));
+                        term->TI_bg[i] = g_strdup(tparm(term->TI_setb, i, 0, 0, 0, 0, 0, 0, 0, 0));
 	} else if (force) {
 		for (i = 0; i < 8; i++)
                         term->TI_bg[i] = g_strdup_printf("\033[%dm", 40+ansitab[i]);
@@ -539,7 +539,7 @@ static void terminfo_input_deinit(TERM_REC *term)
 void terminfo_cont(TERM_REC *term)
 {
 	if (term->TI_smcup)
-		tput(tparm(term->TI_smcup));
+		tput(tparm(term->TI_smcup, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 
 	if (term->appkey_enabled)
 		terminfo_set_appkey_mode(term, TRUE);
@@ -562,7 +562,7 @@ void terminfo_stop(TERM_REC *term)
 
 	/* stop cup-mode */
 	if (term->TI_rmcup)
-		tput(tparm(term->TI_rmcup));
+		tput(tparm(term->TI_rmcup, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 
 	if (term->appkey_enabled)
 		terminfo_set_appkey_mode(term, FALSE);


### PR DESCRIPTION
Add the missing arguments to tparm. X/Open Curses specifies tparm takes a fixed number of 10 arguments, while ncurses has implemented it as a varargs function. tiparm is a standardized version of varargs tparm, support in both NetBSD libcurses and ncurses, but not by older versions of Solaris.

This is an alternate fix to the one proposed in #1305 that should keep compatibility with older versions of Solaris by avoiding tiparm.