### PR TITLE
replace str->str & g_string_free with g_string_free_and_steal

### DIFF
--- a/src/core/levels.c
+++ b/src/core/levels.c
@@ -19,6 +19,7 @@
 */
 
 #include "module.h"
+#include <irssi/src/core/misc.h>
 #include <irssi/src/core/levels.h>
 
 /* the order of these levels must match the bits in levels.h */
@@ -169,8 +170,7 @@ char *bits2level(int bits)
         if (str->len > 0)
 		g_string_truncate(str, str->len-1);
 
-	ret = str->str;
-	g_string_free(str, FALSE);
+	ret = g_string_free_and_steal(str);
 
 	return ret;
 }

--- a/src/core/misc.c
+++ b/src/core/misc.c
@@ -135,6 +135,15 @@ GDateTime *g_date_time_new_from_iso8601(const gchar *iso_date, GTimeZone *defaul
 }
 #endif
 
+#if GLIB_CHECK_VERSION(2, 76, 0)
+/* nothing */
+#else
+gchar *g_string_free_and_steal(GString *string)
+{
+	return g_string_free(string, FALSE);
+}
+#endif
+
 int find_substr(const char *list, const char *item)
 {
 	const char *ptr;
@@ -261,8 +270,7 @@ char *gslistptr_to_string(GSList *list, int offset, const char *delimiter)
 		list = list->next;
 	}
 
-        ret = str->str;
-	g_string_free(str, FALSE);
+	ret = g_string_free_and_steal(str);
 	return ret;
 }
 
@@ -280,8 +288,7 @@ char *i_slist_to_string(GSList *list, const char *delimiter)
 		list = list->next;
 	}
 
-        ret = str->str;
-	g_string_free(str, FALSE);
+	ret = g_string_free_and_steal(str);
 	return ret;
 }
 

--- a/src/core/misc.h
+++ b/src/core/misc.h
@@ -26,6 +26,12 @@ long get_timeval_diff(const GTimeVal *tv1, const GTimeVal *tv2) G_GNUC_DEPRECATE
 GDateTime *g_date_time_new_from_iso8601(const gchar *iso_date, GTimeZone *default_tz);
 #endif
 
+#if GLIB_CHECK_VERSION(2, 76, 0)
+/* nothing */
+#else
+gchar *g_string_free_and_steal(GString *string);
+#endif
+
 GSList *i_slist_find_string(GSList *list, const char *key);
 GSList *i_slist_find_icase_string(GSList *list, const char *key);
 GList *i_list_find_string(GList *list, const char *key);

--- a/src/core/servers.c
+++ b/src/core/servers.c
@@ -134,8 +134,7 @@ static char *server_create_tag(SERVER_CONNECT_REC *conn)
 	}
 	g_free(tag);
 
-	tag = str->str;
-	g_string_free(str, FALSE);
+	tag = g_string_free(str, FALSE);
 	return tag;
 }
 

--- a/src/core/special-vars.c
+++ b/src/core/special-vars.c
@@ -88,8 +88,7 @@ static char *get_argument(char **cmd, char **arglist)
 	}
 	if (str->len > 0) g_string_truncate(str, str->len-1);
 
-	ret = str->str;
-	g_string_free(str, FALSE);
+	ret = g_string_free_and_steal(str);
 	return ret;
 }
 
@@ -412,8 +411,7 @@ char *get_alignment(const char *text, int align, int flags, char pad)
 		}
 	}
 
-	ret = str->str;
-	g_string_free(str, FALSE);
+	ret = g_string_free_and_steal(str);
 	return ret;
 }
 
@@ -604,8 +602,7 @@ char *parse_special_string(const char *cmd, SERVER_REC *server, void *item,
 	}
 	g_strfreev(arglist);
 
-	ret = str->str;
-	g_string_free(str, FALSE);
+	ret = g_string_free_and_steal(str);
 	return ret;
 }
 

--- a/src/fe-common/core/completion.c
+++ b/src/fe-common/core/completion.c
@@ -111,8 +111,7 @@ char *auto_word_complete(const char *line, int *pos)
 		*pos = startpos+strlen(replace);
 
 		g_string_insert(result, startpos, replace);
