### PR TITLE
core/chatnets : Make object local to the object file

### DIFF
--- a/src/core/chatnets.c
+++ b/src/core/chatnets.c
@@ -30,7 +30,9 @@
 #include <irssi/src/core/chatnets.h>
 #include <irssi/src/core/servers.h>
 
-GSList *chatnets, *chatnets_unavailable; /* list of available chat networks */
+/* list of available chat networks */
+GSList *chatnets;
+static GSList *chatnets_unavailable;
 
 static void chatnet_config_save(CHATNET_REC *chatnet)
 {


### PR DESCRIPTION
This object is not exposed via extern and therefore isn't accessible to other source files except through another extern which, even then conflict with the coding style in the rest of irssi.

 This makes it safe to assume that it should be local to this file.

There probably is an isolated occurrence and even if other such issues exist in the rest of the code, it would be great to get some comments on this one first.

