### PR TITLE
Fix generate tag from address (servers.c)

### DIFF
--- a/src/core/servers.c
+++ b/src/core/servers.c
@@ -80,11 +80,10 @@ static char *server_create_address_tag(const char *address)
 		start = end = NULL;
 	} else if (g_ascii_strncasecmp(address, "irc", 3) == 0 ||
 	    g_ascii_strncasecmp(address, "chat", 4) == 0) {
-		/* irc.it-hobby.km.ua -> it-hobby, chat.bt.net -> bt */
-		int offset = 3;
-		if (g_ascii_strncasecmp(address, "chat", 4) == 0) offset++;
-		end = strchr(address + offset + 1, '.');
-		start = address + offset;
+		/* irc-2.cs.hut.fi -> hut, chat.bt.net -> bt */
+		end = strrchr(address, '.');
+		start = end-1;
+		while (start > address && *start != '.') start--;
 	} else {
 		/* efnet.cs.hut.fi -> efnet */
 		end = strchr(address, '.');

--- a/src/core/servers.c
+++ b/src/core/servers.c
@@ -78,6 +78,10 @@ static char *server_create_address_tag(const char *address)
 	/* try to generate a reasonable server tag */
 	if (strchr(address, '.') == NULL) {
 		start = end = NULL;
+	} else if (g_ascii_strncasecmp(address, "irc.", 4) == 0) {
+		/* irc.it-hobby.km.ua -> it-hobby, irc.karbo-labs.pp.ua -> karbo-labs */
+		end = strchr(address + 3 + 1, '.');
+		start = address + 3;
 	} else if (g_ascii_strncasecmp(address, "irc", 3) == 0 ||
 	    g_ascii_strncasecmp(address, "chat", 4) == 0) {
 		/* irc-2.cs.hut.fi -> hut, chat.bt.net -> bt */

--- a/src/core/servers.c
+++ b/src/core/servers.c
@@ -80,10 +80,11 @@ static char *server_create_address_tag(const char *address)
 		start = end = NULL;
 	} else if (g_ascii_strncasecmp(address, "irc", 3) == 0 ||
 	    g_ascii_strncasecmp(address, "chat", 4) == 0) {
-		/* irc-2.cs.hut.fi -> hut, chat.bt.net -> bt */
-		end = strrchr(address, '.');
-		start = end-1;
-		while (start > address && *start != '.') start--;
+		/* irc.it-hobby.km.ua -> it-hobby, chat.bt.net -> bt */
+		int offset = 3;
+		if (g_ascii_strncasecmp(address, "chat", 4) == 0) offset++;
+		end = strchr(address + offset + 1, '.');
+		start = address + offset;
 	} else {
 		/* efnet.cs.hut.fi -> efnet */
 		end = strchr(address, '.');


### PR DESCRIPTION
This commit fixed the generation of the tag from the address in such a way as to contain a name. For example: IRC.it-hobby.km.ua-> it-hobby.