-		ret = result->str;
-		g_string_free(result, FALSE);
+		ret = g_string_free_and_steal(result);
 	}
 
 	g_free(word);
@@ -290,8 +289,7 @@ char *word_complete(WINDOW_REC *window, const char *line, int *pos, int erase, i
 	g_free_not_null(last_line);
 	last_line = g_strdup(result->str);
 
-	ret = result->str;
-	g_string_free(result, FALSE);
+	ret = g_string_free_and_steal(result);
 
 	/* free the data */
 	g_free(data);

--- a/src/fe-common/core/fe-log.c
+++ b/src/fe-common/core/fe-log.c
@@ -214,8 +214,7 @@ static char *log_items_get_list(LOG_REC *log)
 	if(rec->servertag != NULL)
 		g_string_append_printf(str, " (%s)", rec->servertag);
 
-	ret = str->str;
-	g_string_free(str, FALSE);
+	ret = g_string_free_and_steal(str);
 	return ret;
 }
 

--- a/src/fe-common/core/fe-messages.c
+++ b/src/fe-common/core/fe-messages.c
@@ -133,8 +133,7 @@ char *expand_emphasis(WI_ITEM_REC *item, const char *text)
 		}
 	}
 
-	ret = str->str;
-	g_string_free(str, FALSE);
+	ret = g_string_free_and_steal(str);
 	return ret;
 }
 
@@ -730,9 +729,8 @@ static void sig_nicklist_new(CHANNEL_REC *channel, NICK_REC *nick)
                 n++;
 	} while (printnick_exists(firstnick, nick, newnick->str));
 
-	g_hash_table_insert(printnicks, nick, newnick->str);
-	g_string_free(newnick, FALSE);
-        g_free(nickhost);
+	g_hash_table_insert(printnicks, nick, g_string_free_and_steal(newnick));
+	g_free(nickhost);
 }
 
 static void sig_nicklist_remove(CHANNEL_REC *channel, NICK_REC *nick)

--- a/src/fe-common/core/formats.c
+++ b/src/fe-common/core/formats.c
@@ -616,8 +616,7 @@ char *format_string_expand(const char *text, int *flags)
 		text++;
 	}
 
-	ret = out->str;
-	g_string_free(out, FALSE);
+	ret = g_string_free_and_steal(out);
 	return ret;
 }
 
@@ -792,8 +791,7 @@ static char *format_get_text_args(TEXT_DEST_REC *dest,
 		text++;
 	}
 
-	ret = out->str;
-	g_string_free(out, FALSE);
+	ret = g_string_free_and_steal(out);
 	return ret;
 }
 
@@ -888,8 +886,7 @@ char *format_add_linestart(const char *text, const char *linestart)
 		text++;
 	}
 
-	ret = str->str;
-	g_string_free(str, FALSE);
+	ret = g_string_free_and_steal(str);
 	return ret;
 }
 
@@ -913,8 +910,7 @@ char *format_add_lineend(const char *text, const char *linestart)
 	}
 	g_string_append(str, linestart);
 
-	ret = str->str;
-	g_string_free(str, FALSE);
+	ret = g_string_free_and_steal(str);
 	return ret;
 }
 

--- a/src/fe-common/core/hilight-text.c
+++ b/src/fe-common/core/hilight-text.c
@@ -469,8 +469,7 @@ static void sig_print_text(TEXT_DEST_REC *dest, const char *text,
 		}
 		g_string_append(str, text + pos);
 
-		newstr = str->str;
-		g_string_free(str, FALSE);
+		newstr = g_string_free_and_steal(str);
 
 		format_dest_meta_stash(dest, "hilight-start",
 		                       tmp = g_strdup_printf("%d", hilight_start));

--- a/src/fe-common/core/printtext.c
+++ b/src/fe-common/core/printtext.c
@@ -24,6 +24,7 @@
 #include <irssi/src/core/signals.h>
 #include <irssi/src/core/commands.h>
 #include <irssi/src/core/settings.h>
+#include <irssi/src/core/misc.h>
 
 #include <irssi/src/core/levels.h>
 #include <irssi/src/core/servers.h>
