### PR TITLE
Typo fix in docs/help/in/lusers.in

### DIFF
--- a/docs/help/in/lusers.in
+++ b/docs/help/in/lusers.in
@@ -5,7 +5,7 @@
 
 %9Parameters:%9
 
-    The server to search on and the remote sever to search on; if no arguments
+    The server to search on and the remote server to search on; if no arguments
     are given, the active server will be used.
 
 %9Description:%9


### PR DESCRIPTION
Good afternoon.

While familiarising myself with the source code of irssi, I decided to read through some of the documentation and I spotted a typo in line 8 of `docs/help/in/lusers.in'.

As a result I decided to be helpful and fix that typo:

```
sever -> server
```

Thanks.