### PR TITLE
Add -comment attribute to hilights & ignores

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3352,7 +3352,7 @@ v0.7.1 1999-03-08  Timo Sirainen <a@sicom.fi> [unstable]
 
           You can use these levels, ALL is set by default:
           ALL, CRAP, PUBLIC, MSGS, NOTICES, WALLOPS, SNOTES, ACTIONS, DCC,
-          CTCP, CLIENTNOTICES, CLIENTERRORS
+          CTCP, CLIENTNOTICE, CLIENTERROR
 	+ Automatically create query window when received msg (option)
 	+ No more "WHO: unknown commmand"s, all unknown commands are sent to
           server just like they were written
@@ -3613,7 +3613,7 @@ v0.3.0 1999-01-18  Timo Sirainen <a@sicom.fi>
            - /UNIGNORE <mask> <ignore level>
            - ignore page added to preferences
            - ignore levels: ALL, CRAP, CHAN, PUBLIC, MSGS, NOTICES, WALLOPS,
-             SNOTES, ACTIONS, DCC, CTCP, CLIENTNOTICES, CLIENTERRORS
+             SNOTES, ACTIONS, DCC, CTCP, CLIENTNOTICE, CLIENTERROR
         + autoignoring msg and ctcp flooders
         + options page added to preferences
         + invite lists (channel mode I)

--- a/docs/help/in/hilight.in
+++ b/docs/help/in/hilight.in
@@ -18,6 +18,7 @@
     -network:     Matches only on the given network.
     -channels:    Matches only on the given channels.
     -priority:    The priority to use when multiple highlights match.
+    -comment:     Comment for internal use.
 
     The text to highlight on; if no argument is given, the list of highlights
     will be displayed.

--- a/docs/help/in/ignore.in
+++ b/docs/help/in/ignore.in
@@ -7,6 +7,7 @@
 
     -regexp:      Indicates that the pattern is a regular expression.
     -full:        Indicates that the pattern must match a full word.
+    -oldpattern:  The text pattern to edit.
     -pattern:     The text pattern to ignore.
     -except:      Negates the ignore.
     -replies:     Also ignore nicknames who are talking to anyone who matches
@@ -16,6 +17,7 @@
     -time:        The timeout to automatically remove the ignore.
                   Accepts units specified in days, hours, minutes, seconds,
                   milliseconds, or no unit for seconds.
+    -comment:     Comment for internal use.
 
     The mask, channels and levels to ignore; if no argument is provided, the
     list of ignores will be displayed.
@@ -31,6 +33,7 @@
     later be revealed using /WINDOW HIDELEVEL -HIDDEN
     The special level 'NOHILIGHT' can be used to suppress hilights without actually
     ignoring the message.
+    The old pattern '*' can be used to edit the first ignore matching the mask.
 
 %9Examples:%9
 
@@ -48,8 +51,8 @@
     /IGNORE #irssi NO_ACT JOINS PARTS QUITS
     /IGNORE mike NO_ACT -MSGS
     /IGNORE mike HIDDEN PUBLIC JOINS PARTS QUITS
-    /IGNORE -time 5days christmas PUBLICS
-    /IGNORE -time 300 mike PUBLICS
+    /IGNORE -time 5days christmas PUBLIC
+    /IGNORE -time 300 mike PUBLIC
 
 %9See also:%9 ACCEPT, SILENCE, UNIGNORE
 

--- a/src/common.h
+++ b/src/common.h
@@ -6,7 +6,7 @@
 #define IRSSI_GLOBAL_CONFIG "irssi.conf" /* config file name in /etc/ */
 #define IRSSI_HOME_CONFIG "config" /* config file name in ~/.irssi/ */
 
-#define IRSSI_ABI_VERSION 58
+#define IRSSI_ABI_VERSION 59
 
 #define DEFAULT_SERVER_ADD_PORT 6667
 #define DEFAULT_SERVER_ADD_TLS_PORT 6697

