### PR TITLE
formats: fix hide_text_style and hide_colors to mitigate color bleed

### DIFF
--- a/src/fe-common/core/formats.c
+++ b/src/fe-common/core/formats.c
@@ -1546,9 +1546,13 @@ void format_send_as_gui_flags(TEXT_DEST_REC *dest, const char *text, SIGNAL_FUNC
 			break;
 		case 15:
 			/* remove all styling */
-			fgcolor = theme->default_color;
-			bgcolor = -1;
-			flags &= GUI_PRINT_FLAG_INDENT|GUI_PRINT_FLAG_MONOSPACE;
+			if (!hide_text_style) {
+				if (!hide_colors) {
+					fgcolor = theme->default_color;
+					bgcolor = -1;
+				}
+				flags &= GUI_PRINT_FLAG_INDENT | GUI_PRINT_FLAG_MONOSPACE;
+			}
 			break;
 		case 17:
 			if (!hide_text_style)


### PR DESCRIPTION
The changes make `hide_text_style` and `hide_colors` mitigate color bleed when processing the `^O` (15) control code without resetting the predefined colors for a given event type.

This PR partially addresses #1592.