### PR TITLE
build: fix linking error on arm64 Darwin

### DIFF
--- a/src/fe-common/core/themes.c
+++ b/src/fe-common/core/themes.c
@@ -34,8 +34,8 @@
 #include "default-theme.h"
 
 GSList *themes;
-THEME_REC *current_theme;
-GHashTable *default_formats;
+THEME_REC *current_theme = NULL;
+GHashTable *default_formats = NULL;
 
 static int init_finished;
 static char *init_errors;


### PR DESCRIPTION
Currently, it is not possible to build git master on Darwin, as seen in several issues reported previously.

This commit fixes that issues, by initializing two variables to NULL. I have no idea, why this solves the linking error, as to my knowledge, global variables do not need to be initialized.