### PR TITLE
otr: fix three bugs in multi-fragment message reassembly

### DIFF
--- a/src/otr/otr.c
+++ b/src/otr/otr.c
@@ -605,6 +605,15 @@ static enum otr_msg_status enqueue_otr_fragment(const char *msg, struct otr_peer
 	/* We are going to use it quite a bit so ease our life a bit. */
 	msg_len = strlen(msg);
 
+	/* An empty fragment carries no data and no end tag. Without this
+	 * guard, the end-tag check on the open-reassembly path indexes
+	 * msg[msg_len - 1]; when msg_len == 0 (size_t) this underflows to
+	 * SIZE_MAX and reads off the page, crashing irssi. */
+	if (msg_len == 0) {
+		ret = opc->full_msg ? OTR_MSG_WAIT_MORE : OTR_MSG_ORIGINAL;
+		return ret;
+	}
+
 	if (opc->full_msg) {
 		if (msg_len > (opc->msg_size - opc->msg_len)) {
 			char *tmp_ptr;

--- a/src/otr/otr.c
+++ b/src/otr/otr.c
@@ -615,7 +615,13 @@ static enum otr_msg_status enqueue_otr_fragment(const char *msg, struct otr_peer
 	}
 
 	if (opc->full_msg) {
-		if (msg_len > (opc->msg_size - opc->msg_len)) {
+		/* Grow the buffer unless it already has room for msg_len bytes
+		 * *plus* the NUL terminator written below. Using '>' here (instead
+		 * of '>=') is an off-by-one: when msg_len exactly equals the
+		 * remaining space, no realloc happens, but opc->full_msg[opc->msg_len]
+		 * is still written after copying, one byte past the end of the
+		 * allocation. */
+		if (msg_len >= (opc->msg_size - opc->msg_len)) {
 			char *tmp_ptr;
 
 			/* Realloc memory if there is not enough space. */

--- a/src/otr/otr.c
+++ b/src/otr/otr.c
@@ -615,6 +615,18 @@ static enum otr_msg_status enqueue_otr_fragment(const char *msg, struct otr_peer
 	}
 
 	if (opc->full_msg) {
+		/* Reject the reassembly if appending this fragment would exceed
+		 * the maximum assembled size. Without this check a peer can keep
+		 * the reassembly open forever (fragments never end with '.') and
+		 * grow opc->full_msg without bound, exhausting memory. */
+		if (opc->msg_len + msg_len + 1 > OTR_REASM_MAX_SIZE) {
+			free(opc->full_msg);
+			opc->full_msg = NULL;
+			opc->msg_size = opc->msg_len = 0;
+			ret = OTR_MSG_ERROR;
+			return ret;
+		}
+
 		/* Grow the buffer unless it already has room for msg_len bytes
 		 * *plus* the NUL terminator written below. Using '>' here (instead
 		 * of '>=') is an off-by-one: when msg_len exactly equals the
@@ -674,6 +686,12 @@ static enum otr_msg_status enqueue_otr_fragment(const char *msg, struct otr_peer
 		 */
 		pos = strstr(msg, OTR_MSG_BEGIN_TAG);
 		if (pos && (pos == msg) && msg[msg_len - 1] != OTR_MSG_END_TAG) {
+			/* Reject oversized initial fragment. */
+			if ((msg_len * 2) + 1 > OTR_REASM_MAX_SIZE) {
+				ret = OTR_MSG_ERROR;
+				return ret;
+			}
+
 			/* Allocate full message buffer with an extra for NULL byte. */
 			opc->full_msg = g_new0(char, (msg_len * 2) + 1);
 			if (!opc->full_msg) {

--- a/src/otr/otr.h
+++ b/src/otr/otr.h
@@ -54,6 +54,12 @@
 #define OTR_MSG_BEGIN_TAG             "?OTR:"
 #define OTR_MSG_END_TAG               '.'
 
+/* Maximum total size of a reassembled multi-fragment OTR message. Incoming
+ * ?OTR: fragments are concatenated into a per-peer heap buffer until the
+ * end tag is received; this caps that buffer so a peer cannot grow it
+ * without bound by sending fragments that never terminate. */
+#define OTR_REASM_MAX_SIZE            (256 * 1024)
+
 /* IRC /me command marker and len. */
 #define OTR_IRC_MARKER_ME             "/me "
 #define OTR_IRC_MARKER_ME_LEN         sizeof(OTR_IRC_MARKER_ME) - 1


### PR DESCRIPTION
enqueue_otr_fragment() in src/otr/otr.c reassembles ?OTR: messages that
arrive split across multiple PRIVMSGs (bitlbee/znc and some ircds do
this). It's reachable for any private message a peer sends, with no
OTR session required, since sig_message_private feeds every query
PRIVMSG straight into it. Three separate bugs there:

1. Empty fragment causes a size_t underflow (msg_len - 1 wraps to
   SIZE_MAX) and reads off the page, crashing irssi. An empty PRIVMSG
   body reaching this path is enough to trigger it.

2. The buffer growth check uses '>' instead of '>=' when deciding
   whether to realloc. When a fragment's length exactly matches the
   remaining space, no realloc happens, but the NUL terminator is
   still written one byte past the end of the buffer, corrupting the
   heap. Fragment lengths and the running remaining-space counter are
   both attacker controlled, so this is reachable remotely too.

3. There's no cap on the total reassembled size, so a peer can open a
   reassembly and never send the terminating '.', growing the buffer
   with every PRIVMSG until the process gets OOM-killed.

Each commit fixes one of these independently. Added a 256 KiB cap for
#3, well above any real OTR message. Existing test suite passes, and I
tested each bug/fix manually with ASan against the reassembly function
in isolation (crashes without the fix, no crash with it, and normal
multi-fragment reassembly still reconstructs the message correctly).