### PR TITLE
rephrase documentation to be abstract to any given network

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,4 @@ an issue on GitHub or send a mail to [staff@irssi.org](mailto:staff@irssi.org).
 Irssi is always looking for developers. Feel free to submit patches through
 GitHub pull requests.
 
-You can also contact the Irssi developers in
-[#irssi](https://irssi.org/support/irc/) on freenode.
+You can also contact the Irssi developers on [one of our official channels](https://irssi.org/support/irc/).

--- a/docs/help/in/admin.in
+++ b/docs/help/in/admin.in
@@ -15,7 +15,7 @@
 %9Examples:%9
 
     /ADMIN
-    /ADMIN orwell.freenode.net
+    /ADMIN foo.bar.net
     /ADMIN mike
 
 %9See also:%9 INFO

--- a/docs/help/in/channel.in
+++ b/docs/help/in/channel.in
@@ -33,12 +33,12 @@
 
     /CHANNEL
     /CHANNEL LIST
-    /CHANNEL ADD -auto #irssi Freenode
+    /CHANNEL ADD -auto #irssi <network>
     /CHANNEL ADD -auto #basementcat Quakenet secret_lair
-    /CHANNEL ADD -auto -bots '*!@*.irssi.org *!bot@irssi.org' -botcmd 'msg $0 op WzerTrzq' #hideout Freenode
+    /CHANNEL ADD -auto -bots '*!@*.irssi.org *!bot@irssi.org' -botcmd 'msg $0 op WzerTrzq' #hideout <network>
     /CHANNEL ADD -auto -bots 'Q!TheQBot@CServe.quakenet.org' -botcmd '^MSG Q op #irssi' #irssi Quakenet
-    /CHANNEL MODIFY -noauto #irssi Freenode
-    /CHANNEL REMOVE #hideout Freenode
+    /CHANNEL MODIFY -noauto #irssi <network>
+    /CHANNEL REMOVE #hideout <network>
 
 %9Special Example:%9
 

--- a/docs/help/in/connect.in
+++ b/docs/help/in/connect.in
@@ -34,9 +34,9 @@
 
 %9Examples:%9
 
-    /CONNECT Freenode
-    /CONNECT -6 Freenode
-    /CONNECT -4 -! -host staff.irssi.org -network Freenode orwell.freenode.net
+    /CONNECT <network>
+    /CONNECT -6 <network>
+    /CONNECT -4 -! -host staff.irssi.org -network <network> <url>
     /CONNECT irc.irssi.org 6667 WzerT8zq mike
 
 %9See also:%9 DISCONNECT, RMRECONNS, SERVER

--- a/docs/help/in/disconnect.in
+++ b/docs/help/in/disconnect.in
@@ -18,7 +18,7 @@
 
 %9Examples:%9
 
-    /DISCONNECT Freenode I'm off for today, take care!
+    /DISCONNECT <network> I'm off for today, take care!
     /DISCONNECT * Vacation time :D
     /DISCONNECT
 

--- a/docs/help/in/info.in
+++ b/docs/help/in/info.in
@@ -15,7 +15,7 @@
 %9Examples:%9
 
     /INFO
-    /INFO orwell.freenode.net
+    /INFO <url>
 
 %9See also:%9 ADMIN
 

--- a/docs/help/in/join.in
+++ b/docs/help/in/join.in
@@ -20,7 +20,7 @@
     /JOIN #irssi
     /JOIN #basementcat secret_lair
     /JOIN -invite
-    /JOIN -freenode #github,#freenode,#irssi
+    /JOIN -<network> #github,#freenode,#irssi
 
 %9See also:%9 KICK, PART
 

--- a/docs/help/in/log.in
+++ b/docs/help/in/log.in
@@ -33,10 +33,10 @@
 %9Examples:%9
 
     /LOG OPEN -targets mike ~/irclogs/mike.log MSGS
-    /LOG OPEN -targets #irssi-freenode ~/irclogs/freenode/irssi-%%Y-%%m-%%d
-    /LOG CLOSE ~/irclogs/freenode/irssi-%%Y-%%m-%%d
-    /LOG STOP ~/irclogs/freenode/irssi-%%Y-%%m-%%d
-    /LOG START ~/irclogs/freenode/irssi-%%Y-%%m-%%d
+    /LOG OPEN -targets #irssi ~/irclogs/irssi-%%Y-%%m-%%d
+    /LOG CLOSE ~/irclogs/irssi-%%Y-%%m-%%d
+    /LOG STOP ~/irclogs/irssi-%%Y-%%m-%%d
+    /LOG START ~/irclogs/irssi-%%Y-%%m-%%d
 
     /SET autolog ON
 

--- a/docs/help/in/motd.in
+++ b/docs/help/in/motd.in
@@ -15,7 +15,7 @@
 %9Examples:%9
 
     /MOTD
-    /MOTD orwel.freenode.org
+    /MOTD <url>
     /MOTD bob
 
 %9See also:%9 ADMIN, INFO, LINKS, MAP

--- a/docs/help/in/names.in
+++ b/docs/help/in/names.in
@@ -21,7 +21,7 @@
 %9Examples:%9
 
     /NAMES -ops
-    /NAMES -voices #irssi,#freenode
+    /NAMES -voices #irssi,#foobar
 
 %9See also:%9 JOIN, PART, WHO, WHOIS
 

--- a/docs/help/in/nctcp.in
+++ b/docs/help/in/nctcp.in
@@ -15,7 +15,7 @@
 %9Examples:%9
 
     /NCTCP #irssi VERSION King of the Jungle v1.0
-    /NCTCP bob,#freenode USERINFO I am bob :p
+    /NCTCP bob,#foobar USERINFO I am bob :p
 
 %9See also:%9 CTCP
 

--- a/docs/help/in/network.in
+++ b/docs/help/in/network.in
@@ -59,11 +59,11 @@
 %9Examples:%9
 
     /NETWORK ADD -usermode +giw EFnet
-    /NETWORK ADD -usermode +iw -nick mike -realname 'The one and only mike!' -host staff.irssi.org Freenode
-    /NETWORK ADD -autosendcmd '^MSG NickServ identify WzerT8zq' Freenode
+    /NETWORK ADD -usermode +iw -nick mike -realname 'The one and only mike!' -host <url> <network>
+    /NETWORK ADD -autosendcmd '^MSG NickServ identify WzerT8zq' <network>
     /NETWORK ADD -autosendcmd '^MSG Q@CServe.quakenet.org AUTH mike WzerT8zq; WAIT 2000; OPER mike WzerT8zq; WAIT 2000; MODE mike +kXP' Quakenet
     /NETWORK MODIFY -usermode +gi EFnet
-    /NETWORK REMOVE Freenode
+    /NETWORK REMOVE <network>
 
 %9See also:%9 CHANNEL, CONNECT, SERVER
 

--- a/docs/help/in/part.in
+++ b/docs/help/in/part.in
@@ -14,7 +14,7 @@
 %9Examples:%9
 
     /PART #irssi
-    /PART #freenode,#irssi
+    /PART #irssi,#foobar
 
 %9See also:%9 JOIN, KICK
 

--- a/docs/help/in/query.in
+++ b/docs/help/in/query.in
@@ -17,8 +17,8 @@
 %9Examples:%9
 
     /QUERY mike
-    /QUERY -freenode bob
-    /QUERY -freenode -window sarah
+    /QUERY -<network> bob
+    /QUERY -<network> -window sarah
 
 %9See also:%9 MSG, UNQUERY, WINDOW
 

--- a/docs/help/in/recode.in
+++ b/docs/help/in/recode.in
@@ -22,7 +22,7 @@
 %9Examples:%9
 
     /RECODE
-    /RECODE ADD Freenode/mike utf-8
+    /RECODE ADD <network>/mike utf-8
     /RECODE ADD #korea euc-kr
     /RECODE REMOVE #korea
 

--- a/docs/help/in/reconnect.in
+++ b/docs/help/in/reconnect.in
@@ -15,8 +15,8 @@
 %9Examples:%9
 
     /RECONNECT
-    /RECONNECT Freenode
-    /RECONNECT EFnet BRB :)
+    /RECONNECT <network>
+    /RECONNECT <network> BRB :)
 
 %9See also:%9 CONNECT, DISCONNECT, NETWORK, RMRECONNS, SERVER
 

