### PR TITLE
feat: Add option to print WHOIS replies in active window (#1)

### DIFF
--- a/src/fe-common/irc/fe-whois.c
+++ b/src/fe-common/irc/fe-whois.c
@@ -12,17 +12,25 @@
 
 #include <irssi/src/fe-common/core/printtext.h>
 
+/* When enabled, prints WHOIS replies into active window while preserving
+ * formatting and theming. */
+#define WHOIS_PRINT(server, nick, level, formatnum, ...)                                           \
+	do {                                                                                       \
+		if (settings_get_bool("print_whois_rpl_in_active_window") && active_win != NULL)   \
+			printformat_window(active_win, level, formatnum, __VA_ARGS__);             \
+		else                                                                               \
+			printformat(server, nick, level, formatnum, __VA_ARGS__);                  \
+	} while (0)
+
 static void event_whois(IRC_SERVER_REC *server, const char *data)
 {
 	char *params, *nick, *user, *host, *realname, *recoded;
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 6, NULL, &nick, &user,
-				  &host, NULL, &realname);
+	params = event_get_params(data, 6, NULL, &nick, &user, &host, NULL, &realname);
 	recoded = recode_in(SERVER(server), realname, nick);
-	printformat(server, nick, MSGLEVEL_CRAP,
-		    IRCTXT_WHOIS, nick, user, host, recoded);
+	WHOIS_PRINT(server, nick, MSGLEVEL_CRAP, IRCTXT_WHOIS, nick, user, host, recoded);
 	g_free(params);
 	g_free(recoded);
 }
@@ -34,8 +42,7 @@ static void event_whois_special(IRC_SERVER_REC *server, const char *data)
 	g_return_if_fail(data != NULL);
 
 	params = event_get_params(data, 3 | PARAM_FLAG_GETREST, NULL, &nick, &str);
-	printformat(server, nick, MSGLEVEL_CRAP,
-		    IRCTXT_WHOIS_SPECIAL, nick, str);
+	WHOIS_PRINT(server, nick, MSGLEVEL_CRAP, IRCTXT_WHOIS_SPECIAL, nick, str);
 	g_free(params);
 }
 
@@ -47,26 +54,24 @@ static void event_whois_idle(IRC_SERVER_REC *server, const char *data)
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 5 | PARAM_FLAG_GETREST, NULL,
-				  &nick, &secstr, &signonstr, &rest);
+	params =
+	    event_get_params(data, 5 | PARAM_FLAG_GETREST, NULL, &nick, &secstr, &signonstr, &rest);
 
 	secs = atol(secstr);
-	signon = strstr(rest, "signon time") == NULL ? 0 :
-		(time_t) atol(signonstr);
+	signon = strstr(rest, "signon time") == NULL ? 0 : (time_t) atol(signonstr);
 
-	days = secs/3600/24;
-	hours = (secs%(3600*24))/3600;
-	mins = (secs%3600)/60;
+	days = secs / 3600 / 24;
+	hours = (secs % (3600 * 24)) / 3600;
+	mins = (secs % 3600) / 60;
 	secs %= 60;
 
 	if (signon == 0)
-		printformat(server, nick, MSGLEVEL_CRAP, IRCTXT_WHOIS_IDLE,
-			    nick, days, hours, mins, secs);
+		WHOIS_PRINT(server, nick, MSGLEVEL_CRAP, IRCTXT_WHOIS_IDLE, nick, days, hours, mins,
+		            secs);
 	else {
 		timestr = my_asctime(signon);
-		printformat(server, nick, MSGLEVEL_CRAP,
-			    IRCTXT_WHOIS_IDLE_SIGNON,
-			    nick, days, hours, mins, secs, timestr);
+		WHOIS_PRINT(server, nick, MSGLEVEL_CRAP, IRCTXT_WHOIS_IDLE_SIGNON, nick, days,
+		            hours, mins, secs, timestr);
 		g_free(timestr);
 	}
 	g_free(params);
@@ -79,8 +84,7 @@ static void event_whois_server(IRC_SERVER_REC *server, const char *data)
 	g_return_if_fail(data != NULL);
 
 	params = event_get_params(data, 4, NULL, &nick, &whoserver, &desc);
