### PR TITLE
Bump actions/upload-artifact from deprecated (defunct) v1 to v4.

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -44,7 +44,7 @@ jobs:
         dry-run: false
         sanitizer: ${{ matrix.sanitizer }}
     - name: Upload Crash
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: ${{ matrix.sanitizer }}-artifacts

--- a/.github/workflows/clangformat.yml
+++ b/.github/workflows/clangformat.yml
@@ -22,7 +22,7 @@ jobs:
           |
             CLANG_FORMAT=clang-format-14 git-clang-format-14 --diff FETCH_HEAD HEAD | tee git-clang-format.diff
             cmp -s <(echo no modified files to format) git-clang-format.diff || cmp -s <(echo -n) git-clang-format.diff
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: git-clang-format.diff


### PR DESCRIPTION
Fix remaining workflows that uses deprecated actions/upload-artifact@v1.
All PRs have these failed since some time, distracting from (potentially) actual issues.

https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/