### PR TITLE
Gio channel rename

### DIFF
--- a/.muon_fmt.ini
+++ b/.muon_fmt.ini
@@ -1,0 +1,14 @@
+# Irssi configuration for muon fmt
+max_line_len = 108
+indent_style = space
+indent_size = 2
+#indent_by = '  '
+space_array = true
+kwargs_force_multiline = true
+wide_colon = true
+no_single_comma_function = true
+insert_final_newline = true
+sort_files = false
+group_arg_value = true
+sticky_parens = true
+continuation_indent = true

--- a/docs/help/meson.build
+++ b/docs/help/meson.build
@@ -116,6 +116,7 @@ install_data(
     'whowas',
     'window',
   ),
-  install_dir : helpdir)
+  install_dir : helpdir,
+)
 
 # subdir('in')

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -13,6 +13,7 @@ install_data(
     'startup-HOWTO.html',
     'startup-HOWTO.txt',
   ),
-  install_dir : docdir)
+  install_dir : docdir,
+)
 
 subdir('help')

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,10 @@
-project('irssi', 'c',
+project(
+  'irssi',
+  'c',
   version : '1.5-head',
   meson_version : '>=0.53',
-  default_options : ['warning_level=1'])
+  default_options : [ 'warning_level=1' ],
+)
 
 ############################
 ############################
@@ -11,11 +14,11 @@ glib_pcre2_internal_version = 'pcre2-10.40'
 glib_libffi_internal_version = 'libffi'
 cc = meson.get_compiler('c')
 rootinc = include_directories('.')
-dep = []
-textui_dep = []
+dep = [  ]
+textui_dep = [  ]
 need_dl_cross_link = false
 need_dl_cross_link_main = false
-dl_cross_irssi_main = []
+dl_cross_irssi_main = [  ]
 # The Android environment requires that all modules are linked to each other.
 # See https://github.com/android/ndk/issues/201
 if host_machine.system() == 'android'
