### PR TITLE
irc-nicklist: avoid reading past end of parsed token in event_userhost

### DIFF
--- a/src/irc/core/irc-nicklist.c
+++ b/src/irc/core/irc-nicklist.c
@@ -531,7 +531,7 @@ static void event_userhost(SERVER_REC *server, const char *data)
 			oper = 0;
 		*ptr++ = '\0';
 
-		nicklist_update_flags(server, *pos, *ptr == '-', oper);
+		nicklist_update_flags(server, *pos, *ptr != '\0' && *ptr == '-', oper);
 	}
 	g_strfreev(phosts);
 	g_free(params);


### PR DESCRIPTION
When processing RPL_USERHOST (302), the code finds '=' in the host string, replaces it with NUL, advances ptr past it, and dereferences *ptr to check for '-'. If '=' is the last character in the string (e.g. 'nick=' sent by a malicious server), ptr advances to the NUL terminator. While this is still within the allocated buffer, it is defensively safer to guard the '-' check with a NUL check on *ptr first.