### PR TITLE
Include <sys/select.h> to get select(3).

### DIFF
--- a/src/core/net-disconnect.c
+++ b/src/core/net-disconnect.c
@@ -21,6 +21,8 @@
 #include "module.h"
 #include <irssi/src/core/network.h>
 
+#include <sys/select.h>
+
 /* when quitting, wait for max. 5 seconds before forcing to close the socket */
 #define MAX_QUIT_CLOSE_WAIT 5
 


### PR DESCRIPTION
This is the header required by POSIX-1.2024.

This change is needed to build irssi on operating systems such as Sortix that have a strict libc without obsolete behaviors.