-	printformat(server, nick, MSGLEVEL_CRAP,
-		    IRCTXT_WHOIS_SERVER, nick, whoserver, desc);
+	WHOIS_PRINT(server, nick, MSGLEVEL_CRAP, IRCTXT_WHOIS_SERVER, nick, whoserver, desc);
 	g_free(params);
 }
 
@@ -99,14 +103,14 @@ static void event_whois_oper(IRC_SERVER_REC *server, const char *data)
 
 	if ((!strncmp(type, "is an ", 6)) || (!strncmp(type, "is a ", 5))) {
 		type += 5;
-		if (*type == ' ') type++;
+		if (*type == ' ')
+			type++;
 	}
 
 	if (*type == '\0')
 		type = "IRC Operator";
 
-	printformat(server, nick, MSGLEVEL_CRAP,
-		IRCTXT_WHOIS_OPER, nick, type);
+	WHOIS_PRINT(server, nick, MSGLEVEL_CRAP, IRCTXT_WHOIS_OPER, nick, type);
 	g_free(params);
 }
 
@@ -116,12 +120,10 @@ static void event_whois_modes(IRC_SERVER_REC *server, const char *data)
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 3 | PARAM_FLAG_GETREST,
-			NULL, &nick, &modes);
+	params = event_get_params(data, 3 | PARAM_FLAG_GETREST, NULL, &nick, &modes);
 	if (!strncmp(modes, "is using modes ", 15))
 		modes += 15;
-	printformat(server, nick, MSGLEVEL_CRAP,
-		    IRCTXT_WHOIS_MODES, nick, modes);
+	WHOIS_PRINT(server, nick, MSGLEVEL_CRAP, IRCTXT_WHOIS_MODES, nick, modes);
 	g_free(params);
 }
 
@@ -131,24 +133,22 @@ static void event_whois_realhost(IRC_SERVER_REC *server, const char *data)
 
 	g_return_if_fail(data != NULL);
 
-        /* <yournick> real hostname <nick> <hostname> */
-	params = event_get_params(data, 5, NULL, &nick, &txt_real,
-				  &txt_hostname, &hostname);
-	if (g_strcmp0(txt_real, "real") != 0 ||
-	    g_strcmp0(txt_hostname, "hostname") != 0) {
+	/* <yournick> real hostname <nick> <hostname> */
+	params = event_get_params(data, 5, NULL, &nick, &txt_real, &txt_hostname, &hostname);
+	if (g_strcmp0(txt_real, "real") != 0 || g_strcmp0(txt_hostname, "hostname") != 0) {
 		/* <yournick> <nick> :... from <hostname> */
-                g_free(params);
+		g_free(params);
 		params = event_get_params(data, 3, NULL, &nick, &hostname);
 
 		hostname = strstr(hostname, "from ");
-                if (hostname != NULL) hostname += 5;
+		if (hostname != NULL)
+			hostname += 5;
 	}
 
 	if (hostname != NULL) {
 		if (!strncmp(hostname, "*@", 2))
 			hostname += 2;
-		printformat(server, nick, MSGLEVEL_CRAP,
-			    IRCTXT_WHOIS_REALHOST, nick, hostname, "");
+		WHOIS_PRINT(server, nick, MSGLEVEL_CRAP, IRCTXT_WHOIS_REALHOST, nick, hostname, "");
 	} else {
 		event_whois_special(server, data);
 	}
@@ -161,11 +161,10 @@ static void event_whois_usermode326(IRC_SERVER_REC *server, const char *data)
 
 	g_return_if_fail(data != NULL);
 
-        /* <yournick> <nick> :has oper privs: <mode> */
+	/* <yournick> <nick> :has oper privs: <mode> */
 	params = event_get_params(data, 3, NULL, &nick, &usermode);
-	printformat(server, nick, MSGLEVEL_CRAP,
-		    IRCTXT_WHOIS_USERMODE, nick, usermode);
-        g_free(params);
+	WHOIS_PRINT(server, nick, MSGLEVEL_CRAP, IRCTXT_WHOIS_USERMODE, nick, usermode);
+	g_free(params);
 }
 
 static void event_whois_realhost327(IRC_SERVER_REC *server, const char *data)