@@ -240,8 +241,7 @@ static char *printtext_get_args(TEXT_DEST_REC *dest, const char *str,
 		}
 	}
 
-	ret = out->str;
-	g_string_free(out, FALSE);
+	ret = g_string_free_and_steal(out);
 	return ret;
 }
 
@@ -270,8 +270,7 @@ static char *printtext_expand_formats(const char *str, int *flags)
 		}
 	}
 
-	ret = out->str;
-	g_string_free(out, FALSE);
+	ret = g_string_free_and_steal(out);
 	return ret;
 }
 

--- a/src/fe-common/core/themes.c
+++ b/src/fe-common/core/themes.c
@@ -395,9 +395,8 @@ char *theme_format_expand_get(THEME_REC *theme, const char **format)
 		(*format)++;
 	}
 
-	ret = str->str;
-        g_string_free(str, FALSE);
-        return ret;
+	ret = g_string_free_and_steal(str);
+	return ret;
 }
 
 static char *theme_format_expand_data_rec(THEME_REC *theme, const char **format,
@@ -496,8 +495,7 @@ static char *theme_format_expand_abstract(THEME_REC *theme, const char **formatp
 		p++;
 	}
 	g_free(ret);
-	abstract = str->str;
-	g_string_free(str, FALSE);
+	abstract = g_string_free_and_steal(str);
 
 	/* abstract may itself contain abstracts or replaces */
 	p = abstract;
@@ -568,15 +566,14 @@ static char *theme_format_expand_data_rec(THEME_REC *theme, const char **format,
 		}
 	}
 
-		/* save the last color */
-		if (save_last_fg != NULL)
-			*save_last_fg = last_fg;
-		if (save_last_bg != NULL)
-			*save_last_bg = last_bg;
+	/* save the last color */
+	if (save_last_fg != NULL)
+		*save_last_fg = last_fg;
+	if (save_last_bg != NULL)
+		*save_last_bg = last_bg;
 
-	ret = str->str;
-        g_string_free(str, FALSE);
-        return ret;
+	ret = g_string_free_and_steal(str);
+	return ret;
 }
 
 /* expand the data part in {abstract data} */
@@ -645,9 +642,8 @@ static char *theme_format_compress_colors(THEME_REC *theme, const char *format)
 		}
 	}
 
-	ret = str->str;
-        g_string_free(str, FALSE);
-        return ret;
+	ret = g_string_free_and_steal(str);
+	return ret;
 }
 
 char *theme_format_expand(THEME_REC *theme, const char *format)

--- a/src/fe-text/terminfo-core.c
+++ b/src/fe-text/terminfo-core.c
@@ -1,5 +1,6 @@
 #include "module.h"
 #include <irssi/src/core/signals.h>
+#include <irssi/src/core/misc.h>
 #include <irssi/src/fe-text/terminfo-core.h>
 
 #ifndef _POSIX_VDISABLE
@@ -678,8 +679,7 @@ static int term_setup(TERM_REC *term)
 	if (term->TI_ritm &&
 	    (term->TI_sgr0 == NULL || g_strcmp0(term->TI_ritm, term->TI_sgr0) != 0))
 		g_string_append(str, term->TI_ritm);
-	term->TI_normal = str->str;
-	g_string_free(str, FALSE);
+	term->TI_normal = g_string_free_and_steal(str);
 	term->tr_set_normal = _set_normal;
 
 	term->tr_beep = term->TI_bel ? _beep : _ignore;

--- a/src/irc/core/bans.c
+++ b/src/irc/core/bans.c
@@ -106,9 +106,8 @@ char *ban_get_masks(IRC_CHANNEL_REC *channel, const char *nicks, int ban_type)
 	if (str->len > 0)
 		g_string_truncate(str, str->len-1);
 
-	ret = str->str;
-	g_string_free(str, FALSE);
-        return ret;
+	ret = g_string_free_and_steal(str);
+	return ret;
 }
 
 void ban_set(IRC_CHANNEL_REC *channel, const char *bans, int ban_type)

--- a/src/irc/core/irc-servers.c
+++ b/src/irc/core/irc-servers.c
@@ -874,8 +874,7 @@ char *irc_server_get_channels(IRC_SERVER_REC *server, int rejoin_channels_mode)
 		if (use_keys) g_string_append_printf(chans, " %s", keys->str);
 	}
 
