### PR TITLE
add ipaddr and family to perl SERVER_REC (and connrec)

### DIFF
--- a/docs/perl.txt
+++ b/docs/perl.txt
@@ -522,6 +522,8 @@ Connect->{}
   address - Address where we connected (irc.blah.org)
   port - Port where we connected
   chatnet - Chat network
+  chosen_family - IP family chosen to connect to
+  ipaddr - IP address connected to
 
   password - Password we used in connection.
   wanted_nick - Nick which we would prefer to use

--- a/src/core/server-connect-rec.h
+++ b/src/core/server-connect-rec.h
@@ -12,6 +12,7 @@ char *proxy_string, *proxy_string_after, *proxy_password;
 
 unsigned short family; /* 0 = don't care, AF_INET or AF_INET6 */
 unsigned short chosen_family; /* family actually chosen during name resolution */
+char *ipaddr;
 char *tag; /* try to keep this tag when connected to server */
 char *address;
 int port;

--- a/src/core/servers.c
+++ b/src/core/servers.c
@@ -212,13 +212,18 @@ static void server_real_connect(SERVER_REC *server, IPADDR *ip,
 
 	g_return_if_fail(ip != NULL || unix_socket != NULL);
 
+	if (ip != NULL) {
+		server->connrec->chosen_family = ip->family;
+		net_ip2host(ip, ipaddr);
+		server->connrec->ipaddr = g_strdup(ipaddr);
+	}
+
 	signal_emit("server connecting", 2, server, ip);
 
 	if (server->connrec->no_connect)
 		return;
 
 	if (ip != NULL) {
-		server->connrec->chosen_family = ip->family;
 		own_ip = IPADDR_IS_V6(ip) ? server->connrec->own_ip6 : server->connrec->own_ip4;
 		port = server->connrec->proxy != NULL ?
 			server->connrec->proxy_port : server->connrec->port;
@@ -637,6 +642,7 @@ void server_connect_unref(SERVER_CONNECT_REC *conn)
 	g_free_not_null(conn->proxy_string_after);
 	g_free_not_null(conn->proxy_password);
 
+	g_free_not_null(conn->ipaddr);
 	g_free_not_null(conn->tag);
 	g_free_not_null(conn->address);
 	g_free_not_null(conn->chatnet);

--- a/src/perl/perl-common.c
+++ b/src/perl/perl-common.c
@@ -287,6 +287,8 @@ void perl_connect_fill_hash(HV *hv, SERVER_CONNECT_REC *conn)
 	(void) hv_store(hv, "type", 4, new_pv(type), 0);
 	(void) hv_store(hv, "chat_type", 9, new_pv(chat_type), 0);
 
+	(void) hv_store(hv, "chosen_family", 13, newSViv(conn->chosen_family), 0);
+	(void) hv_store(hv, "ipaddr", 6, new_pv(conn->ipaddr), 0);
 	(void) hv_store(hv, "tag", 3, new_pv(conn->tag), 0);
 	(void) hv_store(hv, "address", 7, new_pv(conn->address), 0);
 	(void) hv_store(hv, "port", 4, newSViv(conn->port), 0);


### PR DESCRIPTION
Add ipaddr to SERVER_REC so that the connected-to IP can be obtained by scripts, even if they weren't running at the time the server connected

(As discussed on IRC, the 'server connecting' event's `ip` is also broken for all but IPv4-on-64bit-systems, so this would also - currently - be the only way to get such information)