### PR TITLE
explicitly list pkg-config as build dependency

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -5,6 +5,7 @@
 To compile Irssi you need:
 
 - meson-0.53 build system with ninja-1.8 or greater
+- pkg-config (or compatible)
 - glib-2.32 or greater
 - openssl (for ssl support)
 - perl-5.8 or greater (for building, and optionally Perl scripts)


### PR DESCRIPTION
meson needs it to find glib