### PR TITLE
Print perl import warning to STDERR

### DIFF
--- a/src/perl/common/Irssi.pm
+++ b/src/perl/common/Irssi.pm
@@ -153,7 +153,7 @@ eval {
 $in_irssi = $@ ? 0 : 1;
 
 if (!in_irssi()) {
-  print "Warning: This script should be run inside irssi\n";
+  print STDERR "Warning: This script should be run inside irssi\n";
 } else {
   bootstrap Irssi $VERSION if (!$static);
 


### PR DESCRIPTION
Printing to STDOUT can interfere with programs which intend to produce machine-readable output and yet for whatever reason import Irssi.pm from outside of irssi.

Closes https://github.com/irssi/irssi/issues/1465