@@ -177,8 +176,7 @@ static void event_whois_realhost327(IRC_SERVER_REC *server, const char *data)
 	/* <yournick> <hostname> <ip> :Real hostname/IP */
 	params = event_get_params(data, 5, NULL, &nick, &hostname, &ip, &text);
 	if (*text != '\0') {
-		printformat(server, nick, MSGLEVEL_CRAP,
-			    IRCTXT_WHOIS_REALHOST, nick, hostname, ip);
+		WHOIS_PRINT(server, nick, MSGLEVEL_CRAP, IRCTXT_WHOIS_REALHOST, nick, hostname, ip);
 	} else {
 		event_whois_special(server, data);
 	}
@@ -199,11 +197,9 @@ static void event_whois_realhost338(IRC_SERVER_REC *server, const char *data)
 	 */
 	params = event_get_params(data, 5, NULL, &nick, &arg1, &arg2, &arg3);
 	if (*arg3 != '\0') {
-		printformat(server, nick, MSGLEVEL_CRAP,
-			    IRCTXT_WHOIS_REALHOST, nick, arg1, arg2);
+		WHOIS_PRINT(server, nick, MSGLEVEL_CRAP, IRCTXT_WHOIS_REALHOST, nick, arg1, arg2);
 	} else if (*arg2 != '\0') {
-		printformat(server, nick, MSGLEVEL_CRAP,
-			    IRCTXT_WHOIS_REALHOST, nick, arg1, "");
+		WHOIS_PRINT(server, nick, MSGLEVEL_CRAP, IRCTXT_WHOIS_REALHOST, nick, arg1, "");
 	} else {
 		event_whois_special(server, data);
 	}
@@ -216,13 +212,11 @@ static void event_whois_usermode(IRC_SERVER_REC *server, const char *data)
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 4, NULL, &txt_usermodes,
-				  &nick, &usermode);
+	params = event_get_params(data, 4, NULL, &txt_usermodes, &nick, &usermode);
 
 	if (g_strcmp0(txt_usermodes, "usermodes") == 0) {
 		/* <yournick> usermodes <nick> usermode */
-		printformat(server, nick, MSGLEVEL_CRAP,
-			    IRCTXT_WHOIS_USERMODE, nick, usermode);
+		WHOIS_PRINT(server, nick, MSGLEVEL_CRAP, IRCTXT_WHOIS_USERMODE, nick, usermode);
 	} else {
 		event_whois_special(server, data);
 	}
@@ -249,7 +243,7 @@ static void hide_safe_channel_id(IRC_SERVER_REC *server, char *chans)
 		if (idchan[1] != ':')
 			return;
 
-		length = strtoul(idchan+2, &end, 10);
+		length = strtoul(idchan + 2, &end, 10);
 		if (*end == ',')
 			end++;
 		else if (*end != '\0')
@@ -292,8 +286,7 @@ static void event_whois_channels(IRC_SERVER_REC *server, const char *data)
 	if (settings_get_bool("whois_hide_safe_channel_id"))
 		hide_safe_channel_id(server, chans);
 	recoded = recode_in(SERVER(server), chans, nick);
-	printformat(server, nick, MSGLEVEL_CRAP,
-		    IRCTXT_WHOIS_CHANNELS, nick, recoded);
+	WHOIS_PRINT(server, nick, MSGLEVEL_CRAP, IRCTXT_WHOIS_CHANNELS, nick, recoded);
 	g_free(chans);
 
 	g_free(params);
@@ -308,8 +301,7 @@ static void event_whois_away(IRC_SERVER_REC *server, const char *data)
 
 	params = event_get_params(data, 3, NULL, &nick, &awaymsg);
 	recoded = recode_in(SERVER(server), awaymsg, nick);
-	printformat(server, nick, MSGLEVEL_CRAP,
-		    IRCTXT_WHOIS_AWAY, nick, recoded);
+	WHOIS_PRINT(server, nick, MSGLEVEL_CRAP, IRCTXT_WHOIS_AWAY, nick, recoded);
 	g_free(params);
 	g_free(recoded);
 }
@@ -322,8 +314,7 @@ static void event_end_of_whois(IRC_SERVER_REC *server, const char *data)
 
 	params = event_get_params(data, 2, NULL, &nick);
 	if (server->whois_found) {
-		printformat(server, nick, MSGLEVEL_CRAP,
-			    IRCTXT_END_OF_WHOIS, nick);
+		WHOIS_PRINT(server, nick, MSGLEVEL_CRAP, IRCTXT_END_OF_WHOIS, nick);
 	}
 	g_free(params);
 }
