### PR TITLE
Replace obsolescent inet_addr(3)/inet_aton(3) with inet_pton(3).

### DIFF
--- a/src/core/network.c
+++ b/src/core/network.c
@@ -491,8 +491,6 @@ int net_ip2host(IPADDR *ip, char *host)
 
 int net_host2ip(const char *host, IPADDR *ip)
 {
-	unsigned long addr;
-
 	if (strchr(host, ':') != NULL) {
 		/* IPv6 */
 		ip->family = AF_INET6;
@@ -501,16 +499,8 @@ int net_host2ip(const char *host, IPADDR *ip)
 	} else {
 		/* IPv4 */
 		ip->family = AF_INET;
-#ifdef HAVE_INET_ATON
-		if (inet_aton(host, &ip->ip.s_addr) == 0)
+		if (inet_pton(AF_INET, host, &ip->ip) == 0)
 			return -1;
-#else
-		addr = inet_addr(host);
-		if (addr == INADDR_NONE)
-			return -1;
-
-		memcpy(&ip->ip, &addr, 4);
-#endif
 	}
 
 	return 0;


### PR DESCRIPTION
inet_addr has become obsolescent as of POSIX-1.2024 and is not available on strict POSIX 2024 libc implementations.

inet_pton(3) is the standard and portable replacement available on all POSIX-1.2001 systems.

--

I'm unclear if you want to accept this change as-is depending on what platforms irssi supports. inet_pton should be on every relevant Unix today since it was added to POSIX 23 years ago. I need this little change or something like it to compile irssi with a strict modern libc. :)