--- a/docs/help/in/server.in
+++ b/docs/help/in/server.in
@@ -61,15 +61,15 @@
 %9Examples:%9
 
     /SERVER
-    /SERVER CONNECT chat.freenode.net
-    /SERVER CONNECT +chat.freenode.net
-    /SERVER ADD -network Freenode -noautosendcmd orwell.freenode.net
-    /SERVER ADD -! -auto -host staff.irssi.org -4 -network Freenode -noproxy orwell.freenode.net 6667
-    /SERVER MODIFY -network Freenode -noauto orwell.freenode.net
-    /SERVER MODIFY -network Freenode orwell.freenode.net 6697 -
-    /SERVER REMOVE orwell.freenode.net 6667 Freenode
+    /SERVER CONNECT <url>
+    /SERVER CONNECT +<url>
+    /SERVER ADD -network <name> -noautosendcmd <url>
+    /SERVER ADD -! -auto -host staff.irssi.org -4 -network <name> -noproxy <url> 6667
+    /SERVER MODIFY -network <name> -noauto <url>
+    /SERVER MODIFY -network <name> <url> 6697 -
+    /SERVER REMOVE <url> 6667 <name>
     /SERVER PURGE
-    /SERVER PURGE orwell.freenode.net
+    /SERVER PURGE <url>
 
 %9See also:%9 CHANNEL, CONNECT, DISCONNECT, NETWORK, RECONNECT, RMRECONNS
 

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -349,7 +349,7 @@
 	after connecting to the network. This is useful for automatically 
 	identifying yourself to NickServ, for example
 