--- a/src/core/ignore.h
+++ b/src/core/ignore.h
@@ -9,6 +9,7 @@ struct _IGNORE_REC {
 	int level; /* ignore these levels */
 	char *mask; /* nick mask */
 	char *servertag; /* this is for autoignoring */
+	char *comment;   /* comment, for internal use only */
 	char **channels; /* ignore only in these channels */
 	char *pattern; /* text body must match this pattern */
 
@@ -32,17 +33,15 @@ int ignore_check_plus(SERVER_REC *server, const char *nick, const char *host,
 
 enum {
 	IGNORE_FIND_PATTERN = 0x01,   /* Match the pattern */
-	IGNORE_FIND_NOACT = 0x02,     /* Exclude the targets with NOACT level */
-	IGNORE_FIND_HIDDEN = 0x04,    /* Exclude the targets with HIDDEN level */
-	IGNORE_FIND_NOHILIGHT = 0x08, /* Exclude the targets with NOHILIGHT level */
+	IGNORE_FIND_NO_ACT = 0x02,    /* Find the targets with NO_ACT level */
+	IGNORE_FIND_HIDDEN = 0x04,    /* Find the targets with HIDDEN level */
+	IGNORE_FIND_NOHILIGHT = 0x08, /* Find the targets with NOHILIGHT level */
+	IGNORE_FIND_EXCEPT = 0x10,    /* Find negated ignore */
+	IGNORE_FIND_ANY = 0x20,       /* Find ignore based on mask only */
 };
 
 IGNORE_REC *ignore_find_full (const char *servertag, const char *mask, const char *pattern,
                 char **channels, const int flags);
-
-/* Convenience wrappers around ignore_find_full, for compatibility purpose */
-
-IGNORE_REC *ignore_find(const char *servertag, const char *mask, char **channels);
 
 void ignore_add_rec(IGNORE_REC *rec);
 void ignore_update_rec(IGNORE_REC *rec);

--- a/src/core/nickmatch-cache.h
+++ b/src/core/nickmatch-cache.h
@@ -1,6 +1,8 @@
 #ifndef IRSSI_CORE_NICKMATCH_CACHE_H
 #define IRSSI_CORE_NICKMATCH_CACHE_H
 
+#include <irssi/src/common.h>
+
 typedef void (*NICKMATCH_REBUILD_FUNC) (GHashTable *list,
 					CHANNEL_REC *channel, NICK_REC *nick);
 

--- a/src/fe-common/core/chat-completion.c
+++ b/src/fe-common/core/chat-completion.c
@@ -1,21 +1,21 @@
 /*
- chat-completion.c : irssi
+chat-completion.c : irssi
 
-    Copyright (C) 1999-2000 Timo Sirainen
+   Copyright (C) 1999-2000 Timo Sirainen
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
-    (at your option) any later version.
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
 #include "module.h"
@@ -649,7 +649,7 @@ static int only_nicks(const char *linestart)
 	int i = 1;
 	char prev;
 
-	// at the beginning of the line
+	/* at the beginning of the line */
 	if (*linestart == '\0') {
 		return TRUE;
 	}

--- a/src/fe-common/core/hilight-text.c
+++ b/src/fe-common/core/hilight-text.c
@@ -81,6 +81,8 @@ static void hilight_add_config(HILIGHT_REC *rec)
 	if (rec->regexp) iconfig_node_set_bool(node, "regexp", TRUE);
 	if (rec->case_sensitive) iconfig_node_set_bool(node, "matchcase", TRUE);
 	if (rec->servertag) iconfig_node_set_str(node, "servertag", rec->servertag);
+	if (rec->comment)
+		iconfig_node_set_str(node, "comment", rec->comment);
 
 	if (rec->channels != NULL && *rec->channels != NULL) {
 		node = iconfig_node_section(node, "channels", NODE_TYPE_LIST);
@@ -107,6 +109,7 @@ static void hilight_destroy(HILIGHT_REC *rec)
 	g_free_not_null(rec->color);
 	g_free_not_null(rec->act_color);
 	g_free_not_null(rec->servertag);
+	g_free_not_null(rec->comment);
 	g_free(rec->text);
 	g_free(rec);
 }
@@ -505,7 +508,7 @@ static void read_hilight_config(void)
 	CONFIG_NODE *node;
 	HILIGHT_REC *rec;
 	GSList *tmp;
-	char *text, *color, *servertag;
+	char *text, *color, *servertag, *comment;
 
 	hilights_destroy_all();
 
@@ -551,6 +554,8 @@ static void read_hilight_config(void)
 		servertag = config_node_get_str(node, "servertag", NULL);
 		rec->servertag = servertag == NULL || *servertag == '\0' ? NULL :
 			g_strdup(servertag);
+		comment = config_node_get_str(node, "comment", NULL);
+		rec->comment = comment == NULL || *comment == '\0' ? NULL : g_strdup(comment);
 		hilight_init_rec(rec);
 
 		node = iconfig_node_section(node, "channels", -1);
@@ -588,6 +593,8 @@ static void hilight_print(int index, HILIGHT_REC *rec)
 		g_string_append_printf(options, "-priority %d ", rec->priority);
 	if (rec->servertag != NULL)
 		g_string_append_printf(options, "-network %s ", rec->servertag);
+	if (rec->comment != NULL)
+		g_string_append_printf(options, "-comment %s ", rec->comment);
 	if (rec->color != NULL)
 		g_string_append_printf(options, "-color %s ", rec->color);
 	if (rec->act_color != NULL)
@@ -626,12 +633,13 @@ static void cmd_hilight_show(void)
 
 /* SYNTAX: HILIGHT [-nick | -word | -line] [-mask | -full | -matchcase | -regexp]
    [-color <color>] [-actcolor <color>] [-level <level>] [-priority <number>]
-   [-network <network>] [-channels <channels>] <text> */
+   [-network <network>] [-channels <channels>] [-comment <comment>] <text> */
 static void cmd_hilight(const char *data)
 {
 	GHashTable *optlist;
 	HILIGHT_REC *rec;
-	char *colorarg, *actcolorarg, *levelarg, *priorityarg, *chanarg, *text, *servertag;
+	char *colorarg, *actcolorarg, *levelarg, *priorityarg, *chanarg, *text, *servertag,
+	    *comment;
 	char **channels;
 	void *free_arg;
 
@@ -652,6 +660,7 @@ static void cmd_hilight(const char *data)
 	colorarg = g_hash_table_lookup(optlist, "color");
 	actcolorarg = g_hash_table_lookup(optlist, "actcolor");
 	servertag = g_hash_table_lookup(optlist, "network");
+	comment = g_hash_table_lookup(optlist, "comment");
 
 	if (*text == '\0') cmd_param_error(CMDERR_NOT_ENOUGH_PARAMS);
 
@@ -708,6 +717,11 @@ static void cmd_hilight(const char *data)
 		g_free_and_null(rec->servertag);
 		if (*servertag != '\0')
 			rec->servertag = g_strdup(servertag);
+	}
+	if (comment != NULL) {
+		g_free_and_null(rec->comment);
+		if (*comment != '\0')
+			rec->comment = g_strdup(comment);
 	}
 
 	hilight_create(rec);
@@ -802,7 +816,8 @@ void hilight_text_init(void)
 
 	command_bind("hilight", NULL, (SIGNAL_FUNC) cmd_hilight);
 	command_bind("dehilight", NULL, (SIGNAL_FUNC) cmd_dehilight);
-	command_set_options("hilight", "-color -actcolor -level -priority -network -channels nick word line mask full regexp matchcase");
+	command_set_options("hilight", "-color -actcolor -level -priority -network -channels "
+	                               "-comment nick word line mask full regexp matchcase");
 }
 
 void hilight_text_deinit(void)

--- a/src/fe-common/core/hilight-text.h
+++ b/src/fe-common/core/hilight-text.h
@@ -23,6 +23,7 @@ struct _HILIGHT_REC {
 	unsigned int case_sensitive:1;/* `text' must match case */
 	Regex *preg;
 	char *servertag;
+	char *comment;
 };
 
 extern GSList *hilights;

--- a/src/fe-common/irc/fe-irc-server.c
+++ b/src/fe-common/irc/fe-irc-server.c
@@ -186,10 +186,10 @@ void fe_irc_server_init(void)
 	command_bind("server list", NULL, (SIGNAL_FUNC) cmd_server_list);
 
 	command_set_options("server add",
-	                    "-ircnet -network -cmdspeed -cmdmax -querychans starttls "
+	                    "~-ircnet -network -cmdspeed -cmdmax -querychans starttls "
 	                    "nostarttls disallow_starttls nodisallow_starttls cap nocap");
 	command_set_options("server modify",
-	                    "-ircnet -network -cmdspeed -cmdmax -querychans starttls nostarttls "
+	                    "~-ircnet -network -cmdspeed -cmdmax -querychans starttls nostarttls "
 	                    "disallow_starttls nodisallow_starttls cap nocap");
 }
 

--- a/src/irc/core/irc-commands.c
+++ b/src/irc/core/irc-commands.c
@@ -1056,7 +1056,7 @@ void irc_commands_init(void)
 	signal_add("whois end", (SIGNAL_FUNC) event_end_of_whois);
 	signal_add("whowas event", (SIGNAL_FUNC) event_whowas);
 
-	command_set_options("connect", "+ircnet starttls disallow_starttls nocap");
+	command_set_options("connect", "~+ircnet starttls disallow_starttls nocap");
 	command_set_options("topic", "delete");
 	command_set_options("list", "yes");
 	command_set_options("away", "one all");


### PR DESCRIPTION
Add -comment attribute to hilights to assist those with many hilights in tracking what they are used for.  Useful for channel ops or network staff that often have many hilights set.