### PR TITLE
Use g_strndup, strndup is not available on old platforms

### DIFF
--- a/src/otr/otr.c
+++ b/src/otr/otr.c
@@ -643,7 +643,7 @@ static enum otr_msg_status enqueue_otr_fragment(const char *msg, struct otr_peer
 		 * Dup the string with enough space for the NULL byte since we are
 		 * about to free it before passing it to the caller.
 		 */
-		*full_msg = strndup(opc->full_msg, opc->msg_len + 1);
+		*full_msg = g_strndup(opc->full_msg, opc->msg_len + 1);
 		/* Reset everything. */
 		free(opc->full_msg);
 		opc->full_msg = NULL;


### PR DESCRIPTION
strndup is not available on Solaris 10, to ensure building is ok use
glib function.