### PR TITLE
Increase default scrollback_lines

### DIFF
--- a/src/fe-text/gui-printtext.c
+++ b/src/fe-text/gui-printtext.c
@@ -405,7 +405,7 @@ void gui_printtext_init(void)
 	indent_functions = g_hash_table_new((GHashFunc) g_str_hash,
 					    (GCompareFunc) g_str_equal);
 
-	settings_add_int("history", "scrollback_lines", 500);
+	settings_add_int("history", "scrollback_lines", 5000);
 	settings_add_time("history", "scrollback_time", "1day");
 	settings_add_time("history", "scrollback_max_age", "0");
 	settings_add_int("history", "scrollback_burst_remove", 10);


### PR DESCRIPTION
It seems common that people miss important messages when being away and want to increase the scrollback.