@@ -335,8 +326,7 @@ static void event_whois_auth(IRC_SERVER_REC *server, const char *data)
 	g_return_if_fail(data != NULL);
 
 	params = event_get_params(data, 3, NULL, &nick, &text);
-	printformat(server, nick, MSGLEVEL_CRAP,
-		    IRCTXT_WHOIS_EXTRA, nick, text);
+	WHOIS_PRINT(server, nick, MSGLEVEL_CRAP, IRCTXT_WHOIS_EXTRA, nick, text);
 	g_free(params);
 }
 
@@ -346,11 +336,9 @@ static void event_whowas(IRC_SERVER_REC *server, const char *data)
 
 	g_return_if_fail(data != NULL);
 
-	params = event_get_params(data, 6, NULL, &nick, &user,
-				  &host, NULL, &realname);
+	params = event_get_params(data, 6, NULL, &nick, &user, &host, NULL, &realname);
 	recoded = recode_in(SERVER(server), realname, nick);
-	printformat(server, nick, MSGLEVEL_CRAP,
-		    IRCTXT_WHOWAS, nick, user, host, recoded);
+	printformat(server, nick, MSGLEVEL_CRAP, IRCTXT_WHOWAS, nick, user, host, recoded);
 	g_free(params);
 	g_free(recoded);
 }
@@ -363,8 +351,7 @@ static void event_end_of_whowas(IRC_SERVER_REC *server, const char *data)
 
 	params = event_get_params(data, 2, NULL, &nick);
 	if (server->whowas_found) {
-		printformat(server, nick, MSGLEVEL_CRAP,
-			    IRCTXT_END_OF_WHOWAS, nick);
+		printformat(server, nick, MSGLEVEL_CRAP, IRCTXT_END_OF_WHOWAS, nick);
 	}
 	g_free(params);
 }
@@ -374,19 +361,17 @@ struct whois_event_table {
 	void (*func)(IRC_SERVER_REC *, const char *);
 };
 
-static struct whois_event_table events[] = {
-	{ 312, event_whois_server },
-	{ 326, event_whois_usermode326 },
-	{ 327, event_whois_realhost327 },
-	{ 338, event_whois_realhost338 },
-	{ 379, event_whois_modes },
-	{ 378, event_whois_realhost },
-	{ 377, event_whois_usermode },
-	{ 317, event_whois_idle },
-	{ 330, event_whois_auth },
-	{ 319, event_whois_channels },
-	{ 0, NULL }
-};
+static struct whois_event_table events[] = { { 312, event_whois_server },
+	                                     { 326, event_whois_usermode326 },
+	                                     { 327, event_whois_realhost327 },
+	                                     { 338, event_whois_realhost338 },
+	                                     { 379, event_whois_modes },
+	                                     { 378, event_whois_realhost },
+	                                     { 377, event_whois_usermode },
+	                                     { 317, event_whois_idle },
+	                                     { 330, event_whois_auth },
+	                                     { 319, event_whois_channels },
+	                                     { 0, NULL } };
 
 static void event_whois_default(IRC_SERVER_REC *server, const char *data)
 {
@@ -406,6 +391,7 @@ static void event_whois_default(IRC_SERVER_REC *server, const char *data)
 void fe_whois_init(void)
 {
 	settings_add_bool("lookandfeel", "whois_hide_safe_channel_id", TRUE);
+	settings_add_bool("lookandfeel", "print_whois_rpl_in_active_window", FALSE);
 
 	signal_add("event 311", (SIGNAL_FUNC) event_whois);
 	signal_add("event 312", (SIGNAL_FUNC) event_whois_server);


### PR DESCRIPTION
# Description
This pull request introduces a new feature that allows WHOIS replies to be printed directly in the active window.  
This helps maintain a smooth workflow by reducing the need to switch between windows.

It addresses the feedback from [PR #1581](https://github.com/irssi/irssi/pull/1581) and isolates the WHOIS functionality into a dedicated pull request.  
The code has also been formatted to match the project’s coding style.

# Configuration
- `print_whois_rpl_in_active_window`: Boolean setting to enable or disable this feature (default: `FALSE`).

# To enable
```irc
/set print_whois_rpl_in_active_window ON
```