### PR TITLE
make Irssi::Irc usable without dcc

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -6,7 +6,7 @@
 #define IRSSI_GLOBAL_CONFIG "irssi.conf" /* config file name in /etc/ */
 #define IRSSI_HOME_CONFIG "config" /* config file name in ~/.irssi/ */
 
-#define IRSSI_ABI_VERSION 57
+#define IRSSI_ABI_VERSION 58
 
 #define DEFAULT_SERVER_ADD_PORT 6667
 #define DEFAULT_SERVER_ADD_TLS_PORT 6697

--- a/src/core/network.c
+++ b/src/core/network.c
@@ -81,6 +81,14 @@ int i_io_channel_read_block(GIOChannel *channel, void *data, int len)
 	return received < len ? -1 : 0;
 }
 
+IPADDR ip4_any = { AF_INET,
+#if defined(IN6ADDR_ANY_INIT)
+	           IN6ADDR_ANY_INIT
+#else
+	           { INADDR_ANY }
+#endif
+};
+
 static void sin_set_ip(union sockaddr_union *so, const IPADDR *ip)
 {
 	if (ip == NULL) {

--- a/src/perl/irc/Dcc.xs
+++ b/src/perl/irc/Dcc.xs
@@ -1,7 +1,74 @@
 #define PERL_NO_GET_CONTEXT
 #include "module.h"
 
+static int initialized = FALSE;
+
+static void perl_dcc_fill_hash(HV *hv, DCC_REC *dcc)
+{
+	(void) hv_store(hv, "type", 4, new_pv(dcc_type2str(dcc->type)), 0);
+	(void) hv_store(hv, "orig_type", 9, new_pv(dcc_type2str(dcc->orig_type)), 0);
+	(void) hv_store(hv, "created", 7, newSViv(dcc->created), 0);
+
+	(void) hv_store(hv, "server", 6, iobject_bless(dcc->server), 0);
+	(void) hv_store(hv, "servertag", 9, new_pv(dcc->servertag), 0);
+	(void) hv_store(hv, "mynick", 6, new_pv(dcc->mynick), 0);
+	(void) hv_store(hv, "nick", 4, new_pv(dcc->nick), 0);
+
+	(void) hv_store(hv, "chat", 4, simple_iobject_bless(dcc->chat), 0);
+	(void) hv_store(hv, "target", 6, new_pv(dcc->target), 0);
+	(void) hv_store(hv, "arg", 3, new_pv(dcc->arg), 0);
+
+	(void) hv_store(hv, "addr", 4, new_pv(dcc->addrstr), 0);
+	(void) hv_store(hv, "port", 4, newSViv(dcc->port), 0);
+
+	(void) hv_store(hv, "starttime", 9, newSViv(dcc->starttime), 0);
+	(void) hv_store(hv, "transfd", 7, newSViv(dcc->transfd), 0);
+}
+
+static void perl_dcc_chat_fill_hash(HV *hv, CHAT_DCC_REC *dcc)
+{
+	perl_dcc_fill_hash(hv, (DCC_REC *) dcc);
+
+	(void) hv_store(hv, "id", 2, new_pv(dcc->id), 0);
+	(void) hv_store(hv, "mirc_ctcp", 9, newSViv(dcc->mirc_ctcp), 0);
+	(void) hv_store(hv, "connection_lost", 15, newSViv(dcc->connection_lost), 0);
+}
+
+static void perl_dcc_file_fill_hash(HV *hv, FILE_DCC_REC *dcc)
+{
+	perl_dcc_fill_hash(hv, (DCC_REC *) dcc);
+
+	(void) hv_store(hv, "size", 4, newSViv(dcc->size), 0);
+	(void) hv_store(hv, "skipped", 7, newSViv(dcc->skipped), 0);
+}
+
+static void perl_dcc_get_fill_hash(HV *hv, GET_DCC_REC *dcc)
+{
+	perl_dcc_file_fill_hash(hv, (FILE_DCC_REC *) dcc);
+
+	(void) hv_store(hv, "get_type", 8, newSViv(dcc->get_type), 0);
+	(void) hv_store(hv, "file", 4, new_pv(dcc->file), 0);
+	(void) hv_store(hv, "file_quoted", 11, newSViv(dcc->file_quoted), 0);
+}
+
+static void perl_dcc_send_fill_hash(HV *hv, SEND_DCC_REC *dcc)
+{
+	perl_dcc_file_fill_hash(hv, (FILE_DCC_REC *) dcc);
+
+	(void) hv_store(hv, "file_quoted", 11, newSViv(dcc->file_quoted), 0);
+	(void) hv_store(hv, "waitforend", 10, newSViv(dcc->waitforend), 0);
+	(void) hv_store(hv, "gotalldata", 10, newSViv(dcc->gotalldata), 0);
+}
+
+static PLAIN_OBJECT_INIT_REC irc_dcc_plains[] = { { "Irssi::Irc::Dcc",
+	                                            (PERL_OBJECT_FUNC) perl_dcc_fill_hash },
+
+	                                          { NULL, NULL } };
+
+/********************************/
+
 MODULE = Irssi::Irc::Dcc  PACKAGE = Irssi::Irc
+
 PROTOTYPES: ENABLE
 
 void
@@ -101,3 +168,38 @@ MODULE = Irssi::Irc::Dcc  PACKAGE = Irssi::Windowitem  PREFIX = item_
 Irssi::Irc::Dcc::Chat
 item_get_dcc(item)
 	Irssi::Windowitem item
+
+#*******************************
+MODULE = Irssi::Irc::Dcc  PACKAGE = Irssi::Irc::Dcc
+#*******************************
+
+void
+init()
+CODE:
+	if (initialized)
+		return;
+	perl_api_version_check("Irssi::Irc::Dcc");
+	initialized = TRUE;
+
+	irssi_add_object(module_get_uniq_id_str("DCC", "CHAT"), 0, "Irssi::Irc::Dcc::Chat",
+	                 (PERL_OBJECT_FUNC) perl_dcc_chat_fill_hash);
+	irssi_add_object(module_get_uniq_id_str("DCC", "GET"), 0, "Irssi::Irc::Dcc::Get",
+	                 (PERL_OBJECT_FUNC) perl_dcc_get_fill_hash);
+	irssi_add_object(module_get_uniq_id_str("DCC", "SEND"), 0, "Irssi::Irc::Dcc::Send",
+	                 (PERL_OBJECT_FUNC) perl_dcc_send_fill_hash);
+	irssi_add_object(module_get_uniq_id_str("DCC", "SERVER"), 0, "Irssi::Irc::Dcc::Server",
+	                 (PERL_OBJECT_FUNC) perl_dcc_send_fill_hash);
+	irssi_add_plains(irc_dcc_plains);
+	perl_eval_pv("@Irssi::Irc::Dcc::Chat::ISA = qw(Irssi::Irc::Dcc);\n"
+	             "@Irssi::Irc::Dcc::Get::ISA = qw(Irssi::Irc::Dcc);\n"
+	             "@Irssi::Irc::Dcc::Send::ISA = qw(Irssi::Irc::Dcc);\n"
+	             "@Irssi::Irc::Dcc::Server::ISA = qw(Irssi::Irc::Dcc);\n",
+	             TRUE);
+
+void
+deinit()
+CODE:
+	initialized = FALSE;
+
+BOOT:
+	/* nothing * /

--- a/src/perl/irc/Irc.xs
+++ b/src/perl/irc/Irc.xs
@@ -69,63 +69,6 @@ static void perl_ban_fill_hash(HV *hv, BAN_REC *ban)
 	(void) hv_store(hv, "time", 4, newSViv(ban->time), 0);
 }
 
-static void perl_dcc_fill_hash(HV *hv, DCC_REC *dcc)
-{
-	(void) hv_store(hv, "type", 4, new_pv(dcc_type2str(dcc->type)), 0);
-	(void) hv_store(hv, "orig_type", 9, new_pv(dcc_type2str(dcc->orig_type)), 0);
-	(void) hv_store(hv, "created", 7, newSViv(dcc->created), 0);
-
-	(void) hv_store(hv, "server", 6, iobject_bless(dcc->server), 0);
-	(void) hv_store(hv, "servertag", 9, new_pv(dcc->servertag), 0);
-	(void) hv_store(hv, "mynick", 6, new_pv(dcc->mynick), 0);
-	(void) hv_store(hv, "nick", 4, new_pv(dcc->nick), 0);
-
-	(void) hv_store(hv, "chat", 4, simple_iobject_bless(dcc->chat), 0);
-	(void) hv_store(hv, "target", 6, new_pv(dcc->target), 0);
-	(void) hv_store(hv, "arg", 3, new_pv(dcc->arg), 0);
-
-	(void) hv_store(hv, "addr", 4, new_pv(dcc->addrstr), 0);
-	(void) hv_store(hv, "port", 4, newSViv(dcc->port), 0);
-
-	(void) hv_store(hv, "starttime", 9, newSViv(dcc->starttime), 0);
-	(void) hv_store(hv, "transfd", 7, newSViv(dcc->transfd), 0);
-}
-
-static void perl_dcc_chat_fill_hash(HV *hv, CHAT_DCC_REC *dcc)
-{
-        perl_dcc_fill_hash(hv, (DCC_REC *) dcc);
-
-	(void) hv_store(hv, "id", 2, new_pv(dcc->id), 0);
-	(void) hv_store(hv, "mirc_ctcp", 9, newSViv(dcc->mirc_ctcp), 0);
-	(void) hv_store(hv, "connection_lost", 15, newSViv(dcc->connection_lost), 0);
-}
-
-static void perl_dcc_file_fill_hash(HV *hv, FILE_DCC_REC *dcc)
-{
-        perl_dcc_fill_hash(hv, (DCC_REC *) dcc);
-
-	(void) hv_store(hv, "size", 4, newSViv(dcc->size), 0);
-	(void) hv_store(hv, "skipped", 7, newSViv(dcc->skipped), 0);
-}
-
-static void perl_dcc_get_fill_hash(HV *hv, GET_DCC_REC *dcc)
-{
-        perl_dcc_file_fill_hash(hv, (FILE_DCC_REC *) dcc);
-
-	(void) hv_store(hv, "get_type", 8, newSViv(dcc->get_type), 0);
-	(void) hv_store(hv, "file", 4, new_pv(dcc->file), 0);
-	(void) hv_store(hv, "file_quoted", 11, newSViv(dcc->file_quoted), 0);
-}
-
-static void perl_dcc_send_fill_hash(HV *hv, SEND_DCC_REC *dcc)
-{
-        perl_dcc_file_fill_hash(hv, (FILE_DCC_REC *) dcc);
-
-	(void) hv_store(hv, "file_quoted", 11, newSViv(dcc->file_quoted), 0);
-	(void) hv_store(hv, "waitforend", 10, newSViv(dcc->waitforend), 0);
-	(void) hv_store(hv, "gotalldata", 10, newSViv(dcc->gotalldata), 0);
-}
-
 static void perl_netsplit_fill_hash(HV *hv, NETSPLIT_REC *netsplit)
 {
         AV *av;
@@ -195,7 +138,6 @@ static void perl_client_fill_hash(HV *hv, CLIENT_REC *client)
 
 static PLAIN_OBJECT_INIT_REC irc_plains[] = {
 	{ "Irssi::Irc::Ban", (PERL_OBJECT_FUNC) perl_ban_fill_hash },
-	{ "Irssi::Irc::Dcc", (PERL_OBJECT_FUNC) perl_dcc_fill_hash },
 	{ "Irssi::Irc::Netsplit", (PERL_OBJECT_FUNC) perl_netsplit_fill_hash },
 	{ "Irssi::Irc::Netsplitserver", (PERL_OBJECT_FUNC) perl_netsplit_server_fill_hash },
 	{ "Irssi::Irc::Netsplitchannel", (PERL_OBJECT_FUNC) perl_netsplit_channel_fill_hash },
@@ -244,27 +186,9 @@ CODE:
 	irssi_add_object(module_get_uniq_id("SERVER CONNECT", 0),
 			 chat_type, "Irssi::Irc::Connect",
 			 (PERL_OBJECT_FUNC) perl_irc_connect_fill_hash);
-	irssi_add_object(module_get_uniq_id("SERVER", 0),
-			 chat_type, "Irssi::Irc::Server",
-			 (PERL_OBJECT_FUNC) perl_irc_server_fill_hash);
-	irssi_add_object(module_get_uniq_id_str("DCC", "CHAT"),
-			 0, "Irssi::Irc::Dcc::Chat",
-			 (PERL_OBJECT_FUNC) perl_dcc_chat_fill_hash);
-	irssi_add_object(module_get_uniq_id_str("DCC", "GET"),
-			 0, "Irssi::Irc::Dcc::Get",
-			 (PERL_OBJECT_FUNC) perl_dcc_get_fill_hash);
-	irssi_add_object(module_get_uniq_id_str("DCC", "SEND"),
-			 0, "Irssi::Irc::Dcc::Send",
-			 (PERL_OBJECT_FUNC) perl_dcc_send_fill_hash);
-	irssi_add_object(module_get_uniq_id_str("DCC", "SERVER"),
-			 0, "Irssi::Irc::Dcc::Server",
-			 (PERL_OBJECT_FUNC) perl_dcc_send_fill_hash);
-        irssi_add_plains(irc_plains);
-	perl_eval_pv("@Irssi::Irc::Dcc::Chat::ISA = qw(Irssi::Irc::Dcc);\n"
-		     "@Irssi::Irc::Dcc::Get::ISA = qw(Irssi::Irc::Dcc);\n"
-		     "@Irssi::Irc::Dcc::Send::ISA = qw(Irssi::Irc::Dcc);\n"
-		     "@Irssi::Irc::Dcc::Server::ISA = qw(Irssi::Irc::Dcc);\n",
-		     TRUE);
+	irssi_add_object(module_get_uniq_id("SERVER", 0), chat_type, "Irssi::Irc::Server",
+	                 (PERL_OBJECT_FUNC) perl_irc_server_fill_hash);
+	irssi_add_plains(irc_plains);
 
 void
 deinit()
@@ -274,7 +198,6 @@ CODE:
 BOOT:
 	irssi_boot(Irc__Channel);
 	irssi_boot(Irc__Ctcp);
-	irssi_boot(Irc__Dcc);
 	irssi_boot(Irc__Modes);
 	irssi_boot(Irc__Netsplit);
 	irssi_boot(Irc__Notifylist);

--- a/src/perl/irc/Irc/Dcc.pm
+++ b/src/perl/irc/Irc/Dcc.pm
@@ -2,7 +2,7 @@
 # Perl interface to irssi functions.
 #
 
-package Irssi::Irc;
+package Irssi::Irc::Dcc;
 
 use strict;
 use vars qw($VERSION @ISA @EXPORT @EXPORT_OK);
@@ -16,17 +16,11 @@ require DynaLoader;
 @EXPORT = qw();
 @EXPORT_OK = qw();
 
-bootstrap Irssi::Irc $VERSION if (!Irssi::Core::is_static());
+bootstrap Irssi::Irc::Dcc $VERSION if (!Irssi::Core::is_static());
 
-Irssi::Irc::init();
+Irssi::Irc::Dcc::init();
 
 Irssi::EXPORT_ALL();
-
-eval {
-    local $@;
-    require Irssi::Irc::Dcc;
-    1;
-};
 
 1;
 

--- a/src/perl/irc/meson.build
+++ b/src/perl/irc/meson.build
@@ -4,7 +4,6 @@ shared_library('Irc',
       'Channel.xs',
       'Client.xs',
       'Ctcp.xs',
-      'Dcc.xs',
       'Irc.xs',
       'Modes.xs',
       'Netsplit.xs',
@@ -27,7 +26,7 @@ shared_library('Irc',
   include_directories : rootinc,
   implicit_include_directories : true,
   dependencies : dep + [ perl_dep ],
-  link_with : dl_cross_perl_core + dl_cross_irc_dcc + dl_cross_irc_notifylist + dl_cross_irc_core + dl_cross_irssi_main,
+  link_with : dl_cross_perl_core + dl_cross_irc_notifylist + dl_cross_irc_core + dl_cross_irssi_main,
   override_options : ['b_lundef=false'],
 )
 
@@ -36,6 +35,37 @@ install_headers(
     'Irc.pm',
   ),
   install_dir : perlmoddir / 'Irssi',
+)
+
+shared_library('Dcc',
+  [ xsubpp.process(
+    files(
+      'Dcc.xs',
+    ),
+    extra_args : [
+      '-typemap',
+      '../common/typemap',
+    ],
+  ) ]
+  + files(
+    'module.h',
+  ),
+  name_prefix : '',
+  name_suffix : perl_module_suffix,
+  install : true,
+  install_dir : perlmoddir / 'auto' / 'Irssi' / 'Irc' / 'Dcc',
+  include_directories : rootinc,
+  implicit_include_directories : true,
+  dependencies : dep + [ perl_dep ],
+  link_with : dl_cross_perl_core + dl_cross_irc_dcc + dl_cross_irc_core + dl_cross_irssi_main,
+  override_options : ['b_lundef=false'],
+)
+
+install_headers(
+  files(
+    'Irc/Dcc.pm',
+  ),
+  install_dir : perlmoddir / 'Irssi' / 'Irc',
 )
   
 # 'Makefile.PL.in',

--- a/src/perl/module.h
+++ b/src/perl/module.h
@@ -17,4 +17,4 @@ extern PerlInterpreter *my_perl; /* must be called my_perl or some perl implemen
 
 /* Change this every time when some API changes between irssi's perl module
    (or irssi itself) and irssi's perl libraries. */
-#define IRSSI_PERL_API_VERSION (20011214 + IRSSI_ABI_VERSION)
+#define IRSSI_PERL_API_VERSION (20160124 + IRSSI_ABI_VERSION)


### PR DESCRIPTION
moved the Perl dcc glue to a separate module Irssi::Irc::Dcc, allowing to use Irssi::Irc with dcc unloaded