-	/NETWORK ADD -autosendcmd "/^msg NickServ identify secret" freenode
+	/NETWORK ADD -autosendcmd "/^msg NickServ identify secret" <network>
 
 	/NETWORK REMOVE <name>
 

--- a/docs/proxy.txt
+++ b/docs/proxy.txt
@@ -24,7 +24,7 @@ You really should set some password for the proxy with:
 Then you'll need to configure the ports/ircnets the proxy listens in,
 something like:
 
-  /SET irssiproxy_ports ircnet=2777 efnet=2778 freenode=2779
+  /SET irssiproxy_ports <networkA>=2777 <networkB>=2778 <networkC>=2779
 
 There we have 3 different irc networks answering in 3 ports. Note that
 you'll have to make the correct /IRCNET ADD and /SERVER ADD commands to

--- a/docs/startup-HOWTO.html
+++ b/docs/startup-HOWTO.html
@@ -68,7 +68,7 @@
 
 <p>And to connect to one of those networks and join a channel:</p>
 
-<div><div><pre><code>/CONNECT Freenode
+<div><div><pre><code>/CONNECT <network>
 /JOIN #irssi
 </code></pre></div></div>
 
@@ -94,7 +94,7 @@
 
 <p>If you have irssi 0.8.18 or higher and the irc network supports it, you can use SASL instead of nickserv, which is more reliable:</p>
 
-<div><div><pre><code>/NETWORK ADD -sasl_username yourname -sasl_password yourpassword -sasl_mechanism PLAIN Freenode
+<div><div><pre><code>/NETWORK ADD -sasl_username yourname -sasl_password yourpassword -sasl_mechanism PLAIN <network>
 </code></pre></div></div>
 
 <p>These commands have many more options, see their help for details:</p>

--- a/docs/startup-HOWTO.txt
+++ b/docs/startup-HOWTO.txt
@@ -43,7 +43,7 @@ has a few predefined networks, to list them:
 
 And to connect to one of those networks and join a channel:
 
-/CONNECT Freenode
+/CONNECT <network>
 /JOIN #irssi
 
 To add more networks:
@@ -67,7 +67,7 @@ wait for 2 seconds before joining channels:
 If you have irssi 0.8.18 or higher and the irc network supports it, you can use
 SASL instead of nickserv, which is more reliable:
 
-/NETWORK ADD -sasl_username yourname -sasl_password yourpassword -sasl_mechanism PLAIN Freenode
+/NETWORK ADD -sasl_username yourname -sasl_password yourpassword -sasl_mechanism PLAIN <network>
 
 These commands have many more options, see their help for details:
 

