### PR TITLE
Update server.c: Add missing include

### DIFF
--- a/src/fe-fuzz/server.c
+++ b/src/fe-fuzz/server.c
@@ -30,6 +30,7 @@
 #include <irssi/src/core/misc.h>
 #include <irssi/src/core/servers-setup.h>
 #include <irssi/src/core/rawlog.h>
+#include <irssi/src/core/network-openssl.h>
 #include <irssi/src/core/net-sendbuffer.h>
 
 #include <stddef.h>


### PR DESCRIPTION
To fix an issue with clang-18:

```
../../src/irssi/src/fe-fuzz/server.c:155:2: error: call to undeclared function 'irssi_ssl_init'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  155 |         irssi_ssl_init();
      |         ^
2 warnings and 1 error generated.
