### PR TITLE
add missing include for wcwidth thread test

### DIFF
--- a/src/perl/perl-core.c
+++ b/src/perl/perl-core.c
@@ -18,6 +18,9 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#define _GNU_SOURCE
+#include <wchar.h>
+
 #define NEED_PERL_H
 #define PERL_NO_GET_CONTEXT
 #include "module.h"


### PR DESCRIPTION
reported on irc 

`Gentoo 6.13.2-gentoo-dist x86_64, 
          Wayland, KDE Plasma 6.2.5, gcc 14.2.1`