@@ -66,14 +69,33 @@ if fs.exists('config.status') or fs.exists('irssi-version.h') or fs.exists('defa
 endif
 
 UNSET = '=INVALID='
-UNSET_ARR = [UNSET]
+UNSET_ARR = [ UNSET ]
 
-chat_modules = ['irc']
+chat_modules = [ 'irc' ]
 
-run_command('mkdir', meson.current_build_dir() / incdir, check : false)
-run_command('ln', '-s', meson.current_source_dir() / 'src', meson.current_build_dir() / incdir, check : false)
-run_command('ln', '-s', meson.current_build_dir() / 'irssi-config.h', meson.current_build_dir() / incdir, check : false)
-run_command('ln', '-s', meson.current_build_dir() / 'irssi-version.h', meson.current_build_dir() / incdir, check : false)
+run_command(
+  'mkdir',
+  meson.current_build_dir() / incdir,
+  check : false,
+)
+run_command(
+  'ln',
+  '-s', meson.current_source_dir() / 'src',
+  meson.current_build_dir() / incdir,
+  check : false,
+)
+run_command(
+  'ln',
+  '-s', meson.current_build_dir() / 'irssi-config.h',
+  meson.current_build_dir() / incdir,
+  check : false,
+)
+run_command(
+  'ln',
+  '-s', meson.current_build_dir() / 'irssi-version.h',
+  meson.current_build_dir() / incdir,
+  check : false,
+)
 
 def_moduledir  = '-D' + 'MODULEDIR'  + '="' + (get_option('prefix') / moduledir) + '"'
 def_sysconfdir = '-D' + 'SYSCONFDIR' + '="' + (get_option('prefix') / get_option('sysconfdir')) + '"'
@@ -83,12 +105,11 @@ def_scriptdir  = '-D' + 'SCRIPTDIR'  + '="' + (get_option('prefix') / scriptdir)
 
 def_suppress_printf_fallback = '-D' + 'SUPPRESS_PRINTF_FALLBACK'
 
-
-module_suffix = []
-perl_module_suffix = []
+module_suffix = [  ]
+perl_module_suffix = [  ]
 # Meson uses the wrong module extensions on Mac.
 # https://gitlab.gnome.org/GNOME/glib/issues/520
-if ['darwin', 'ios'].contains(host_machine.system())
+if [ 'darwin', 'ios' ].contains(host_machine.system())
   module_suffix = 'so'
   perl_module_suffix = 'bundle'
 endif
@@ -97,13 +118,20 @@ endif
 # Help files #
 ##############
 
-build_perl = find_program('perl', native : true)
+build_perl = find_program(
+  'perl',
+  native : true,
+)
 if meson.is_cross_build()
   cross_perl = find_program('perl')
 else
   cross_perl = build_perl
 endif
-run_command(build_perl, files('utils/syntax.pl'), check : true)
+run_command(
+  build_perl,
+  files('utils/syntax.pl'),
+  check : true,
+)
 
 ###################
 # irssi-version.h #
@@ -111,12 +139,12 @@ run_command(build_perl, files('utils/syntax.pl'), check : true)
 
 env = find_program('env')
 irssi_version_sh = find_program('utils/irssi-version.sh')
-irssi_version_h = custom_target('irssi-version.h',
+irssi_version_h = custom_target(
+  'irssi-version.h',
   build_by_default : true,
   build_always_stale : true,
   capture : true,
-  command : [env, 'VERSION=' + meson.project_version(),
-    irssi_version_sh, meson.current_source_dir()],
+  command : [ env, 'VERSION=' + meson.project_version(), irssi_version_sh, meson.current_source_dir() ],
   output : 'irssi-version.h',
   install : true,
   install_dir : includedir / incdir,
@@ -127,22 +155,24 @@ irssi_version_h = custom_target('irssi-version.h',
 ####################
 
 file2header = find_program('utils/file2header.sh')
-default_config_h = custom_target('default-config.h',
+default_config_h = custom_target(
+  'default-config.h',
   input : files('irssi.conf'),
   output : 'default-config.h',
   capture : true,
-  command : [file2header, '@INPUT@', 'default_config'],
+  command : [ file2header, '@INPUT@', 'default_config' ],
 )
 
 ###################
 # default-theme.h #
 ###################
 
-default_theme_h = custom_target('default-theme.h',
+default_theme_h = custom_target(
+  'default-theme.h',
   input : files('themes/default.theme'),
   output : 'default-theme.h',
   capture : true,
-  command : [file2header, '@INPUT@', 'default_theme'],
+  command : [ file2header, '@INPUT@', 'default_theme' ],
 )
 
 ################
@@ -151,12 +181,18 @@ default_theme_h = custom_target('default-theme.h',
 
 #### inet_addr ####
 inet_addr_found = false
-foreach inet_addr_provider : ['', 'nsl']
-  prov_lib = []
+foreach inet_addr_provider : [ '', 'nsl' ]
+  prov_lib = [  ]
   if inet_addr_provider != ''
-    prov_lib += cc.find_library(inet_addr_provider, required : false)
+    prov_lib += cc.find_library(
+      inet_addr_provider,
+      required : false,
+    )
   endif
-  if (prov_lib.length() == 0 or prov_lib[0].found()) and cc.has_function('inet_addr', dependencies : prov_lib)
+  if (prov_lib.length() == 0 or prov_lib[0].found()) and cc.has_function(
+      'inet_addr',
+      dependencies : prov_lib,
+    )
     dep += prov_lib
     inet_addr_found = true
     break
@@ -168,12 +204,18 @@ endif
 
 #### socket ####
 socket_found = false
-foreach socket_provider : ['', 'socket', 'network']
-  prov_lib = []
+foreach socket_provider : [ '', 'socket', 'network' ]
+  prov_lib = [  ]
   if socket_provider != ''
-    prov_lib += cc.find_library(socket_provider, required : false)
+    prov_lib += cc.find_library(
+      socket_provider,
+      required : false,
+    )
   endif
-  if (prov_lib.length() == 0 or prov_lib[0].found()) and cc.has_function('socket', dependencies : prov_lib)
+  if (prov_lib.length() == 0 or prov_lib[0].found()) and cc.has_function(
+      'socket',
+      dependencies : prov_lib,
+    )
     dep += prov_lib
     socket_found = true
     break
@@ -183,7 +225,7 @@ if not socket_found
   error('socket not found')
 endif
 
-built_src = []
+built_src = [  ]
 glib_internal = false
 message('*** If you don\'t have GLib, you can run meson ... -Dinstall-glib=yes')
 message('*** to download and build it automatically')
@@ -191,54 +233,82 @@ message('*** Or alternatively install your distribution\'s package')
 message('*** On Debian: sudo apt-get install libglib2.0-dev')
 message('*** On Redhat: dnf install glib2-devel')
 if not require_glib_internal
-  glib_dep = dependency('glib-2.0', version : '>=2.32', required : not want_glib_internal, static : want_static_dependency, include_type : 'system')
+  glib_dep = dependency(
+    'glib-2.0',
+    version : '>=2.32',
+    required : not want_glib_internal,
+    static : want_static_dependency,
+    include_type : 'system',
+  )
 else
-  glib_dep = dependency('', required : false)
+  glib_dep = dependency(
+    '',
+    required : false,
+  )
 endif
 if not glib_dep.found()
   glib_internal = true
   meson_cmd = find_program('meson')
   ninja = find_program('ninja')
 
-  glib_internal_download_t = custom_target('glib-internal-download',
+  glib_internal_download_t = custom_target(
+    'glib-internal-download',
     command : [ meson_cmd, 'subprojects', 'download', 'glib', '--sourcedir', meson.current_source_dir() ],
     console : true,
-    output : ['glib-internal-download'],
+    output : [ 'glib-internal-download' ],
   )
 
   glib_internal_dependencies = [
     dependency('threads'),
   ]
-  glib_internal_configure_args = []
+  glib_internal_configure_args = [  ]
 
   glib_internal_usr_local = false
   if not cc.has_function('iconv_open')
-    prov_lib = cc.find_library('iconv', required : false)
+    prov_lib = cc.find_library(
+      'iconv',
+      required : false,
+    )
     if not prov_lib.found()
-      prov_lib = cc.find_library('iconv', dirs : '/usr/local/lib')
+      prov_lib = cc.find_library(
+        'iconv',
+        dirs : '/usr/local/lib',
+      )
       glib_internal_usr_local = true
     endif
     glib_internal_dependencies += prov_lib
   endif
 
   if not cc.has_function('ngettext')
-    prov_lib = cc.find_library('intl', required : false)
+    prov_lib = cc.find_library(
+      'intl',
+      required : false,
+    )
     if not prov_lib.found()
-      prov_lib = cc.find_library('intl', dirs : '/usr/local/lib')
+      prov_lib = cc.find_library(
+        'intl',
+        dirs : '/usr/local/lib',
+      )
       glib_internal_usr_local = true
     endif
     glib_internal_dependencies += prov_lib
   endif
 
   if glib_internal_usr_local
-    glib_internal_configure_args += ['-Dc_args=-I/usr/local/include', '-Dc_link_args=-L/usr/local/lib']
+    glib_internal_configure_args += [ '-Dc_args=-I/usr/local/include', '-Dc_link_args=-L/usr/local/lib' ]
   endif
 
   if not cc.has_function('getxattr') or not cc.has_header('sys/xattr.h')
     if cc.has_header_symbol('attr/xattr.h', 'getxattr')
-      prov_lib = cc.find_library('xattr', required : false)
+      prov_lib = cc.find_library(
+        'xattr',
+        required : false,
+      )
     else
-      prov_lib = dependency('', required : false)
+      prov_lib = dependency(
+        '',
+        required : false,
+      )
     endif
     if prov_lib.found()
       glib_internal_dependencies += prov_lib
@@ -247,28 +317,41 @@ if not glib_dep.found()
     endif
   endif
 
-  glib_internal_configure_t = custom_target('glib-internal-configure',
-    command : [ meson_cmd, 'setup', '--prefix=/irssi-glib-internal',
+  glib_internal_configure_t = custom_target(
+    'glib-internal-configure',
+    command : [
+      meson_cmd,
+      'setup',
+      '--prefix=/irssi-glib-internal',
       '--buildtype=' + get_option('buildtype'),
-      '-Dlibmount=disabled', '-Dselinux=disabled', '-Ddefault_library=static', '-Dforce_fallback_for=pcre2,libffi',
+      '-Dlibmount=disabled',
+      '-Dselinux=disabled',
+      '-Ddefault_library=static',
+      '-Dforce_fallback_for=pcre2,libffi',
       glib_internal_configure_args,
       (meson.current_build_dir() / 'build-subprojects' / 'glib'),
-      (meson.current_source_dir() / 'subprojects' / glib_internal_version) ],
+      (meson.current_source_dir() / 'subprojects' / glib_internal_version),
+    ],
     console : true,
-    output : ['glib-internal-configure'],
-    depends : glib_internal_download_t,)
-  glib_internal_build_t = custom_target('glib-internal-build',
-    command : [ ninja, '-C', meson.current_build_dir() / 'build-subprojects' / 'glib',
+    output : [ 'glib-internal-configure' ],
+    depends : glib_internal_download_t,
+  )
+  glib_internal_build_t = custom_target(
+    'glib-internal-build',
+    command : [
+      ninja,
+      '-C', meson.current_build_dir() / 'build-subprojects' / 'glib',
       'subprojects' / glib_libffi_internal_version / 'src' / 'libffi.a',
       'subprojects' / glib_pcre2_internal_version / 'libpcre2-8.a',
       'glib' / 'libglib-2.0.a',
       'gmodule' / 'libgmodule-2.0.a',
       'gobject' / 'libgobject-2.0.a',
       'gio' / 'libgio-2.0.a',
-      ],
+    ],
     console : true,
-    output : ['glib-internal-build'],
-    depends : glib_internal_configure_t,)
+    output : [ 'glib-internal-build' ],
+    depends : glib_internal_configure_t,
+  )
   glib_dep = declare_dependency(
     dependencies : glib_internal_dependencies,
     sources : glib_internal_build_t,
@@ -283,28 +366,37 @@ if not glib_dep.found()
     ],
   )
   built_src += glib_internal_build_t
-  libdl_dep = []
-  prov_lib = cc.find_library('dl', required : false)
-  if prov_lib.found() and cc.has_function('dlopen', dependencies : prov_lib)
+  libdl_dep = [  ]
+  prov_lib = cc.find_library(
+    'dl',
+    required : false,
+  )
+  if prov_lib.found() and cc.has_function(
+      'dlopen',
+      dependencies : prov_lib,
+    )
     libdl_dep += prov_lib
   endif
-  gmodule_dep = declare_dependency(sources : glib_internal_build_t,
+  gmodule_dep = declare_dependency(
+    sources : glib_internal_build_t,
     dependencies : libdl_dep,
     compile_args : [
       '-isystem' + (meson.current_source_dir() / 'subprojects' / glib_internal_version / 'gmodule'),
     ],
     link_args : [ meson.current_build_dir() / 'build-subprojects' / 'glib' / 'gmodule' / 'libgmodule-2.0.a' ],
   )
-  gobject_dep = declare_dependency(sources : glib_internal_build_t,
+  gobject_dep = declare_dependency(
+    sources : glib_internal_build_t,
     compile_args : [
       '-isystem' + (meson.current_build_dir() / 'build-subprojects' / 'glib'),
     ],
     link_args : [
       meson.current_build_dir() / 'build-subprojects' / 'glib' / 'subprojects' / glib_libffi_internal_version / 'src' / 'libffi.a',
-      meson.current_build_dir() / 'build-subprojects' / 'glib' / 'gobject' / 'libgobject-2.0.a'
+      meson.current_build_dir() / 'build-subprojects' / 'glib' / 'gobject' / 'libgobject-2.0.a',
     ],
   )
-  gio_dep = declare_dependency(sources : glib_internal_build_t,
+  gio_dep = declare_dependency(
+    sources : glib_internal_build_t,
     dependencies : cc.find_library('z'),
     compile_args : [
       '-isystem' + (meson.current_source_dir() / 'subprojects' / glib_internal_version / 'gio'),
@@ -313,9 +405,21 @@ if not glib_dep.found()
     link_args : [ meson.current_build_dir() / 'build-subprojects' / 'glib' / 'gio' / 'libgio-2.0.a' ],
   )
 else
-  gmodule_dep = dependency('gmodule-2.0', static : want_static_dependency, include_type : 'system')
-  gobject_dep = dependency('gobject-2.0', static : want_static_dependency, include_type : 'system')
-  gio_dep = dependency('gio-2.0', static : want_static_dependency, include_type : 'system')
+  gmodule_dep = dependency(
+    'gmodule-2.0',
+    static : want_static_dependency,
+    include_type : 'system',
+  )
+  gobject_dep = dependency(
+    'gobject-2.0',
+    static : want_static_dependency,
+    include_type : 'system',
+  )
+  gio_dep = dependency(
+    'gio-2.0',
+    static : want_static_dependency,
+    include_type : 'system',
+  )
 endif
 dep += glib_dep
 dep += gmodule_dep
@@ -323,10 +427,17 @@ dep += gobject_dep
 dep += gio_dep
 
 if glib_internal and want_static_dependency and want_fuzzer
-  openssl_proj = subproject('openssl', default_options : ['default_library=static', 'asm=disabled'])
+  openssl_proj = subproject(
+    'openssl',
+    default_options : [ 'default_library=static', 'asm=disabled' ],
+  )
   openssl_dep = openssl_proj.get_variable('openssl_dep')
 else
-  openssl_dep = dependency('openssl', static : want_static_dependency, include_type : 'system')
+  openssl_dep = dependency(
+    'openssl',
+    static : want_static_dependency,
+    include_type : 'system',
+  )
 endif
 dep += openssl_dep
 
@@ -335,10 +446,16 @@ dep += openssl_dep
 ############
 
 have_libutf8proc = false
-libutf8proc = []
+libutf8proc = [  ]
 if want_libutf8proc
-  libutf8proc = cc.find_library('utf8proc', required : require_libutf8proc)
-  have_libutf8proc = cc.has_function('utf8proc_version', dependencies : libutf8proc)
+  libutf8proc = cc.find_library(
+    'utf8proc',
+    required : require_libutf8proc,
+  )
+  have_libutf8proc = cc.has_function(
+    'utf8proc_version',
+    dependencies : libutf8proc,
+  )
   if have_libutf8proc
     dep += libutf8proc
   endif
@@ -353,9 +470,15 @@ endif
 
 if want_textui
   setupterm_found = false
-  foreach setupterm_provider : ['tinfo', 'ncursesw', 'ncurses', 'terminfo']
-    prov_lib = cc.find_library(setupterm_provider, required : false)
-    if prov_lib.found() and cc.has_function('setupterm', dependencies : prov_lib)
+  foreach setupterm_provider : [ 'tinfo', 'ncursesw', 'ncurses', 'terminfo' ]
+    prov_lib = cc.find_library(
+      setupterm_provider,
+      required : false,
+    )
+    if prov_lib.found() and cc.has_function(
+        'setupterm',
+        dependencies : prov_lib,
+      )
       textui_dep += prov_lib
       setupterm_found = true
       break
@@ -372,15 +495,20 @@ endif
 
 have_perl = false
 if want_perl
-  perl_cflags = []
-  perl_ldflags = []
-  perl_rpath_flags = []
+  perl_cflags = [  ]
+  perl_ldflags = [  ]
+  perl_rpath_flags = [  ]
   perl_rpath = ''
 
   #### ccopts ####
   perl_ccopts = meson.get_cross_property('perl_ccopts', UNSET_ARR)
   if perl_ccopts == UNSET_ARR
-    res = run_command(cross_perl, '-MExtUtils::Embed', '-e', 'ccopts', check : true)
+    res = run_command(
+      cross_perl,
+      '-MExtUtils::Embed',
+      '-e', 'ccopts',
+      check : true,
+    )
     perl_ccopts = res.stdout().strip().split()
   endif
   foreach fl : perl_ccopts
@@ -397,10 +525,15 @@ if want_perl
   #### ldopts ####
   perl_ldopts = meson.get_cross_property('perl_ldopts', UNSET_ARR)
   if perl_ldopts == UNSET_ARR
-    res = run_command(cross_perl, '-MExtUtils::Embed', '-e', 'ldopts', check : true)
+    res = run_command(
+      cross_perl,
+      '-MExtUtils::Embed',
+      '-e', 'ldopts',
+      check : true,
+    )
     perl_ldopts = res.stdout().strip().split()
   endif
-  skip_libs = ['-ldb', '-ldbm', '-lndbm', '-lgdbm', '-lc', '-lposix', '-rdynamic']
+  skip_libs = [ '-ldb', '-ldbm', '-lndbm', '-lgdbm', '-lc', '-lposix', '-rdynamic' ]
   foreach fl : perl_ldopts
     if not fl.startswith('-A') and not skip_libs.contains(fl)
       if fl.startswith('-Wl,-rpath,')
@@ -414,18 +547,26 @@ if want_perl
 
   perl_version = meson.get_cross_property('perl_version', UNSET)
   if perl_version == UNSET
-    perl_version = run_command(cross_perl, '-V::version:', check : true).stdout().split('\'')[1]
+    perl_version = run_command(
+      cross_perl,
+      '-V::version:',
+      check : true,
+    ).stdout().split('\'')[1]
   endif
 
   # disable clang warning
   if perl_version.version_compare('<5.35.2')
     perl_cflags += cc.get_supported_arguments('-Wno-compound-token-split-by-macro')
   endif
-  perl_dep = declare_dependency(compile_args : perl_cflags, link_args : perl_ldflags,
-    version : perl_version)
+  perl_dep = declare_dependency(
+    compile_args : perl_cflags,
+    link_args : perl_ldflags,
+    version : perl_version,
+  )
 
   ####
-  if not cc.links('''
+  if not cc.links(
+      '''
 #include <EXTERN.h>
 #include <perl.h>
 int main()
@@ -433,8 +574,10 @@ int main()
   perl_alloc();
   return 0;
 }
-''', args : perl_cflags + perl_ldflags + perl_rpath_flags,
-     name : 'working Perl support')
+''',
+      args : perl_cflags + perl_ldflags + perl_rpath_flags,
+      name : 'working Perl support',
+    )
     if require_perl
       error('error linking with perl libraries')
     else
@@ -443,9 +586,15 @@ int main()
   else
     xsubpp_file_c = meson.get_cross_property('perl_xsubpp', UNSET)
     if xsubpp_file_c == UNSET
-      xsubpp_file_c = run_command(build_perl, '-MExtUtils::ParseXS', '-e($r = $INC{"ExtUtils/ParseXS.pm"}) =~ s{ParseXS\\.pm$}{xsubpp}; print $r', check : true).stdout()
+      xsubpp_file_c = run_command(
+        build_perl,
+        '-MExtUtils::ParseXS',
+        '-e($r = $INC{"ExtUtils/ParseXS.pm"}) =~ s{ParseXS\\.pm$}{xsubpp}; print $r',
+        check : true,
+      ).stdout()
     endif
-    xsubpp = generator(build_perl,
+    xsubpp = generator(
+      build_perl,
       output : '@BASENAME@.c',
       capture : true,
       arguments : [ xsubpp_file_c, '@EXTRA_ARGS@', '@INPUT@' ],
@@ -453,31 +602,44 @@ int main()
     xsubpp_file = files(xsubpp_file_c)
 
     if with_perl_lib == 'module'
-      perl_install_base = run_command(build_perl, '-MText::ParseWords=shellwords', '-e', 'grep { s/^INSTALL_BASE=// && print && exit } shellwords $ENV{PERL_MM_OPT}', check : true).stdout()
+      perl_install_base = run_command(
+        build_perl,
+        '-MText::ParseWords=shellwords',
+        '-e', 'grep { s/^INSTALL_BASE=// && print && exit } shellwords $ENV{PERL_MM_OPT}',
+        check : true,
+      ).stdout()
       if perl_install_base == ''
         with_perl_lib = ''
       endif
     endif
     if with_perl_lib == ''
-      if get_option('prefix') in ['/usr/local', 'C:/']
+      if get_option('prefix') in [ '/usr/local', 'C:/' ]
         with_perl_lib = 'site'
-      elif get_option('prefix') in ['/usr']
+      elif get_option('prefix') in [ '/usr' ]
         with_perl_lib = 'vendor'
       endif
     endif
     perlmoddir = ''
-    if with_perl_lib in ['site', 'vendor', 'module']
+    if with_perl_lib in [ 'site', 'vendor', 'module' ]
       set_perl_use_lib = false
       perl_library_dir = with_perl_lib + ' default'
-      if with_perl_lib in ['site', 'vendor']
+      if with_perl_lib in [ 'site', 'vendor' ]
         perlmoddir = meson.get_cross_property('perl_install' + with_perl_lib + 'arch', UNSET)
         if perlmoddir == UNSET
-          perlmoddir = run_command(cross_perl, '-V::install' + with_perl_lib + 'arch:', check : true).stdout().split('\'')[1]
+          perlmoddir = run_command(
+            cross_perl,
+            '-V::install' + with_perl_lib + 'arch:',
+            check : true,
+          ).stdout().split('\'')[1]
         endif
       elif with_perl_lib == 'module'
         perl_archname = meson.get_cross_property('perl_archname', UNSET)
         if perl_archname == UNSET
-          perl_archname = run_command(cross_perl, '-V::archname:', check : true).stdout().split('\'')[1]
+          perl_archname = run_command(
+            cross_perl,
+            '-V::archname:',
+            check : true,
+          ).stdout().split('\'')[1]
         endif
         perlmoddir = perl_install_base / 'lib' / 'perl5' / perl_archname
       endif
@@ -498,7 +660,12 @@ int main()
     if set_perl_use_lib
       perl_inc = meson.get_cross_property('perl_inc', UNSET_ARR)
       if perl_inc == UNSET_ARR
-        set_perl_use_lib = run_command(cross_perl, '-e', 'exit ! grep $_ eq $ARGV[0], grep /^\\//, @INC', perl_use_lib, check : false).returncode() != 0
+        set_perl_use_lib = run_command(
+          cross_perl,
+          '-e', 'exit ! grep $_ eq $ARGV[0], grep /^\\//, @INC',
+          perl_use_lib,
+          check : false,
+        ).returncode() != 0
       else
         set_perl_use_lib = not perl_inc.contains(perl_use_lib)
       endif
@@ -524,8 +691,20 @@ endif
 
 have_otr = false
 if want_otr
-  libgcrypt = dependency('libgcrypt', version : '>=1.2.0', required : require_otr, static : want_static_dependency, include_type : 'system')
-  libotr = dependency('libotr', version : '>=4.1.0', required : require_otr, static : want_static_dependency, include_type : 'system')
+  libgcrypt = dependency(
+    'libgcrypt',
+    version : '>=1.2.0',
+    required : require_otr,
+    static : want_static_dependency,
+    include_type : 'system',
+  )
+  libotr = dependency(
+    'libotr',
+    version : '>=4.1.0',
+    required : require_otr,
+    static : want_static_dependency,
+    include_type : 'system',
+  )
   if libgcrypt.found() and libotr.found()
     dep += libgcrypt
     dep += libotr
@@ -539,9 +718,19 @@ endif
 
 have_capsicum = false
 if want_capsicum
-  if cc.has_function('cap_enter', dependencies : cc.find_library('c'))
-    libnv = cc.find_library('nv', required : require_capsicum)
-    nvlist_create_found = libnv.found() and cc.has_function('nvlist_create', dependencies : libnv, prefix : '#include <sys/nv.h>')
+  if cc.has_function(
+      'cap_enter',
+      dependencies : cc.find_library('c'),
+    )
+    libnv = cc.find_library(
+      'nv',
+      required : require_capsicum,
+    )
+    nvlist_create_found = libnv.found() and cc.has_function(
+      'nvlist_create',
+      dependencies : libnv,
+      prefix : '#include <sys/nv.h>',
+    )
     if nvlist_create_found
       dep += libnv
       have_capsicum = true
@@ -558,11 +747,14 @@ if want_capsicum
 endif
 
 # dependency helper sets
-dep_cflagsonly = []
+dep_cflagsonly = [  ]
 foreach d : dep
-  dep_cflagsonly += d.partial_dependency(includes : true, compile_args : true)
+  dep_cflagsonly += d.partial_dependency(
+    includes : true,
+    compile_args : true,
+  )
 endforeach
-dl_cross_dep = []
+dl_cross_dep = [  ]
 if need_dl_cross_link
   dl_cross_dep = dep
 endif
@@ -573,11 +765,19 @@ endif
 
 conf = configuration_data()
 
-conf.set('HAVE_CAPSICUM', have_capsicum, description : 'Build with Capsicum support')
+conf.set(
+  'HAVE_CAPSICUM',
+  have_capsicum,
+  description : 'Build with Capsicum support',
+)
 conf.set('HAVE_GMODULE', true)
 conf.set('TERM_TRUECOLOR', true)
 conf.set('USE_GREGEX', true)
-conf.set10('_DARWIN_USE_64_BIT_INODE', true, description : 'Enable large inode numbers on Mac OS X 10.5.')
+conf.set10(
+  '_DARWIN_USE_64_BIT_INODE',
+  true,
+  description : 'Enable large inode numbers on Mac OS X 10.5.',
+)
 conf.set_quoted('FHS_PREFIX', get_option('fhs-prefix'))
 
 headers = [
@@ -591,31 +791,50 @@ headers = [
 ]
 foreach h : headers
   if cc.has_header(h)
-    conf.set('HAVE_' + h.underscorify().to_upper(), 1, description : 'Define to 1 if you have the <' + h + '> header file.')
+    conf.set(
+      'HAVE_' + h.underscorify().to_upper(),
+      1,
+      description : 'Define to 1 if you have the <' + h + '> header file.',
+    )
   endif
 endforeach
 
 if want_textui and conf.get('HAVE_TERM_H', 0) == 1
-  if cc.links('''
+  if cc.links(
+      '''
 #include <stdio.h>
 #include <term.h>
 int main (void) {
   return tputs("x", 1, putchar);
 }
-''', args : '-pedantic-errors', dependencies : textui_dep, name : 'Curses working')
+''',
+      args : '-pedantic-errors',
+      dependencies : textui_dep,
+      name : 'Curses working',
+    )
     # ok
   else
     has_curses_h = cc.has_header('curses.h')
-    if has_curses_h and cc.links('''
+    if has_curses_h and cc.links(
+        '''
 #include <curses.h>
 #include <term.h>
 int main (void) {
   return tputs("x", 1, putchar);
 }
-''', args : '-pedantic-errors', dependencies : textui_dep, name : 'Curses working with curses.h')
-      conf.set('NEED_CURSES_H', 1, description : 'tputs needs curses.h')
+''',
+        args : '-pedantic-errors',
+        dependencies : textui_dep,
+        name : 'Curses working with curses.h',
+      )
+      conf.set(
+        'NEED_CURSES_H',
+        1,
+        description : 'tputs needs curses.h',
+      )
     else
-      if has_curses_h and cc.links('''
+      if has_curses_h and cc.links(
+          '''
 #include <curses.h>
 #include <term.h>
 int char_putchar (char c) {
@@ -624,9 +843,21 @@ int char_putchar (char c) {
 int main (void) {
   return tputs("x", 1, char_putchar);
 }
-''', args : '-pedantic-errors', dependencies : textui_dep, name : 'Curses with tputs third argument arg char')
-        conf.set('NEED_CURSES_H', 1, description : 'tputs needs curses.h')
-        conf.set('TPUTS_SVR4', 1, description : 'third argument of tputs has the type int (*)(char)')
+''',
+          args : '-pedantic-errors',
+          dependencies : textui_dep,
+          name : 'Curses with tputs third argument arg char',
+        )
+        conf.set(
+          'NEED_CURSES_H',
+          1,
+          description : 'tputs needs curses.h',
+        )
+        conf.set(
+          'TPUTS_SVR4',
+          1,
+          description : 'third argument of tputs has the type int (*)(char)',
+        )
       else
         error('could not link terminfo')
       endif
@@ -638,21 +869,32 @@ conf.set('HAVE_LIBUTF8PROC', have_libutf8proc)
 conf.set_quoted('PACKAGE_VERSION', package_version)
 conf.set_quoted('PACKAGE_TARNAME', meson.project_name())
 
-configure_file(output : 'irssi-config.h',
+configure_file(
+  output : 'irssi-config.h',
   configuration : conf,
-  install_dir : includedir / incdir)
+  install_dir : includedir / incdir,
+)
 
 ##########
 # CFLAGS #
 ##########
 
 #### warnings ####
-add_project_arguments(cc.get_supported_arguments('-Werror=declaration-after-statement'), language : 'c')
+add_project_arguments(
+  cc.get_supported_arguments('-Werror=declaration-after-statement'),
+  language : 'c',
+)
 
 #### personality ####
-add_project_arguments(cc.get_supported_arguments('-fno-strict-aliasing'), language : 'c')
+add_project_arguments(
+  cc.get_supported_arguments('-fno-strict-aliasing'),
+  language : 'c',
+)
 if get_option('buildtype').contains('debug')
-  add_project_arguments(cc.get_supported_arguments('-fno-omit-frame-pointer'), language : 'c')
+  add_project_arguments(
+    cc.get_supported_arguments('-fno-omit-frame-pointer'),
+    language : 'c',
+  )
 endif
 
 if want_fuzzer
@@ -660,7 +902,10 @@ if want_fuzzer
     if not cc.has_argument('-fsanitize=fuzzer-no-link')
       error('compiler does not support -fsanitize=fuzzer-no-link, try clang?')
     endif
-    add_project_arguments('-fsanitize=fuzzer-no-link', language : 'c')
+    add_project_arguments(
+      '-fsanitize=fuzzer-no-link',
+      language : 'c',
+    )
   endif
   if fuzzer_link_language != 'c'
     add_languages(fuzzer_link_language)
@@ -672,7 +917,7 @@ endif
 ##############
 
 pc = import('pkgconfig')
-pc_requires = []
+pc_requires = [  ]
 if not glib_internal
   pc_requires += glib_dep
 endif
@@ -687,7 +932,8 @@ if signalsfile.startswith('/')
 else
   signalsfile = '${prefix}' / signalsfile
 endif
-pc.generate(filebase : 'irssi-1',
+pc.generate(
+  filebase : 'irssi-1',
   name : 'Irssi',
   description : 'Irssi chat client',
   version : package_version,

--- a/scripts/meson.build
+++ b/scripts/meson.build
@@ -11,4 +11,5 @@ install_data(
     'scriptassist.pl',
     'usercount.pl',
   ),
-  install_dir : scriptdir)
+  install_dir : scriptdir,
+)

--- a/src/core/meson.build
+++ b/src/core/meson.build
@@ -3,10 +3,11 @@
 if have_capsicum
   core_capsicum_source = files('capsicum.c')
 else
-  core_capsicum_source = []
+  core_capsicum_source = [  ]
 endif
 
-libcore_a = static_library('core',
+libcore_a = static_library(
+  'core',
   files(
     'args.c',
     'channels-setup.c',
@@ -63,7 +64,8 @@ libcore_a = static_library('core',
     def_moduledir,
     def_sysconfdir,
   ],
-  dependencies : dep)
+  dependencies : dep,
+)
 
 install_headers(
   files(
@@ -122,4 +124,5 @@ install_headers(
     'window-item-def.h',
     'write-buffer.h',
   ),
-  subdir : incdir / 'src' / 'core')
+  subdir : incdir / 'src' / 'core',
+)

--- a/src/core/net-disconnect.h
+++ b/src/core/net-disconnect.h
@@ -1,9 +1,11 @@
 #ifndef IRSSI_CORE_NET_DISCONNECT_H
 #define IRSSI_CORE_NET_DISCONNECT_H
 
+#include <irssi/src/common.h>
+
 /* Try to let the other side close the connection, if it still isn't
    disconnected after certain amount of time, close it ourself */
-void net_disconnect_later(GIOChannel *handle);
+void net_disconnect_later(NET_SENDBUF_REC *handle);
 
 void net_disconnect_init(void);
 void net_disconnect_deinit(void);

--- a/src/core/net-sendbuffer.h
+++ b/src/core/net-sendbuffer.h
@@ -1,24 +1,26 @@
 #ifndef IRSSI_CORE_NET_SENDBUFFER_H
 #define IRSSI_CORE_NET_SENDBUFFER_H
 
+#include <irssi/src/common.h>
+
 #define DEFAULT_BUFFER_SIZE 8192
 #define MAX_BUFFER_SIZE 1048576
 
 struct _NET_SENDBUF_REC {
-        GIOChannel *handle;
-        LINEBUF_REC *readbuffer; /* receive buffer */
+	GIOChannel *channel;
+	LINEBUF_REC *readbuffer; /* receive buffer */
 
-        int send_tag;
-        int bufsize;
-        int bufpos;
-        char *buffer; /* Buffer is NULL until it's actually needed. */
-        int def_bufsize;
-        unsigned int dead:1;
+	int send_tag;
+	int bufsize;
+	int bufpos;
+	char *buffer; /* Buffer is NULL until it's actually needed. */
+	int def_bufsize;
+	unsigned int dead : 1;
 };
 
 /* Create new buffer - if `bufsize' is zero or less, DEFAULT_BUFFER_SIZE
    is used */
-NET_SENDBUF_REC *net_sendbuffer_create(GIOChannel *handle, int bufsize);
+NET_SENDBUF_REC *net_sendbuffer_create_channel(GIOChannel *channel, int bufsize);
 /* Destroy the buffer. `close' specifies if socket handle should be closed. */
 void net_sendbuffer_destroy(NET_SENDBUF_REC *rec, int close);
 
@@ -33,6 +35,6 @@ int net_sendbuffer_receive_line(NET_SENDBUF_REC *rec, char **str, int read_socke
 void net_sendbuffer_flush(NET_SENDBUF_REC *rec);
 
 /* Returns the socket handle */
-GIOChannel *net_sendbuffer_handle(NET_SENDBUF_REC *rec);
+GIOChannel *net_sendbuffer_channel(NET_SENDBUF_REC *rec);
 
 #endif

--- a/src/core/network.h
+++ b/src/core/network.h
@@ -57,34 +57,34 @@ int i_io_channel_read_block(GIOChannel *channel, void *data, int len);
 int net_connect_ip_handle(const IPADDR *ip, int port, const IPADDR *my_ip);
 
 /* Connect to socket with ip address and SSL*/
-GIOChannel *net_connect_ip_ssl(IPADDR *ip, int port, IPADDR *my_ip, SERVER_REC *server);
+GIOChannel *net_connect_ip_ssl_channel(IPADDR *ip, int port, IPADDR *my_ip, SERVER_REC *server);
 /* Start TLS */
-GIOChannel *net_start_ssl(SERVER_REC *server);
+GIOChannel *net_start_ssl_channel(SERVER_REC *server);
 
-int irssi_ssl_handshake(GIOChannel *handle);
+int irssi_ssl_handshake_channel(GIOChannel *channel);
 /* Connect to socket with ip address */
-GIOChannel *net_connect_ip(IPADDR *ip, int port, IPADDR *my_ip);
+GIOChannel *net_connect_ip_channel(IPADDR *ip, int port, IPADDR *my_ip);
 /* Connect to named UNIX socket */
-GIOChannel *net_connect_unix(const char *path);
+GIOChannel *net_connect_unix_channel(const char *path);
 /* Disconnect socket */
-void net_disconnect(GIOChannel *handle);
+void net_disconnect_channel(GIOChannel *channel);
 
 /* Listen for connections on a socket */
-GIOChannel *net_listen(IPADDR *my_ip, int *port);
+GIOChannel *net_listen_channel(IPADDR *my_ip, int *port);
 /* Accept a connection on a socket */
-GIOChannel *net_accept(GIOChannel *handle, IPADDR *addr, int *port);
+GIOChannel *net_accept_channel(GIOChannel *channel, IPADDR *addr, int *port);
 
 /* Read data from socket, return number of bytes read, -1 = error */
-int net_receive(GIOChannel *handle, char *buf, int len);
+int net_receive_channel(GIOChannel *channel, char *buf, int len);
 /* Transmit data, return number of bytes sent, -1 = error */
-int net_transmit(GIOChannel *handle, const char *data, int len);
+int net_transmit_channel(GIOChannel *channel, const char *data, int len);
 
 /* Get the first IP address for host, both IPv4 and IPv6 if possible. */
 int net_gethostbyname_first_ips(const char *addr, GResolverNameLookupFlags flags, IPADDR *ip4,
                                 IPADDR *ip6);
 
 /* Get socket address/port */
-int net_getsockname(GIOChannel *handle, IPADDR *addr, int *port);
+int net_getsockname_channel(GIOChannel *channel, IPADDR *addr, int *port);
 
 /* IPADDR -> char* translation. `host' must be at least MAX_IP_LEN bytes */
 int net_ip2host(IPADDR *ip, char *host);
@@ -92,7 +92,7 @@ int net_ip2host(IPADDR *ip, char *host);
 int net_host2ip(const char *host, IPADDR *ip);
 
 /* Get socket error */
-int net_geterror(GIOChannel *handle);
+int net_geterror_channel(GIOChannel *channel);
 
 /* Get name of TCP service */
 char *net_getservbyport(int port);

--- a/src/core/server-connect-rec.h
+++ b/src/core/server-connect-rec.h
@@ -34,7 +34,7 @@ char *tls_ciphers;
 char *tls_pinned_cert;
 char *tls_pinned_pubkey;
 
-GIOChannel *connect_handle; /* connect using this handle */
+GIOChannel *connect_channel; /* connect using this handle */
 
 /* when reconnecting, the old server status */
 unsigned int reconnection:1; /* we're trying to reconnect a connected server */

--- a/src/core/session.c
+++ b/src/core/session.c
@@ -175,13 +175,13 @@ static void session_save_server(SERVER_REC *server, CONFIG_REC *config,
 	config_node_set_str(config, node, "tls_pinned_cert", server->connrec->tls_pinned_cert);
 	config_node_set_str(config, node, "tls_pinned_pubkey", server->connrec->tls_pinned_pubkey);
 
-	handle = g_io_channel_unix_get_fd(net_sendbuffer_handle(server->handle));
+	handle = g_io_channel_unix_get_fd(net_sendbuffer_channel(server->handle));
 	config_node_set_int(config, node, "handle", handle);
 
 	signal_emit("session save server", 3, server, config, node);
 
 	/* fake the server disconnection */
-	g_io_channel_unref(net_sendbuffer_handle(server->handle));
+	g_io_channel_unref(net_sendbuffer_channel(server->handle));
 	net_sendbuffer_destroy(server->handle, FALSE);
 	server->handle = NULL;
 
@@ -282,7 +282,7 @@ static void session_restore_server(CONFIG_NODE *node)
 	conn->tls_pinned_pubkey = g_strdup(config_node_get_str(node, "tls_pinned_pubkey", NULL));
 
 	conn->reconnection = TRUE;
-	conn->connect_handle = i_io_channel_new(handle);
+	conn->connect_channel = i_io_channel_new(handle);
 
 	server = proto->server_init_connect(conn);
 	server->version = g_strdup(config_node_get_str(node, "version", NULL));

--- a/src/fe-common/core/fe-exec.c
+++ b/src/fe-common/core/fe-exec.c
@@ -305,9 +305,9 @@ static void process_exec(PROCESS_REC *rec, const char *cmd)
 		GIOChannel *outio = i_io_channel_new(in[1]);
 
 		rec->in = i_io_channel_new(out[0]);
-		rec->out = net_sendbuffer_create(outio, 0);
+		rec->out = net_sendbuffer_create_channel(outio, 0);
 
-                close(out[1]);
+		close(out[1]);
 		close(in[0]);
 		pidwait_add(rec->pid);
                 return;
@@ -360,7 +360,7 @@ static void sig_exec_input_reader(PROCESS_REC *rec)
 
 	g_return_if_fail(rec != NULL);
 
-	recvlen = net_receive(rec->in, tmpbuf, sizeof(tmpbuf));
+	recvlen = net_receive_channel(rec->in, tmpbuf, sizeof(tmpbuf));
 	do {
 		ret = line_split(tmpbuf, recvlen, &str, &rec->databuf);
 		if (ret == -1) {

--- a/src/fe-common/core/meson.build
+++ b/src/fe-common/core/meson.build
@@ -3,7 +3,7 @@
 if have_capsicum
   fe_common_core_capsicum_source = files('fe-capsicum.c')
 else
-  fe_common_core_capsicum_source = []
+  fe_common_core_capsicum_source = [  ]
 endif
 
 fe_common_core_sources = [
@@ -43,10 +43,11 @@ fe_common_core_sources = [
   + [
     default_theme_h,
     irssi_version_h,
-  ]
+  ],
 ]
 
-libfe_common_core_a = static_library('fe_common_core',
+libfe_common_core_a = static_library(
+  'fe_common_core',
   fe_common_core_sources,
   include_directories : rootinc,
   implicit_include_directories : false,
@@ -54,10 +55,12 @@ libfe_common_core_a = static_library('fe_common_core',
     def_helpdir,
     def_themesdir,
   ],
-  dependencies : dep)
+  dependencies : dep,
+)
 
 if want_fuzzer
-  libfuzzer_fe_common_core_a = static_library('fuzzer_fe_common_core',
+  libfuzzer_fe_common_core_a = static_library(
+    'fuzzer_fe_common_core',
     fe_common_core_sources,
     include_directories : rootinc,
     implicit_include_directories : false,
@@ -66,7 +69,8 @@ if want_fuzzer
       def_themesdir,
       def_suppress_printf_fallback,
     ],
-    dependencies : dep)
+    dependencies : dep,
+  )
 endif
 
 install_headers(
@@ -96,4 +100,5 @@ install_headers(
     'window-items.h',
     'windows-layout.h',
   ),
-  subdir : incdir / 'src' / 'fe-common' / 'core')
+  subdir : incdir / 'src' / 'fe-common' / 'core',
+)

--- a/src/fe-common/irc/dcc/meson.build
+++ b/src/fe-common/irc/dcc/meson.build
@@ -1,6 +1,7 @@
 # this file is part of irssi
 
-libfe_irc_dcc_a = static_library('fe_irc_dcc',
+libfe_irc_dcc_a = static_library(
+  'fe_irc_dcc',
   files(
     'fe-dcc-chat-messages.c',
     'fe-dcc-chat.c',
@@ -16,14 +17,17 @@ libfe_irc_dcc_a = static_library('fe_irc_dcc',
     def_helpdir,
     def_sysconfdir,
   ],
-  dependencies : dep)
-shared_library('fe_irc_dcc',
+  dependencies : dep,
+)
+shared_library(
+  'fe_irc_dcc',
   name_suffix : module_suffix,
   install : true,
   install_dir : moduledir,
   link_with : dl_cross_irc_dcc + dl_cross_irc_core + dl_cross_irssi_main,
   link_whole : libfe_irc_dcc_a,
-  override_options : ['b_lundef=false'])
+  override_options : [ 'b_lundef=false' ],
+)
 
 install_headers(
   files(
@@ -31,4 +35,5 @@ install_headers(
     'module-formats.h',
     'module.h',
   ),
-  subdir : incdir / 'src' / 'fe-common' / 'irc' / 'dcc')
+  subdir : incdir / 'src' / 'fe-common' / 'irc' / 'dcc',
+)

--- a/src/fe-common/irc/meson.build
+++ b/src/fe-common/irc/meson.build
@@ -1,6 +1,7 @@
 # this file is part of irssi
 
-libfe_common_irc_a = static_library('fe_common_irc',
+libfe_common_irc_a = static_library(
+  'fe_common_irc',
   files(
     'fe-cap.c',
     'fe-common-irc.c',
@@ -27,14 +28,17 @@ libfe_common_irc_a = static_library('fe_common_irc',
     def_helpdir,
     def_themesdir,
   ],
-  dependencies : dep)
-shared_library('fe_common_irc',
+  dependencies : dep,
+)
+shared_library(
+  'fe_common_irc',
   name_suffix : module_suffix,
   install : true,
   install_dir : moduledir,
   link_with : dl_cross_irc_core + dl_cross_irssi_main,
   link_whole : libfe_common_irc_a,
-  override_options : ['b_lundef=false'])
+  override_options : [ 'b_lundef=false' ],
+)
 
 install_headers(
   files(
@@ -43,7 +47,8 @@ install_headers(
     'module-formats.h',
     'module.h',
   ),
-  subdir : incdir / 'src' / 'fe-common' / 'irc')
+  subdir : incdir / 'src' / 'fe-common' / 'irc',
+)
 
 subdir('dcc')
 subdir('notifylist')

--- a/src/fe-common/irc/notifylist/meson.build
+++ b/src/fe-common/irc/notifylist/meson.build
@@ -1,6 +1,7 @@
 # this file is part of irssi
 
-libfe_irc_notifylist_a = static_library('fe_irc_notifylist',
+libfe_irc_notifylist_a = static_library(
+  'fe_irc_notifylist',
   files(
     'fe-notifylist.c',
     'module-formats.c',
@@ -11,18 +12,22 @@ libfe_irc_notifylist_a = static_library('fe_irc_notifylist',
     def_helpdir,
     def_sysconfdir,
   ],
-  dependencies : dep)
-shared_library('fe_irc_notifylist',
+  dependencies : dep,
+)
+shared_library(
+  'fe_irc_notifylist',
   name_suffix : module_suffix,
   install : true,
   install_dir : moduledir,
   link_with : dl_cross_irc_notifylist + dl_cross_irssi_main,
   link_whole : libfe_irc_notifylist_a,
-  override_options : ['b_lundef=false'])
+  override_options : [ 'b_lundef=false' ],
+)
 
 install_headers(
   files(
     'module-formats.h',
     'module.h',
   ),
-  subdir : incdir / 'src' / 'fe-common' / 'irc' / 'notifylist')
+  subdir : incdir / 'src' / 'fe-common' / 'irc' / 'notifylist',
+)

--- a/src/fe-fuzz/fe-common/core/meson.build
+++ b/src/fe-fuzz/fe-common/core/meson.build
@@ -1,5 +1,6 @@
 # this file is part of irssi
-executable('theme-load-fuzz',
+executable(
+  'theme-load-fuzz',
   files(
     '../../null-logger.c',
     'theme-load.c',
@@ -10,12 +11,12 @@ executable('theme-load-fuzz',
     libcore_a,
     libfuzzer_fe_common_core_a,
   ],
-  link_args : [fuzzer_lib],
+  link_args : [ fuzzer_lib ],
   link_language : fuzzer_link_language,
   include_directories : rootinc,
   implicit_include_directories : false,
   install : true,
-  dependencies : dep
+  dependencies : dep,
 )
 
 # noinst_headers = files(

--- a/src/fe-fuzz/irc/core/meson.build
+++ b/src/fe-fuzz/irc/core/meson.build
@@ -1,6 +1,7 @@
 # this file is part of irssi
 
-executable('event-get-params-fuzz',
+executable(
+  'event-get-params-fuzz',
   files(
     '../../null-logger.c',
     'event-get-params.c',
@@ -12,12 +13,12 @@ executable('event-get-params-fuzz',
     libirc_core_a,
     libfuzzer_fe_common_core_a,
   ],
-  link_args : [fuzzer_lib],
+  link_args : [ fuzzer_lib ],
   link_language : fuzzer_link_language,
   include_directories : rootinc,
   implicit_include_directories : false,
   install : true,
-  dependencies : dep
+  dependencies : dep,
 )
 
 # noinst_headers = files(

--- a/src/fe-fuzz/meson.build
+++ b/src/fe-fuzz/meson.build
@@ -3,7 +3,8 @@
 subdir('irc')
 subdir('fe-common')
 
-executable('irssi-fuzz',
+executable(
+  'irssi-fuzz',
   files(
     'null-logger.c',
     'irssi.c',
@@ -14,15 +15,16 @@ executable('irssi-fuzz',
     libcore_a,
     libfuzzer_fe_common_core_a,
   ],
-  link_args : [fuzzer_lib],
+  link_args : [ fuzzer_lib ],
   link_language : fuzzer_link_language,
   include_directories : rootinc,
   implicit_include_directories : false,
   install : true,
-  dependencies : dep
+  dependencies : dep,
 )
 
-executable('server-fuzz',
+executable(
+  'server-fuzz',
   files(
     'null-logger.c',
     'server.c',
@@ -37,12 +39,12 @@ executable('server-fuzz',
     libfe_irc_dcc_a,
     libfe_irc_notifylist_a,
   ],
-  link_args : [fuzzer_lib],
+  link_args : [ fuzzer_lib ],
   link_language : fuzzer_link_language,
   include_directories : rootinc,
   implicit_include_directories : false,
   install : true,
-  dependencies : dep
+  dependencies : dep,
 )
 
 # noinst_headers = files(

--- a/src/fe-fuzz/server.c
+++ b/src/fe-fuzz/server.c
@@ -83,7 +83,7 @@ void event_connected(IRC_SERVER_REC *server, const char *data, const char *from)
 	server->real_connect_time = time(NULL);
 
 	/* let the queue send now that we are identified */
-	g_get_current_time(&server->wait_cmd);
+	server->wait_cmd = g_get_real_time();
 
 	if (server->connrec->usermode != NULL) {
 		/* Send the user mode, before the autosendcmd.
@@ -124,7 +124,7 @@ void test_server() {
 	server->session_reconnect = TRUE;
 	g_free(server->tag);
 	server->tag = g_strdup("testserver");
-	server->handle = net_sendbuffer_create(handle, 0);
+	server->handle = net_sendbuffer_create_channel(handle, 0);
 
 	/* we skip some initialisations that would try to send data */
 	/* irc_servers_deinit(); */

--- a/src/fe-none/meson.build
+++ b/src/fe-none/meson.build
@@ -1,6 +1,7 @@
 # this file is part of irssi
 
-fe_none_irssi = executable('botti',
+fe_none_irssi = executable(
+  'botti',
   files(
     'irssi.c',
   ),
@@ -13,7 +14,7 @@ fe_none_irssi = executable('botti',
     libcore_a,
   ],
   install : true,
-  dependencies : dep
+  dependencies : dep,
 )
 if need_dl_cross_link_main
   dl_cross_irssi_main = [ fe_none_irssi ]

--- a/src/fe-text/meson.build
+++ b/src/fe-text/meson.build
@@ -1,6 +1,7 @@
 # this file is part of irssi
 
-fe_text_irssi = executable('irssi',
+fe_text_irssi = executable(
+  'irssi',
   files(
     #### terminfo_sources ####
     'term-terminfo.c',
@@ -40,10 +41,9 @@ fe_text_irssi = executable('irssi',
     libconfig_a,
     libcore_a,
     libfe_common_core_a,
-    ],
+  ],
   install : true,
-  dependencies : dep
-  + textui_dep
+  dependencies : dep + textui_dep,
 )
 if need_dl_cross_link_main
   dl_cross_irssi_main = [ fe_text_irssi ]
@@ -61,7 +61,8 @@ install_headers(
     'textbuffer-view.h',
     'textbuffer.h',
   ),
-  subdir : incdir / 'src' / 'fe-text')
+  subdir : incdir / 'src' / 'fe-text',
+)
 
 # noinst_headers = files(
 #   'gui-entry.h',

--- a/src/irc/core/irc.c
+++ b/src/irc/core/irc.c
@@ -579,8 +579,10 @@ static void irc_init_server(IRC_SERVER_REC *server)
 	if (!IS_IRC_SERVER(server))
 		return;
 
-	server->readtag = i_input_add(net_sendbuffer_handle(server->handle), I_INPUT_READ,
-	                              (GInputFunction) irc_parse_incoming, server);
+	if (server->handle->channel != NULL) {
+		server->readtag = i_input_add(net_sendbuffer_channel(server->handle), I_INPUT_READ,
+		                              (GInputFunction) irc_parse_incoming, server);
+	}
 }
 
 void irc_irc_init(void)

--- a/src/irc/core/meson.build
+++ b/src/irc/core/meson.build
@@ -1,6 +1,7 @@
 # this file is part of irssi
 
-libirc_core_a = static_library('irc_core',
+libirc_core_a = static_library(
+  'irc_core',
   files(
     'bans.c',
     'channel-events.c',
@@ -38,16 +39,19 @@ libirc_core_a = static_library('irc_core',
     def_moduledir,
     def_sysconfdir,
   ],
-  dependencies : dep)
-libirc_core_sm = shared_library('irc_core',
+  dependencies : dep,
+)
+libirc_core_sm = shared_library(
+  'irc_core',
   name_suffix : module_suffix,
   install : true,
   install_dir : moduledir,
   link_whole : libirc_core_a,
   link_with : dl_cross_irssi_main,
-  override_options : ['b_lundef=false'])
+  override_options : [ 'b_lundef=false' ],
+)
 
-dl_cross_irc_core = []
+dl_cross_irc_core = [  ]
 if need_dl_cross_link
   dl_cross_irc_core += libirc_core_sm
 endif
@@ -77,4 +81,5 @@ install_headers(
     'servers-idle.h',
     'servers-redirect.h',
   ),
-  subdir : incdir / 'src' / 'irc' / 'core')
+  subdir : incdir / 'src' / 'irc' / 'core',
+)

--- a/src/irc/dcc/dcc-rec.h
+++ b/src/irc/dcc/dcc-rec.h
@@ -15,7 +15,7 @@ IPADDR addr; /* address we're connected in */
 char addrstr[MAX_IP_LEN]; /* in readable form */
 int port; /* port we're connected in */
 
-GIOChannel *handle; /* socket handle */
+GIOChannel *channel; /* socket handle */
 int tagconn, tagread, tagwrite;
 time_t starttime; /* transfer start time */
 uoff_t transfd; /* bytes transferred */

--- a/src/irc/dcc/dcc.h
+++ b/src/irc/dcc/dcc.h
@@ -17,12 +17,10 @@ typedef struct {
         ((dcc)->starttime != 0)
 
 /* not connected, we're waiting for other side to connect */
-#define dcc_is_listening(dcc) \
-        ((dcc)->handle != NULL && (dcc)->starttime == 0)
+#define dcc_is_listening_channel(dcc) ((dcc)->channel != NULL && (dcc)->starttime == 0)
 
 /* not connected, waiting for user to accept it */
-#define dcc_is_waiting_user(dcc) \
-        ((dcc)->handle == NULL)
+#define dcc_is_waiting_user_channel(dcc) ((dcc)->channel == NULL)
 
 /* passive DCC */
 #define dcc_is_passive(dcc) \
@@ -52,9 +50,9 @@ void dcc_ip2str(IPADDR *ip, char *str);
 void dcc_str2ip(const char *str, IPADDR *ip);
 
 /* Start listening for incoming connections */
-GIOChannel *dcc_listen(GIOChannel *iface, IPADDR *ip, int *port);
+GIOChannel *dcc_listen_channel(GIOChannel *iface, IPADDR *ip, int *port);
 /* Connect to specified IP address using the correct own_ip. */
-GIOChannel *dcc_connect_ip(IPADDR *ip, int port);
+GIOChannel *dcc_connect_ip_channel(IPADDR *ip, int port);
 
 /* Close DCC - sends "dcc closed" signal and calls dcc_destroy() */
 void dcc_close(DCC_REC *dcc);

--- a/src/irc/dcc/meson.build
+++ b/src/irc/dcc/meson.build
@@ -1,6 +1,7 @@
 # this file is part of irssi
 
-libirc_dcc_sm = shared_library('irc_dcc',
+libirc_dcc_sm = shared_library(
+  'irc_dcc',
   files(
     'dcc-autoget.c',
     'dcc-chat.c',
@@ -18,9 +19,10 @@ libirc_dcc_sm = shared_library('irc_dcc',
   install_dir : moduledir,
   link_with : dl_cross_irc_core + dl_cross_irssi_main,
   dependencies : dep,
-  override_options : ['b_lundef=false'])
+  override_options : [ 'b_lundef=false' ],
+)
 
-dl_cross_irc_dcc = []
+dl_cross_irc_dcc = [  ]
 if need_dl_cross_link
   dl_cross_irc_dcc += libirc_dcc_sm
 endif
@@ -38,4 +40,5 @@ install_headers(
     'dcc.h',
     'module.h',
   ),
-  subdir : incdir / 'src' / 'irc' / 'dcc')
+  subdir : incdir / 'src' / 'irc' / 'dcc',
+)

--- a/src/irc/flood/meson.build
+++ b/src/irc/flood/meson.build
@@ -1,21 +1,26 @@
 # this file is part of irssi
 
-libirc_flood_a = static_library('irc_flood',
+libirc_flood_a = static_library(
+  'irc_flood',
   files(
     'autoignore.c',
     'flood.c',
   ),
   include_directories : rootinc,
   implicit_include_directories : false,
-  dependencies : dep)
-shared_library('irc_flood',
+  dependencies : dep,
+)
+shared_library(
+  'irc_flood',
   name_suffix : module_suffix,
   install : true,
   install_dir : moduledir,
   link_with : dl_cross_irc_core + dl_cross_irssi_main,
   link_whole : libirc_flood_a,
-  override_options : ['b_lundef=false'])
+  override_options : [ 'b_lundef=false' ],
+)
 
 install_headers(
   files('module.h'),
-  subdir : incdir / 'src' / 'irc' / 'flood')
+  subdir : incdir / 'src' / 'irc' / 'flood',
+)

--- a/src/irc/notifylist/meson.build
+++ b/src/irc/notifylist/meson.build
@@ -1,6 +1,7 @@
 # this file is part of irssi
 
-libirc_notifylist_sm = shared_library('irc_notifylist',
+libirc_notifylist_sm = shared_library(
+  'irc_notifylist',
   files(
     'notify-commands.c',
     'notify-ison.c',
@@ -15,9 +16,10 @@ libirc_notifylist_sm = shared_library('irc_notifylist',
   install_dir : moduledir,
   link_with : dl_cross_irc_core + dl_cross_irssi_main,
   dependencies : dep,
-  override_options : ['b_lundef=false'])
+  override_options : [ 'b_lundef=false' ],
+)
 
-dl_cross_irc_notifylist = []
+dl_cross_irc_notifylist = [  ]
 if need_dl_cross_link
   dl_cross_irc_notifylist += libirc_notifylist_sm
 endif
@@ -28,4 +30,5 @@ install_headers(
     'notify-setup.h',
     'notifylist.h',
   ),
-  subdir : incdir / 'src' / 'irc' / 'notifylist')
+  subdir : incdir / 'src' / 'irc' / 'notifylist',
+)

--- a/src/irc/proxy/meson.build
+++ b/src/irc/proxy/meson.build
@@ -1,6 +1,7 @@
 # this file is part of irssi
 
-shared_library('irc_proxy',
+shared_library(
+  'irc_proxy',
   files(
     'dump.c',
     'listen.c',
@@ -13,7 +14,7 @@ shared_library('irc_proxy',
   install : true,
   install_dir : moduledir,
   dependencies : dep,
-  override_options : ['b_lundef=false'],
+  override_options : [ 'b_lundef=false' ],
 )
 
 # noinst_headers = files(

--- a/src/irc/proxy/proxy.h
+++ b/src/irc/proxy/proxy.h
@@ -13,7 +13,7 @@ typedef struct {
 	char *ircnet;
 
 	int tag;
-	GIOChannel *handle;
+	GIOChannel *channel;
 
 	GSList *clients;
 

--- a/src/lib-config/meson.build
+++ b/src/lib-config/meson.build
@@ -1,6 +1,7 @@
 # this file is part of irssi
 
-libconfig_a = static_library('irssi_config',
+libconfig_a = static_library(
+  'irssi_config',
   files(
     'get.c',
     'parse.c',
@@ -9,11 +10,13 @@ libconfig_a = static_library('irssi_config',
   ),
   include_directories : rootinc,
   implicit_include_directories : false,
-  dependencies : dep)
+  dependencies : dep,
+)
 
 install_headers(
   files(
     'iconfig.h',
     'module.h',
   ),
-  subdir : incdir / 'src' / 'lib-config')
+  subdir : incdir / 'src' / 'lib-config',
+)

--- a/src/meson.build
+++ b/src/meson.build
@@ -24,7 +24,6 @@ if want_fuzzer
 endif
 
 install_headers(
-  files(
-    'common.h'
-  ),
-  subdir : incdir / 'src')
+  files('common.h'),
+  subdir : incdir / 'src',
+)

--- a/src/otr/meson.build
+++ b/src/otr/meson.build
@@ -1,6 +1,7 @@
 # this file is part of irssi
 
-shared_library('otr_core',
+shared_library(
+  'otr_core',
   files(
     'key.c',
     'otr-fe.c',
@@ -15,7 +16,7 @@ shared_library('otr_core',
   install : true,
   install_dir : moduledir,
   dependencies : dep,
-  override_options : ['b_lundef=false'],
+  override_options : [ 'b_lundef=false' ],
 )
 
 # noinst_headers = files(

--- a/src/perl/common/meson.build
+++ b/src/perl/common/meson.build
@@ -1,20 +1,22 @@
-
-shared_library('Irssi',
-  [ xsubpp.process(
-    files(
-      'Channel.xs',
-      'Core.xs',
-      'Expando.xs',
-      'Ignore.xs',
-      'Irssi.xs',
-      'Log.xs',
-      'Masks.xs',
-      'Query.xs',
-      'Rawlog.xs',
-      'Server.xs',
-      'Settings.xs',
-    )
-  ) ]
+shared_library(
+  'Irssi',
+  [
+    xsubpp.process(
+      files(
+        'Channel.xs',
+        'Core.xs',
+        'Expando.xs',
+        'Ignore.xs',
+        'Irssi.xs',
+        'Log.xs',
+        'Masks.xs',
+        'Query.xs',
+        'Rawlog.xs',
+        'Server.xs',
+        'Settings.xs',
+      )
+    ),
+  ]
   + files(
     'module.h',
   )
@@ -27,7 +29,7 @@ shared_library('Irssi',
   implicit_include_directories : true,
   dependencies : dep + [ perl_dep ],
   link_with : dl_cross_perl_core + dl_cross_irssi_main,
-  override_options : ['b_lundef=false'],
+  override_options : [ 'b_lundef=false' ],
 )
 
 install_headers(
@@ -36,6 +38,6 @@ install_headers(
   ),
   install_dir : perlmoddir,
 )
-  
+
 # 'Makefile.PL.in',
 # 'typemap',

--- a/src/perl/irc/meson.build
+++ b/src/perl/irc/meson.build
@@ -1,21 +1,23 @@
-shared_library('Irc',
-  [ xsubpp.process(
-    files(
-      'Channel.xs',
-      'Client.xs',
-      'Ctcp.xs',
-      'Irc.xs',
-      'Modes.xs',
-      'Netsplit.xs',
-      'Notifylist.xs',
-      'Query.xs',
-      'Server.xs',
+shared_library(
+  'Irc',
+  [
+    xsubpp.process(
+      files(
+        'Channel.xs',
+        'Client.xs',
+        'Ctcp.xs',
+        'Irc.xs',
+        'Modes.xs',
+        'Netsplit.xs',
+        'Notifylist.xs',
+        'Query.xs',
+        'Server.xs',
+      ),
+      extra_args : [
+        '-typemap', '../common/typemap',
+      ],
     ),
-    extra_args : [
-      '-typemap',
-      '../common/typemap',
-    ],
-  ) ]
+  ]
   + files(
     'module.h',
   ),
@@ -27,7 +29,7 @@ shared_library('Irc',
   implicit_include_directories : true,
   dependencies : dep + [ perl_dep ],
   link_with : dl_cross_perl_core + dl_cross_irc_notifylist + dl_cross_irc_core + dl_cross_irssi_main,
-  override_options : ['b_lundef=false'],
+  override_options : [ 'b_lundef=false' ],
 )
 
 install_headers(
@@ -37,16 +39,18 @@ install_headers(
   install_dir : perlmoddir / 'Irssi',
 )
 
-shared_library('Dcc',
-  [ xsubpp.process(
-    files(
-      'Dcc.xs',
+shared_library(
+  'Dcc',
+  [
+    xsubpp.process(
+      files(
+        'Dcc.xs',
+      ),
+      extra_args : [
+        '-typemap', '../common/typemap',
+      ],
     ),
-    extra_args : [
-      '-typemap',
-      '../common/typemap',
-    ],
-  ) ]
+  ]
   + files(
     'module.h',
   ),
@@ -58,7 +62,7 @@ shared_library('Dcc',
   implicit_include_directories : true,
   dependencies : dep + [ perl_dep ],
   link_with : dl_cross_perl_core + dl_cross_irc_dcc + dl_cross_irc_core + dl_cross_irssi_main,
-  override_options : ['b_lundef=false'],
+  override_options : [ 'b_lundef=false' ],
 )
 
 install_headers(
@@ -67,6 +71,6 @@ install_headers(
   ),
   install_dir : perlmoddir / 'Irssi' / 'Irc',
 )
-  
+
 # 'Makefile.PL.in',
 # 'typemap',

--- a/src/perl/meson.build
+++ b/src/perl/meson.build
@@ -1,32 +1,36 @@
-
-perl_signals_list_h = custom_target('perl-signals-list.h',
+perl_signals_list_h = custom_target(
+  'perl-signals-list.h',
   input : files('../../docs/signals.txt'),
   output : 'perl-signals-list.h',
   capture : true,
   depend_files : files('get-signals.pl'),
-  command : [build_perl, files('get-signals.pl'), '@INPUT@'],
+  command : [ build_perl, files('get-signals.pl'), '@INPUT@' ],
 )
 
-irssi_core_pl_h = custom_target('irssi-core.pl.h',
+irssi_core_pl_h = custom_target(
+  'irssi-core.pl.h',
   input : files('irssi-core.pl'),
   output : 'irssi-core.pl.h',
   capture : true,
-  command : [file2header, '@INPUT@', 'irssi_core_code'],
+  command : [ file2header, '@INPUT@', 'irssi_core_code' ],
 )
 
 # required as of Meson 0.58.0
 generated_files_inc = include_directories('.')
 
-libperl_core_sm = shared_library('perl_core',
+libperl_core_sm = shared_library(
+  'perl_core',
   files(
     'perl-common.c',
     'perl-core.c',
     'perl-signals.c',
     'perl-sources.c',
-  ) + [
+  )
+  + [
     irssi_core_pl_h,
     perl_signals_list_h,
-  ] + built_src,
+  ]
+  + built_src,
   c_args : [
     def_scriptdir,
     def_perl_use_lib,
@@ -39,16 +43,17 @@ libperl_core_sm = shared_library('perl_core',
   install_rpath : perl_rpath,
   build_rpath : perl_rpath,
   dependencies : dep_cflagsonly + [ perl_dep ] + dl_cross_dep,
-  override_options : ['b_asneeded=false', 'b_lundef=false'],
+  override_options : [ 'b_asneeded=false', 'b_lundef=false' ],
   link_with : dl_cross_irssi_main,
 )
 
-dl_cross_perl_core = []
+dl_cross_perl_core = [  ]
 if need_dl_cross_link
   dl_cross_perl_core += libperl_core_sm
 endif
 
-shared_library('fe_perl',
+shared_library(
+  'fe_perl',
   files(
     'module-formats.c',
     'perl-fe.c',
@@ -63,7 +68,7 @@ shared_library('fe_perl',
   install_dir : moduledir,
   dependencies : dep,
   link_with : dl_cross_perl_core + dl_cross_irssi_main,
-  override_options : ['b_lundef=false'],
+  override_options : [ 'b_lundef=false' ],
 )
 
 subdir('common')

--- a/src/perl/textui/meson.build
+++ b/src/perl/textui/meson.build
@@ -1,18 +1,19 @@
-shared_library('TextUI',
-  [ xsubpp.process(
-    files(
-      'Statusbar.xs',
-      'TextBufferView.xs',
-      'TextBuffer.xs',
-      'TextUI.xs',
+shared_library(
+  'TextUI',
+  [
+    xsubpp.process(
+      files(
+        'Statusbar.xs',
+        'TextBufferView.xs',
+        'TextBuffer.xs',
+        'TextUI.xs',
+      ),
+      extra_args : [
+        '-typemap', '../common/typemap',
+        '-typemap', '../ui/typemap',
+      ],
     ),
-    extra_args : [
-      '-typemap',
-      '../common/typemap',
-      '-typemap',
-      '../ui/typemap',
-    ],
-  ) ]
+  ]
   + files(
     'module.h',
   ),
@@ -24,7 +25,7 @@ shared_library('TextUI',
   implicit_include_directories : true,
   dependencies : dep + [ perl_dep ],
   link_with : dl_cross_perl_core + dl_cross_irssi_main,
-  override_options : ['b_lundef=false'],
+  override_options : [ 'b_lundef=false' ],
 )
 
 install_headers(
@@ -33,6 +34,6 @@ install_headers(
   ),
   install_dir : perlmoddir / 'Irssi',
 )
-  
+
 # 'Makefile.PL.in',
 # 'typemap',

--- a/src/perl/ui/meson.build
+++ b/src/perl/ui/meson.build
@@ -1,16 +1,18 @@
-shared_library('UI',
-  [ xsubpp.process(
-    files(
-      'Formats.xs',
-      'Themes.xs',
-      'UI.xs',
-      'Window.xs',
+shared_library(
+  'UI',
+  [
+    xsubpp.process(
+      files(
+        'Formats.xs',
+        'Themes.xs',
+        'UI.xs',
+        'Window.xs',
+      ),
+      extra_args : [
+        '-typemap', '../common/typemap',
+      ],
     ),
-    extra_args : [
-      '-typemap',
-      '../common/typemap',
-    ],
-  ) ]
+  ]
   + files(
     'module.h',
   ),
@@ -22,7 +24,7 @@ shared_library('UI',
   implicit_include_directories : true,
   dependencies : dep + [ perl_dep ],
   link_with : dl_cross_perl_core + dl_cross_irssi_main,
-  override_options : ['b_lundef=false'],
+  override_options : [ 'b_lundef=false' ],
 )
 
 install_headers(
@@ -31,6 +33,6 @@ install_headers(
   ),
   install_dir : perlmoddir / 'Irssi',
 )
-  
+
 # 'Makefile.PL.in',
 # 'typemap',

--- a/tests/fe-common/core/meson.build
+++ b/tests/fe-common/core/meson.build
@@ -1,4 +1,5 @@
-test_test_formats = executable('test-formats',
+test_test_formats = executable(
+  'test-formats',
   files(
     'test-formats.c',
   ),
@@ -12,8 +13,11 @@ test_test_formats = executable('test-formats',
   ],
   include_directories : rootinc,
   implicit_include_directories : false,
-  dependencies : dep
+  dependencies : dep,
 )
-test('test-formats test', test_test_formats,
-  args : ['--tap'],
-  protocol : 'tap')
+test(
+  'test-formats test',
+  test_test_formats,
+  args : [ '--tap' ],
+  protocol : 'tap',
+)

--- a/tests/fe-text/meson.build
+++ b/tests/fe-text/meson.build
@@ -1,4 +1,5 @@
-test_test_paste_join_multiline = executable('test-paste-join-multiline',
+test_test_paste_join_multiline = executable(
+  'test-paste-join-multiline',
   files(
     '../../src/fe-text/gui-entry.c',
     '../../src/fe-text/gui-printtext.c',
@@ -25,7 +26,9 @@ test_test_paste_join_multiline = executable('test-paste-join-multiline',
   implicit_include_directories : false,
   dependencies : dep + textui_dep,
 )
-test('test-paste-join-multiline test', test_test_paste_join_multiline,
-  args : ['--tap'],
-  protocol : 'tap')
-
+test(
+  'test-paste-join-multiline test',
+  test_test_paste_join_multiline,
+  args : [ '--tap' ],
+  protocol : 'tap',
+)

--- a/tests/irc/core/meson.build
+++ b/tests/irc/core/meson.build
@@ -1,4 +1,5 @@
-test_test_irc = executable('test-irc',
+test_test_irc = executable(
+  'test-irc',
   files(
     'test-irc.c',
   ),
@@ -13,15 +14,19 @@ test_test_irc = executable('test-irc',
   ],
   include_directories : rootinc,
   implicit_include_directories : false,
-  dependencies : dep
+  dependencies : dep,
 )
-test('test-irc test', test_test_irc,
+test(
+  'test-irc test',
+  test_test_irc,
   args : [
     '--tap',
   ],
-  protocol : 'tap')
+  protocol : 'tap',
+)
 
-test_test_channel_events = executable('test-channel-events',
+test_test_channel_events = executable(
+  'test-channel-events',
   files(
     'test-channel-events.c',
   ),
@@ -36,10 +41,13 @@ test_test_channel_events = executable('test-channel-events',
   ],
   include_directories : rootinc,
   implicit_include_directories : false,
-  dependencies : dep
+  dependencies : dep,
 )
-test('test-channel-events test', test_test_channel_events,
+test(
+  'test-channel-events test',
+  test_test_channel_events,
   args : [
     '--tap',
   ],
-  protocol : 'tap')
+  protocol : 'tap',
+)

--- a/tests/irc/flood/meson.build
+++ b/tests/irc/flood/meson.build
@@ -1,4 +1,5 @@
-test_test_796 = executable('test-796',
+test_test_796 = executable(
+  'test-796',
   files(
     'test-796.c',
   ),
@@ -17,10 +18,13 @@ test_test_796 = executable('test-796',
   ],
   include_directories : rootinc,
   implicit_include_directories : false,
-  dependencies : dep
+  dependencies : dep,
 )
-test('test-796 test', test_test_796,
+test(
+  'test-796 test',
+  test_test_796,
   args : [
     '--tap',
   ],
-  protocol : 'tap')
+  protocol : 'tap',
+)

--- a/themes/meson.build
+++ b/themes/meson.build
@@ -3,4 +3,5 @@ install_data(
     'default.theme',
     'colorless.theme',
   ),
-  install_dir : themedir)
+  install_dir : themedir,
+)


### PR DESCRIPTION
This is a huge rename from `handle` fields to `channel` and suffix\`ing of all `GIOChannel`-related functions with `_channel`. There should be no functional changes, otherwise that would be a bug. The purpose is to prepare for the migration of server connections to GSocketConnection/GIOStream, which will be done by the addition of a `stream` field and creating `_stream` and `_source` functions to deal with all kinds of GIOStream IO in a later PR