### PR TITLE
fix usage of $type in ExtUtils::ParseXS 3.50

### DIFF
--- a/src/perl/common/typemap
+++ b/src/perl/common/typemap
@@ -28,5 +28,5 @@ T_IrssiObj
 	$arg = iobject_bless((SERVER_REC *)$var);
 
 T_PlainObj
-	$arg = plain_bless($var, \"$type\");
+	$arg = plain_bless($var, \"$ntype\");
 

--- a/src/perl/irc/typemap
+++ b/src/perl/irc/typemap
@@ -36,5 +36,5 @@ T_DccObj
 	$arg = simple_iobject_bless((DCC_REC *)$var);
 
 T_PlainObj
-	$arg = plain_bless($var, \"$type\");
+	$arg = plain_bless($var, \"$ntype\");
 

--- a/src/perl/textui/typemap
+++ b/src/perl/textui/typemap
@@ -18,7 +18,7 @@ T_BufferLineWrapper
 OUTPUT
 
 T_PlainObj
-	$arg = plain_bless($var, \"$type\");
+	$arg = plain_bless($var, \"$ntype\");
 
 T_BufferLineWrapper
 	$arg = perl_buffer_line_bless($var);

--- a/src/perl/ui/typemap
+++ b/src/perl/ui/typemap
@@ -13,5 +13,5 @@ T_PlainObj
 OUTPUT
 
 T_PlainObj
-	$arg = plain_bless($var, \"$type\");
+	$arg = plain_bless($var, \"$ntype\");
 


### PR DESCRIPTION
broken by https://github.com/Perl/perl5/pull/20985 (Perl ≥ 5.37) thanks @leont for the guidance

Errors such as

```
Can't locate object method "format_expand" via package "Irssi__UI__Theme"
```
or
```
Can't locate object method "get_bookmark" via package "Irssi__TextUI__TextBufferView"
```

Fix for 1.4.4: https://github.com/irssi/irssi/releases/download/1.4.4/perl-ntype.patch
