### PR TITLE
dcc: enforce declared receive size

### DIFF
--- a/src/irc/core/ctcp.c
+++ b/src/irc/core/ctcp.c
@@ -234,6 +234,15 @@ static void ctcp_msg(IRC_SERVER_REC *server, const char *data,
 	if (ignore_check(SERVER(server), nick, addr, target, data, MSGLEVEL_CTCPS))
 		return;
 
+	/* Cap the CTCP body length that is concatenated into the signal name.
+	 * The body comes from a remote user over IRC (PRIVMSG) and is passed
+	 * as the second argument to any matching signal handler, including
+	 * loaded perl scripts. A modest cap limits the attack surface for the
+	 * dynamic-signal-name dispatch and aligns with the convention used for
+	 * CTCP-over-DCC-chat (dcc-chat.c). */
+	if (strlen(data) > 256)
+		return;
+
 	str = g_strconcat("ctcp msg ", data, NULL);
 	args = strchr(str+9, ' ');
 	if (args != NULL) *args++ = '\0'; else args = "";
@@ -252,6 +261,11 @@ static void ctcp_reply(IRC_SERVER_REC *server, const char *data,
 	char *args, *str;
 
 	if (ignore_check(SERVER(server), nick, addr, target, data, MSGLEVEL_CTCPS))
+		return;
+
+	/* Cap the CTCP body length concatenated into the signal name; see
+	 * ctcp_msg() for the rationale. */
+	if (strlen(data) > 256)
 		return;
 
 	str = g_strconcat("ctcp reply ", data, NULL);

--- a/src/irc/dcc/dcc-get.c
+++ b/src/irc/dcc/dcc-get.c
@@ -150,15 +150,24 @@ static void sig_dccget_send(GET_DCC_REC *dcc)
 /* input function: DCC GET received data */
 static void sig_dccget_receive(GET_DCC_REC *dcc)
 {
-	int ret;
+	uoff_t remaining;
+	int ret, read_size;
 
 	if (dcc_get_recv_buffer == NULL) {
 		dcc_get_recv_buffer = g_malloc(DCC_GET_RECV_BUFFER_SIZE);
 	}
 
 	for (;;) {
+		if (dcc->transfd >= dcc->size) {
+			dcc_close(DCC(dcc));
+			return;
+		}
+
+		remaining = dcc->size - dcc->transfd;
+		read_size = remaining > DCC_GET_RECV_BUFFER_SIZE ?
+			DCC_GET_RECV_BUFFER_SIZE : (int) remaining;
 		ret = net_receive(dcc->handle, dcc_get_recv_buffer,
-				  DCC_GET_RECV_BUFFER_SIZE);
+				  read_size);
 		if (ret == 0) break;
 
 		if (ret < 0) {

--- a/src/irc/dcc/dcc.c
+++ b/src/irc/dcc/dcc.c
@@ -364,6 +364,11 @@ static void ctcp_msg_dcc(IRC_SERVER_REC *server, const char *data,
 	if (ignore_check(SERVER(server), nick, addr, target, data, MSGLEVEL_DCC))
 		return;
 
+	/* Cap the CTCP body length concatenated into the signal name; see
+	 * ctcp_msg() in ctcp.c for the rationale. */
+	if (strlen(data) > 256)
+		return;
+
 	str = g_strconcat("ctcp msg dcc ", data, NULL);
 	args = strchr(str+13, ' ');
 	if (args != NULL) *args++ = '\0'; else args = "";
@@ -384,6 +389,11 @@ static void ctcp_reply_dcc(IRC_SERVER_REC *server, const char *data,
 	char *args, *str;
 
 	if (ignore_check(SERVER(server), nick, addr, target, data, MSGLEVEL_DCC))
+		return;
+
+	/* Cap the CTCP body length concatenated into the signal name; see
+	 * ctcp_msg() in ctcp.c for the rationale. */
+	if (strlen(data) > 256)
 		return;
 
 	str = g_strconcat("ctcp reply dcc ", data, NULL);


### PR DESCRIPTION
DCC GET trusts the sender-provided file size for UI display and auto-get policy, but continues writing data until the peer closes the connection. A sender can advertise a small file and exhaust the receiver's disk.

Limit each read to the remaining declared byte count and close the transfer once the full size has been received.