### PR TITLE
Fix using HOST_NOT_FOUND instead of EAI_NONAME.

### DIFF
--- a/src/core/network.c
+++ b/src/core/network.c
@@ -430,7 +430,7 @@ int net_gethostbyname(const char *addr, IPADDR *ip4, IPADDR *ip6)
 	}
 
 	if (count_v4 == 0 && count_v6 == 0)
-		return HOST_NOT_FOUND; /* shouldn't happen? */
+		return EAI_NONAME; /* shouldn't happen? */
 
 	/* if there are multiple addresses, return random one */
 	use_v4 = count_v4 <= 1 ? 0 : rand() % count_v4;


### PR DESCRIPTION
HOST_NOT_FOUND is a gethostbyname(3) error condition rather than a getaddrinfo(3) error condition and cannot be passed to net_gethosterror as documented as it calls gai_strerror(3). EAI_NONAME is the appropriate similar error condition as standardized by POSIX for getaddrinfo(3).

--

I agree that this condition shouldn't happen, as per POSIX-1.2024:

> Upon successful return of getaddrinfo(), the location to which res points shall refer to a linked list of addrinfo structures, each of which shall specify a socket address and information for use in creating a socket with which to use that socket address. The list shall include at least one addrinfo structure.

https://pubs.opengroup.org/onlinepubs/9799919799/functions/freeaddrinfo.html

However, though, I can't rule out that this condition won't happen if any getaddrinfo(3) implementations are buggy on any of the operating systems supported by irssi.

If you prefer, I could simply remove the logic.

This change also happens to fix the build on modern POSIX systems as gethostbyname was marked obsolescent in POSIX-1.2001 and removed in POSIX-1.2008 and the `HOST_NOT_FOUND` constant happens be not exist anymore portably.