### PR TITLE
fix irssi SASL negotiation with multiple CAP ACK

### DIFF
--- a/src/irc/core/irc-cap.c
+++ b/src/irc/core/irc-cap.c
@@ -234,7 +234,7 @@ static void event_cap (IRC_SERVER_REC *server, char *args, char *nick, char *add
 		}
 	}
 	else if (!g_ascii_strcasecmp(evt, "ACK")) {
-		int got_sasl = FALSE;
+		int got_sasl = (i_slist_find_string(server->cap_active, "sasl") != NULL);
 
 		/* Emit a signal for every ack'd cap */
 		for (i = 0; i < caps_length; i++) {


### PR DESCRIPTION
when attempting SASL, if multiple CAP ACK were received (for example, because a script sent an additional CAP REQ), then any not containing `sasl` would cause SASL to fail (immediately aborting the connection with no message, depending on sasl_disconnect_on_failure setting)

check not only if SASL is set in this line, but also if we've already seen it in a previous line.

https://github.com/solanum-ircd/solanum/issues/449