### PR TITLE
Fix cursor getting stuck for auto completions that changes case

### DIFF
--- a/src/fe-common/core/completion.c
+++ b/src/fe-common/core/completion.c
@@ -104,7 +104,7 @@ char *auto_word_complete(const char *line, int *pos)
 
 	/* check for words in autocompletion list */
 	replace = completion_find(word, TRUE);
-	if (replace == NULL) {
+	if (replace == NULL || (!g_strcmp0(replace, word))) {
 		ret = NULL;
 		g_string_free(result, TRUE);
 	} else {


### PR DESCRIPTION
Fixes #1176

So I realized autocomplete code is case insensitive - I did not change that behavior. For example if you only define the following autocomplete: ` abccd -> ABCCD`. `abccd`, `aBccD`, `ABcCD` all will convert to `ABCCD`. This also means `ABCCD` would convert to the identical string `ABCCD`. This is the source of the bug

This bug was reproducible for any complete that exclusively changes the case of letters and no other character changes; `:d` -> `:D`, `Ffrogman` -> `ffrogman`, `FfroGmAn` -> `ffrogman`.. 

The autocomplete would return a match for these and the replacement would happen every time space was pressed - even after the completion was already made. After an auto completion the cursor jumps to one character after the completion. So every space would trigger another completion and reset the cursor even though there would be no change.

Fix is to stop trying to replace these identical strings if they are already. There's no reason to do the work of swapping out identical strings.