--- a/irssi.conf
+++ b/irssi.conf
@@ -1,18 +1,19 @@
 servers = (
-  { address = "irc.dal.net";       chatnet = "DALnet";    port = "6667"; },
-  { address = "ssl.efnet.org";     chatnet = "EFNet";     port = "9999"; use_tls = "yes"; tls_verify = "no"; },
-  { address = "irc.esper.net";     chatnet = "EsperNet";  port = "6697"; use_tls = "yes"; tls_verify = "yes"; },
-  { address = "chat.freenode.net"; chatnet = "Freenode";  port = "6697"; use_tls = "yes"; tls_verify = "yes"; },
-  { address = "irc.gamesurge.net"; chatnet = "GameSurge"; port = "6667"; },
-  { address = "ssl.ircnet.ovh";    chatnet = "IRCnet";    port = "6697"; use_tls = "yes"; tls_verify = "yes"; },
-  { address = "open.ircnet.net";   chatnet = "IRCnet";    port = "6667"; },
-  { address = "irc.ircsource.net"; chatnet = "IRCSource"; port = "6667"; },
-  { address = "irc.netfuze.net";   chatnet = "NetFuze";   port = "6667"; },
-  { address = "irc.oftc.net";      chatnet = "OFTC";      port = "6697"; use_tls = "yes"; tls_verify = "yes"; },
-  { address = "irc.quakenet.org";  chatnet = "QuakeNet";  port = "6667"; },
-  { address = "irc.rizon.net";     chatnet = "Rizon";     port = "6697"; use_tls = "yes"; tls_verify = "yes"; },
-  { address = "silc.silcnet.org";  chatnet = "SILC";      port = "706";  },
-  { address = "irc.undernet.org";  chatnet = "Undernet";  port = "6667"; }
+  { address = "irc.dal.net";       chatnet = "DALnet";     port = "6667"; },
+  { address = "ssl.efnet.org";     chatnet = "EFNet";      port = "9999"; use_tls = "yes"; tls_verify = "no"; },
+  { address = "irc.esper.net";     chatnet = "EsperNet";   port = "6697"; use_tls = "yes"; tls_verify = "yes"; },
+  { address = "chat.freenode.net"; chatnet = "Freenode";   port = "6697"; use_tls = "yes"; tls_verify = "yes"; },
+  { address = "irc.libera.chat";   chatnet = "liberachat"; port = "6697"; use_tls = "yes"; tls_verify = "yes" },
+  { address = "irc.gamesurge.net"; chatnet = "GameSurge";  port = "6667"; },
+  { address = "ssl.ircnet.ovh";    chatnet = "IRCnet";     port = "6697"; use_tls = "yes"; tls_verify = "yes"; },
+  { address = "open.ircnet.net";   chatnet = "IRCnet";     port = "6667"; },
+  { address = "irc.ircsource.net"; chatnet = "IRCSource";  port = "6667"; },
+  { address = "irc.netfuze.net";   chatnet = "NetFuze";    port = "6667"; },
+  { address = "irc.oftc.net";      chatnet = "OFTC";       port = "6697"; use_tls = "yes"; tls_verify = "yes"; },
+  { address = "irc.quakenet.org";  chatnet = "QuakeNet";   port = "6667"; },
+  { address = "irc.rizon.net";     chatnet = "Rizon";      port = "6697"; use_tls = "yes"; tls_verify = "yes"; },
+  { address = "silc.silcnet.org";  chatnet = "SILC";       port = "706";  },
+  { address = "irc.undernet.org";  chatnet = "Undernet";   port = "6667"; }
 );
 
 chatnets = {
@@ -29,6 +30,12 @@ chatnets = {
     max_whois = "1";
   };
   EsperNet = {
+    type      = "IRC";
+    max_kicks = "1";
+    max_msgs  = "4";
+    max_whois = "1";
+  };
+  liberachat = {
     type      = "IRC";
     max_kicks = "1";
     max_msgs  = "4";


### PR DESCRIPTION
```
IRSSI is an IRC client and should not advertise nor be beholden to any
particular IRC network. This patch is inspired by both of the following
commits, and aims to remove references to any particular network in the
documentation, in an effort to avoid potential conflict amongst team and
community members:

- a4486c236a3bf15192d0500b3a1892f7465826c7
- 1ba48840a112dfacf13cbbf6b77c1e3489fefcf8

Based on a (as of this writing) draft blog post [0], and the discussion
that has occurred regarding the blog post, it doesn't appear as if the
IRSSI development team is interested in being transparent about the
reasoning behind its aversion to removing the Freenode network,
specifically related to the comments about "potential legal
consequences". By removing references to any given network in the
documentation, this project moves forward without taking a political
stance, but in a way that avoids recommending any given network to
users.

[0]: https://github.com/irssi/irssi.github.io/pull/79
```