### PR TITLE
dcc-server: expire idle accepted clients

### DIFF
--- a/src/irc/core/ctcp.c
+++ b/src/irc/core/ctcp.c
@@ -234,6 +234,15 @@ static void ctcp_msg(IRC_SERVER_REC *server, const char *data,
 	if (ignore_check(SERVER(server), nick, addr, target, data, MSGLEVEL_CTCPS))
 		return;
 
+	/* Cap the CTCP body length that is concatenated into the signal name.
+	 * The body comes from a remote user over IRC (PRIVMSG) and is passed
+	 * as the second argument to any matching signal handler, including
+	 * loaded perl scripts. A modest cap limits the attack surface for the
+	 * dynamic-signal-name dispatch and aligns with the convention used for
+	 * CTCP-over-DCC-chat (dcc-chat.c). */
+	if (strlen(data) > 256)
+		return;
+
 	str = g_strconcat("ctcp msg ", data, NULL);
 	args = strchr(str+9, ' ');
 	if (args != NULL) *args++ = '\0'; else args = "";
@@ -252,6 +261,11 @@ static void ctcp_reply(IRC_SERVER_REC *server, const char *data,
 	char *args, *str;
 
 	if (ignore_check(SERVER(server), nick, addr, target, data, MSGLEVEL_CTCPS))
+		return;
+
+	/* Cap the CTCP body length concatenated into the signal name; see
+	 * ctcp_msg() for the rationale. */
+	if (strlen(data) > 256)
 		return;
 
 	str = g_strconcat("ctcp reply ", data, NULL);

--- a/src/irc/dcc/dcc.c
+++ b/src/irc/dcc/dcc.c
@@ -364,6 +364,11 @@ static void ctcp_msg_dcc(IRC_SERVER_REC *server, const char *data,
 	if (ignore_check(SERVER(server), nick, addr, target, data, MSGLEVEL_DCC))
 		return;
 
+	/* Cap the CTCP body length concatenated into the signal name; see
+	 * ctcp_msg() in ctcp.c for the rationale. */
+	if (strlen(data) > 256)
+		return;
+
 	str = g_strconcat("ctcp msg dcc ", data, NULL);
 	args = strchr(str+13, ' ');
 	if (args != NULL) *args++ = '\0'; else args = "";
@@ -384,6 +389,11 @@ static void ctcp_reply_dcc(IRC_SERVER_REC *server, const char *data,
 	char *args, *str;
 
 	if (ignore_check(SERVER(server), nick, addr, target, data, MSGLEVEL_DCC))
+		return;
+
+	/* Cap the CTCP body length concatenated into the signal name; see
+	 * ctcp_msg() in ctcp.c for the rationale. */
+	if (strlen(data) > 256)
 		return;
 
 	str = g_strconcat("ctcp reply dcc ", data, NULL);

--- a/src/irc/dcc/dcc.c
+++ b/src/irc/dcc/dcc.c
@@ -461,13 +461,16 @@ static int dcc_timeout_func(void)
 		DCC_REC *dcc = tmp->data;
 
 		next = tmp->next;
-		if (dcc->tagread == -1 && now > dcc->created && !IS_DCC_SERVER(dcc)) {
+		if (now > dcc->created &&
+		    ((dcc->tagread == -1 && !IS_DCC_SERVER(dcc)) ||
+		     (IS_DCC_SERVER(dcc) && dcc->tagread != -1))) {
 			/* Timed out - don't send DCC REJECT CTCP so CTCP
 			   flooders won't affect us and it really doesn't
 			   matter that much anyway if the other side doen't
 			   get it..
 
-			   We don't want dcc servers to time out. */
+			   Connected DCC SERVER clients must send their first
+			   protocol line before the timeout. */
 			dcc_close(dcc);
 		}
 	}


### PR DESCRIPTION
DCC SERVER accepts and retains every peer connection, while the generic DCC timeout explicitly excludes server records. Silent peers can exhaust file descriptors and memory.

Apply the existing DCC timeout to accepted DCC SERVER clients until they send their first protocol line.