### PR TITLE
fe-netsplit: fix nickname truncation to avoid trailing comma-space

### DIFF
--- a/src/fe-common/irc/fe-netsplit.c
+++ b/src/fe-common/irc/fe-netsplit.c
@@ -137,7 +137,7 @@ static void get_server_splits(void *key, NETSPLIT_REC *split,
 			g_string_append_printf(chanrec->nicks, "%s, ", split->nick);
 
 			if (chanrec->nick_count == netsplit_max_nicks)
-                                chanrec->maxnickpos = chanrec->nicks->len;
+				chanrec->maxnickpos = chanrec->nicks->len - 2;
 		}
 	}
 }


### PR DESCRIPTION
Following several network splits, I noticed that `netsplit_more` theme format exhibits a minor cosmetic inconsistency, while `netsplit_join_more` is not affected. Investigation of `src/fe-common/irc/fe-netsplit.c` revealed that subtracting 2 from `chanrec->nicks->len` to set `chanrec->maxnickpos` on line 140 ensures correct truncation on line 181 using `g_string_truncate(chan->nicks, chan->maxnickpos)` and eliminates the extra separators added by line 137 `g_string_append_printf(chanrec->nicks, "%s, ", split->nick)` to prevent a trailing ", " (comma-space) in the nickname list before the "(+$3 more, use /NETSPLIT to show all of them)" suffix.