### PR TITLE
irc-nicklist: initialize nickrec->hops when sscanf fails in fill_who

### DIFF
--- a/src/irc/core/irc-nicklist.c
+++ b/src/irc/core/irc-nicklist.c
@@ -245,7 +245,8 @@ static void fill_who(SERVER_REC *server, const char *channel, const char *user, 
 			nicklist_set_account(chanrec, nickrec,
 			                     strcmp(account, "0") == 0 ? "*" : account);
 		}
-		sscanf(hops, "%d", &nickrec->hops);
+		if (sscanf(hops, "%d", &nickrec->hops) != 1)
+			nickrec->hops = 0;
 	}
 
 	nicklist_update_flags(server, nick,


### PR DESCRIPTION
When fill_who() is called from event_whox_channel_full, the hops parameter may be an empty string if the server sent a malformed WHOX reply with fewer tokens than expected. sscanf() on an empty string returns 0 (no items matched), leaving nickrec->hops at its prior value rather than a clean default.

Fix: check the sscanf return value and set hops to 0 if parsing failed.