### PR TITLE
irc-proxy: guard NULL chatnet in CTCP forwarding

### DIFF
--- a/src/irc/proxy/listen.c
+++ b/src/irc/proxy/listen.c
@@ -539,7 +539,8 @@ static void sig_server_event(IRC_SERVER_REC *server, const char *line,
 
 			if (rec->want_ctcp == 1) {
                         	/* only CTCP for the chatnet where client is connected to will be forwarded */
-                        	if (strstr(rec->proxy_address, server->connrec->chatnet) != NULL) {
+                        	if (server->connrec->chatnet != NULL &&
+                        	    strstr(rec->proxy_address, server->connrec->chatnet) != NULL) {
 					net_sendbuffer_send(rec->handle,
 							    next_line->str, next_line->len);
 					signal_stop();


### PR DESCRIPTION
sig_server_event() in src/irc/proxy/listen.c forwards CTCP PRIVMSGs to
proxy clients that have CTCP forwarding enabled, using
strstr(rec->proxy_address, server->connrec->chatnet). If the server
connection has no chatnet (e.g. connected via /server without a
network definition, which is a normal thing to do), connrec->chatnet
is NULL and strstr() dereferences it, crashing irssi. Any remote user
can trigger it by sending the victim a CTCP.

connrec->chatnet is nullable in general, and event_connected() in the
same file already guards the same field at an equivalent strstr() call
a bit further down. This path was just missing that guard.