### PR TITLE
added links for the scripts section, added a docker section

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ ninja -C Build && sudo ninja -C Build install
 
 ## [Modules](https://irssi.org/modules/)
 
+## [Docker](https://hub.docker.com/_/irssi)
+
+Unofficial official images are available on dockerhub [here](https://hub.docker.com/_/irssi).
+
+You can run the lastest release without a hitch using [gvisor](https://gvisor.dev/) and `--cap-drop ALL`.
+
+
 ## [Security information](https://irssi.org/security/)
 
 Please report security issues to staff@irssi.org. Thanks!


### PR DESCRIPTION
added a section for docker.

for the second sentence regarding gvisor and `--cap-drop all` thats how i run my irssi instance so i can always verify whether that's true or not.

anyways, thought it is cool that you can run irssi with runsc and dropping all capabilities and everything still works.