### PR TITLE
Fix libnv detection on recent FreeBSD

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -495,7 +495,7 @@ have_capsicum = false
 if want_capsicum
   if cc.has_function('cap_enter', dependencies : cc.find_library('c'))
     libnv = cc.find_library('nv', required : require_capsicum)
-    nvlist_create_found = libnv.found() and cc.has_function('nvlist_create', dependencies : libnv)
+    nvlist_create_found = libnv.found() and cc.has_function('nvlist_create', dependencies : libnv, prefix : '#include <sys/nv.h>')
     if nvlist_create_found
       dep += libnv
       have_capsicum = true


### PR DESCRIPTION
On recent FreeBSD systems it is required to include the sys/nv.h file, otherwise symbols are missing.

Reported here: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=265397

Patch suggested by: Kristof Provost <kp@freebsd.org>