### PR TITLE
feat: add support for JOIN 0 to leave all channels

### DIFF
--- a/docs/help/in/join.in
+++ b/docs/help/in/join.in
@@ -13,7 +13,7 @@
 
 %9Description:%9
 
-    Joins the given channels.
+    Joins the given channels, or use `JOIN 0` to leave all currently joined channels.
 
 %9Examples:%9
 
@@ -21,6 +21,7 @@
     /JOIN #basementcat secret_lair
     /JOIN -invite
     /JOIN -liberachat #github,#libera,#irssi
+    /JOIN 0
 
 %9See also:%9 KICK, PART
 

--- a/src/fe-common/core/fe-channels.c
+++ b/src/fe-common/core/fe-channels.c
@@ -117,7 +117,7 @@ static void sig_channel_joined(CHANNEL_REC *channel)
 	}
 }
 
-/* SYNTAX: JOIN [-window] [-invite] [-<server tag>] <channels> [<keys>] */
+/* SYNTAX: JOIN [-window] [-invite] [-<server tag>] <channels> [<keys>] / "0" */
 static void cmd_join(const char *data, SERVER_REC *server)
 {
 	WINDOW_REC *window;
@@ -141,6 +141,15 @@ static void cmd_join(const char *data, SERVER_REC *server)
 
 	/* -<server tag> */
 	server = cmd_options_get_server("join", optlist, server);
+
+	/* JOIN 0 (leave all channels) */
+	if (!invite && !samewindow && strcmp(pdata, "0") == 0) {
+		if (server == NULL || !server->connected)
+			cmd_param_error(CMDERR_NOT_CONNECTED);
+		server->channels_join(server, pdata, FALSE);
+		cmd_params_free(free_arg);
+		return;
+	}
 
 	channel = channel_find(server, pdata);
 	if (channel != NULL) {

--- a/src/irc/core/irc-channels.c
+++ b/src/irc/core/irc-channels.c
@@ -92,6 +92,12 @@ static void irc_channels_join(IRC_SERVER_REC *server, const char *data,
 	g_return_if_fail(IS_IRC_SERVER(server) && server->connected);
 	if (*data == '\0') return;
 
+	/* JOIN 0 (leave all channels) */
+	if (strcmp(data, "0") == 0) {
+	    irc_send_cmd(IRC_SERVER(server), "JOIN 0");
+	    return;
+	}
+
 	if (!cmd_get_params(data, &free_arg, 2 | PARAM_FLAG_GETREST,
 			    &channels, &keys))
 		return;


### PR DESCRIPTION
This PR adds support for the `JOIN 0` command, to leave all currently joined channels as defined in [RFC 2812 §3.2.1](https://www.rfc-editor.org/rfc/rfc2812.html#section-3.2.1).
- Prevents automatic `#` prefixing for 0 when no other parameter is given. 
- Updates `/help join` with this behavior (syntax, description, and example).