-	ret = chans->str;
-	g_string_free(chans, FALSE);
+	ret = g_string_free_and_steal(chans);
 	g_string_free(keys, TRUE);
 
 	return ret;

--- a/src/irc/core/modes.c
+++ b/src/irc/core/modes.c
@@ -21,6 +21,7 @@
 #include "module.h"
 #include <irssi/src/core/signals.h>
 #include <irssi/src/core/settings.h>
+#include <irssi/src/core/misc.h>
 
 #include <irssi/src/irc/core/irc-commands.h>
 #include <irssi/src/irc/core/irc-servers.h>
@@ -443,8 +444,7 @@ char *modes_join(IRC_SERVER_REC *server, const char *old,
 	}
 	g_free(dup);
 
-	modestr = newmode->str;
-	g_string_free(newmode, FALSE);
+	modestr = g_string_free_and_steal(newmode);
 	return modestr;
 }
 
@@ -755,8 +755,7 @@ static char *get_nicks(IRC_SERVER_REC *server, WI_ITEM_REC *item,
 	}
 
         if (str->len > 0) g_string_truncate(str, str->len-1);
-	ret = str->str;
-	g_string_free(str, FALSE);
+	ret = g_string_free_and_steal(str);
 	g_strfreev(matches);
 	cmd_params_free(free_arg);
 

--- a/src/irc/dcc/dcc-get.c
+++ b/src/irc/dcc/dcc-get.c
@@ -88,8 +88,7 @@ static char *dcc_get_rename_file(const char *fname)
 		num++;
 	} while (stat(newname->str, &statbuf) == 0);
 
-	ret = newname->str;
-	g_string_free(newname, FALSE);
+	ret = g_string_free_and_steal(newname);
 	return ret;
 }
 
@@ -416,8 +415,7 @@ char *get_file_name(char **params, int fileparams)
 		out = g_string_append(out, params[pos]);
 	}
 
-	ret = out->str;
-	g_string_free(out, FALSE);
+	ret = g_string_free_and_steal(out);
 	return ret;
 }
 

--- a/src/lib-config/write.c
+++ b/src/lib-config/write.c
@@ -26,6 +26,15 @@
 #define CONFIG_INDENT_SIZE 2
 static const char *indent_block = "  "; /* needs to be the same size as CONFIG_INDENT_SIZE! */
 
+#if GLIB_CHECK_VERSION(2, 76, 0)
+/* nothing */
+#else
+static gchar *g_string_free_and_steal(GString *string)
+{
+	return g_string_free(string, FALSE);
+}
+#endif
+
 /* write needed amount of indentation to the start of the line */
 static int config_write_indent(CONFIG_REC *rec)
 {
@@ -108,8 +117,7 @@ static char *config_escape_string(const char *text)
 
 	g_string_append_c(str, '"');
 
-	ret = str->str;
-	g_string_free(str, FALSE);
+	ret = g_string_free_and_steal(str);
 	return ret;
 }
 

--- a/src/perl/perl-common.c
+++ b/src/perl/perl-common.c
@@ -239,9 +239,8 @@ char *perl_get_use_list(void)
 	for (tmp = use_protocols; tmp != NULL; tmp = tmp->next)
 		g_string_append_printf(str, "use Irssi::%s;", (char *) tmp->data);
 
-	ret = str->str;
-        g_string_free(str, FALSE);
-        return ret;
+	ret = g_string_free_and_steal(str);
+	return ret;
 }
 
 void irssi_callXS(void (*subaddr)(pTHX_ CV* cv), CV *cv, SV **mark)

--- a/src/perl/perl-core.c
+++ b/src/perl/perl-core.c
@@ -202,9 +202,8 @@ static char *script_data_get_name(void)
                 n++;
 	} while (perl_script_find(name->str) != NULL);
 
-	ret = name->str;
-        g_string_free(name, FALSE);
-        return ret;
+	ret = g_string_free_and_steal(name);
+	return ret;
 }
 
 static int perl_script_eval(PERL_SCRIPT_REC *script)


### PR DESCRIPTION
solving unused warning in GLib 2.76